### PR TITLE
:sparkles: Mise en place de Husky et de son pre push

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+pnpm amibroken

--- a/package.json
+++ b/package.json
@@ -3,16 +3,19 @@
   "version": "0.1.0",
   "license": "MIT",
   "scripts": {
+    "amibroken": "pnpm lint:css && pnpm typecheck && pnpm lint:ts && pnpm test:coverage",
     "build": "next build",
     "deadcode": "knip",
     "depcheck": "depcheck",
     "dev": "next dev --turbo",
     "lint:css": "stylelint 'src/**/*.css'",
     "lint:ts": "eslint . --ext .tsx,.ts --max-warnings=0",
+    "prepare": "husky",
     "start": "next start",
     "test": "vitest run",
-    "test:coverage": "pnpm test --coverage",
-    "test:watch": "vitest"
+    "test:coverage": "pnpm test -- --coverage",
+    "test:watch": "vitest",
+    "typecheck": "tsc"
   },
   "dependencies": {
     "next": "14.2.3",
@@ -39,6 +42,7 @@
     "eslint-plugin-testing-library": "^6.2.2",
     "eslint-plugin-unused-imports": "^3.2.0",
     "eslint-plugin-vitest": "^0.4.1",
+    "husky": "^9.0.11",
     "jsdom": "^24.0.0",
     "knip": "^5.16.0",
     "stylelint": "^16.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       eslint-plugin-vitest:
         specifier: ^0.4.1
         version: 0.4.1(@typescript-eslint/eslint-plugin@7.10.0(@typescript-eslint/parser@7.10.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)(vitest@1.6.0(@types/node@20.12.12)(jsdom@24.0.0))
+      husky:
+        specifier: ^9.0.11
+        version: 9.0.11
       jsdom:
         specifier: ^24.0.0
         version: 24.0.0
@@ -1766,6 +1769,11 @@ packages:
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
+
+  husky@9.0.11:
+    resolution: {integrity: sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -5046,6 +5054,8 @@ snapshots:
       - supports-color
 
   human-signals@5.0.0: {}
+
+  husky@9.0.11: {}
 
   iconv-lite@0.6.3:
     dependencies:


### PR DESCRIPTION
L'idée est que les linters et les tests soient lancés avant de pusher plutôt que sur la CI pour avoir un feedback plus rapide et moins consommer d'énergie sur une CI.