### PR TITLE
:page_facing_up: Mise à jour de la license vers AGPL 3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "suite-gestionnaire-numerique",
   "version": "0.1.0",
-  "license": "MIT",
+  "license": "AGPL-3.0",
   "scripts": {
     "amibroken": "pnpm lint:css && pnpm typecheck && pnpm lint:ts && pnpm test:coverage",
     "build": "next build",


### PR DESCRIPTION
La licence AGPL 3 est celle utilisée par défaut dans les projets ANCT