### PR TITLE
Suite de l'invitation

### DIFF
--- a/src/app/api/actions/inviterUnUtilisateurAction.test.ts
+++ b/src/app/api/actions/inviterUnUtilisateurAction.test.ts
@@ -1,3 +1,5 @@
+import { ZodIssue } from 'zod'
+
 import { inviterUnUtilisateurAction } from './inviterUnUtilisateurAction'
 import * as ssoGateway from '@/gateways/ProConnectAuthentificationGateway'
 import { ssoProfileFactory } from '@/gateways/testHelper'
@@ -96,21 +98,60 @@ describe('inviter un utilisateur action', () => {
     expect(result).toBe('emailExistant')
   })
 
-  it('étant donné une invitation avec un rôle invalide quand on invite un utilisateur alors cela renvoie une erreur', async () => {
-    // GIVEN
-    const inviterUnUtilisateurParams = {
-      email: 'martin.tartempion@example.com',
-      nom: 'Tartempion',
-      organisation: 'La Poste',
-      prenom: 'Martin',
-      role: 'Rôle bidon',
-    }
+  describe('étant donné une invitation avec des données invalides, quand on invite un utilisateur alors cela renvoie une erreur', () => {
+    it.each([
+      {
+        desc: 'nom vide',
+        email: 'martin.tartempion@example.com',
+        expectedError: 'Le nom doit contenir au moins 1 caractère',
+        nom: '',
+        prenom: 'Martin',
+      },
+      {
+        desc: 'prénom vide',
+        email: 'martin.tartempion@example.com',
+        expectedError: 'Le prénom doit contenir au moins 1 caractère',
+        nom: 'Tartempion',
+        prenom: '',
+      },
+      {
+        desc: 'email vide',
+        email: '',
+        expectedError: 'L’email doit être valide',
+        nom: 'Tartempion',
+        prenom: 'Martin',
+      },
+      {
+        desc: 'rôle invalide',
+        email: 'martin.tartempion@example.com',
+        expectedError: 'Le rôle n’est pas correct',
+        nom: 'Tartempion',
+        prenom: 'Martin',
+        role: 'Rôle bidon',
+      },
+      {
+        desc: 'organisation vide',
+        email: 'martin.tartempion@example.com',
+        expectedError: 'L’organisation doit être renseignée',
+        nom: 'Tartempion',
+        organisation: '',
+        prenom: 'Martin',
+      },
+    ])('$desc', async ({ email, nom, prenom, role, organisation, expectedError }) => {
+      // GIVEN
+      const inviterUnUtilisateurParams = {
+        email,
+        nom,
+        organisation,
+        prenom,
+        role,
+      }
 
-    // WHEN
-    const result = await inviterUnUtilisateurAction(inviterUnUtilisateurParams)
+      // WHEN
+      const result = await inviterUnUtilisateurAction(inviterUnUtilisateurParams)
 
-    // THEN
-    // @ts-expect-error
-    expect(result[0].message).toBe('Le rôle n’est pas correct')
+      // THEN
+      expect((result as ReadonlyArray<ZodIssue>)[0].message).toBe(expectedError)
+    })
   })
 })

--- a/src/app/api/actions/inviterUnUtilisateurAction.test.ts
+++ b/src/app/api/actions/inviterUnUtilisateurAction.test.ts
@@ -62,6 +62,21 @@ describe('inviter un utilisateur action', () => {
           uidUtilisateurCourant: sub,
         },
       },
+      {
+        actionParams: {
+          email: 'martin.tartempion@example.com',
+          nom: 'Tartempion',
+          organisation: 'La Poste',
+          prenom: 'Martin',
+        },
+        desc: 'avec organisation spécifiée sans rôle : ignorée',
+        expectedCommand: {
+          email: 'martin.tartempion@example.com',
+          nom: 'Tartempion',
+          prenom: 'Martin',
+          uidUtilisateurCourant: sub,
+        },
+      },
     ])('$desc', async ({ actionParams, expectedCommand }) => {
       // GIVEN
       // @ts-expect-error

--- a/src/app/api/actions/inviterUnUtilisateurAction.test.ts
+++ b/src/app/api/actions/inviterUnUtilisateurAction.test.ts
@@ -4,29 +4,75 @@ import { ssoProfileFactory } from '@/gateways/testHelper'
 import { InviterUnUtilisateur } from '@/use-cases/commands/InviterUnUtilisateur'
 
 describe('inviter un utilisateur action', () => {
-  it('étant donné une invitation valide quand on invite un utilisateur alors cela invite l’utilisateur', async () => {
-    // GIVEN
+  describe('étant donné une invitation valide quand on invite un utilisateur alors cela invite l’utilisateur', () => {
     const sub = 'd96a66b5-8980-4e5c-88a9-aa0ff334a828'
-    vi.spyOn(ssoGateway, 'getSession').mockResolvedValueOnce(ssoProfileFactory({ sub }))
-    vi.spyOn(InviterUnUtilisateur.prototype, 'execute').mockResolvedValueOnce('OK')
 
-    const inviterUnUtilisateurParams = {
-      email: 'martin.tartempion@example.com',
-      nom: 'Tartempion',
-      organisation: 'La Poste',
-      prenom: 'Martin',
-      role: 'Gestionnaire département',
-    }
+    it.each([
+      {
+        actionParams: {
+          email: 'martin.tartempion@example.com',
+          nom: 'Tartempion',
+          prenom: 'Martin',
+        },
+        desc: 'sans rôle spécifié',
+        expectedCommand: {
+          email: 'martin.tartempion@example.com',
+          nom: 'Tartempion',
+          prenom: 'Martin',
+          uidUtilisateurCourant: sub,
+        },
+      },
+      {
+        actionParams: {
+          email: 'martin.tartempion@example.com',
+          nom: 'Tartempion',
+          prenom: 'Martin',
+          role: 'Instructeur',
+        },
+        desc: 'avec rôle spécifié',
+        expectedCommand: {
+          email: 'martin.tartempion@example.com',
+          nom: 'Tartempion',
+          prenom: 'Martin',
+          role: {
+            type: 'Instructeur',
+          },
+          uidUtilisateurCourant: sub,
+        },
+      },
+      {
+        actionParams: {
+          email: 'martin.tartempion@example.com',
+          nom: 'Tartempion',
+          organisation: 'La Poste',
+          prenom: 'Martin',
+          role: 'Gestionnaire structure',
+        },
+        desc: 'avec rôle et organisation spécifiés',
+        expectedCommand: {
+          email: 'martin.tartempion@example.com',
+          nom: 'Tartempion',
+          prenom: 'Martin',
+          role: {
+            organisation: 'La Poste',
+            type: 'Gestionnaire structure',
+          },
+          uidUtilisateurCourant: sub,
+        },
+      },
+    ])('$desc', async ({ actionParams, expectedCommand }) => {
+      // GIVEN
+      // @ts-expect-error
+      vi.spyOn(ssoGateway, 'getSession').mockResolvedValueOnce({ user: { sub } })
+      vi.spyOn(InviterUnUtilisateur.prototype, 'execute').mockResolvedValueOnce('OK')
 
-    // WHEN
-    const result = await inviterUnUtilisateurAction(inviterUnUtilisateurParams)
+      // WHEN
+      const result = await inviterUnUtilisateurAction(actionParams)
 
-    // THEN
-    expect(InviterUnUtilisateur.prototype.execute).toHaveBeenCalledWith({
-      ...inviterUnUtilisateurParams,
-      uidUtilisateurCourant: sub,
+      // THEN
+      expect(InviterUnUtilisateur.prototype.execute).toHaveBeenCalledWith(expectedCommand)
+      expect(result).toBe('OK')
     })
-    expect(result).toBe('OK')
   })
 
   it('étant donné une invitation valide quand on invite un utilisateur qui existe déjà alors cela renvoie une erreur', async () => {

--- a/src/app/api/actions/inviterUnUtilisateurAction.ts
+++ b/src/app/api/actions/inviterUnUtilisateurAction.ts
@@ -3,11 +3,12 @@
 import { z, ZodIssue } from 'zod'
 
 import prisma from '../../../../prisma/prismaClient'
+import { InviterUnUtilisateurCommand,
+  InviterUnUtilisateur, InviterUnUtilisateurFailure } from '../../../use-cases/commands/InviterUnUtilisateur'
 import { Roles } from '@/domain/Role'
 import { PostgreUtilisateurRepository } from '@/gateways/PostgreUtilisateurRepository'
 import { getSession } from '@/gateways/ProConnectAuthentificationGateway'
 import { ResultAsync } from '@/use-cases/CommandHandler'
-import { InviterUnUtilisateur, InviterUnUtilisateurFailure } from '@/use-cases/commands/InviterUnUtilisateur'
 
 export async function inviterUnUtilisateurAction(
   actionParams: ActionParams
@@ -18,22 +19,35 @@ export async function inviterUnUtilisateurAction(
     return roleValidationResult.error.issues
   }
 
-  return new InviterUnUtilisateur(new PostgreUtilisateurRepository(prisma)).execute({
-    ...actionParams,
-    role: roleValidationResult.data.role,
+  let command: InviterUnUtilisateurCommand = {
+    email: actionParams.email,
+    nom: actionParams.nom,
+    prenom: actionParams.prenom,
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     uidUtilisateurCourant: (await getSession())!.user.sub,
-  })
+  }
+
+  if (roleValidationResult.data.role) {
+    command = {
+      ...command,
+      role: {
+        organisation: actionParams.organisation,
+        type: roleValidationResult.data.role,
+      },
+    }
+  }
+
+  return new InviterUnUtilisateur(new PostgreUtilisateurRepository(prisma)).execute(command)
 }
 
 const roleValidation = z.object({
-  role: z.enum(Roles, { message: 'Le rôle n’est pas correct' }),
+  role: z.enum(Roles, { message: 'Le rôle n’est pas correct' }).optional(),
 })
 
 type ActionParams = Readonly<{
   prenom: string
   nom: string
   email: string
-  organisation: string
-  role: string
+  organisation?: string
+  role?: string
 }>

--- a/src/app/api/actions/inviterUnUtilisateurAction.ts
+++ b/src/app/api/actions/inviterUnUtilisateurAction.ts
@@ -3,14 +3,14 @@
 import { z, ZodIssue } from 'zod'
 
 import prisma from '../../../../prisma/prismaClient'
-import {
-  InviterUnUtilisateurCommand,
-  InviterUnUtilisateur, InviterUnUtilisateurFailure,
-} from '../../../use-cases/commands/InviterUnUtilisateur'
 import { Roles } from '@/domain/Role'
 import { PostgreUtilisateurRepository } from '@/gateways/PostgreUtilisateurRepository'
 import { getSession } from '@/gateways/ProConnectAuthentificationGateway'
 import { ResultAsync } from '@/use-cases/CommandHandler'
+import {
+  InviterUnUtilisateurCommand,
+  InviterUnUtilisateur, InviterUnUtilisateurFailure,
+} from '@/use-cases/commands/InviterUnUtilisateur'
 
 export async function inviterUnUtilisateurAction(
   actionParams: ActionParams
@@ -42,13 +42,13 @@ export async function inviterUnUtilisateurAction(
   return new InviterUnUtilisateur(new PostgreUtilisateurRepository(prisma)).execute(command)
 }
 
-export type ActionParams = Partial<Readonly<{
+type ActionParams = Readonly<{
   prenom: string
   nom: string
   email: string
   organisation?: string
   role?: string
-}>>
+}>
 
 const validator = z.object({
   email: z.string().email({ message: 'L’email doit être valide' }),

--- a/src/components/MesUtilisateurs/InviterUnUtilisateur.tsx
+++ b/src/components/MesUtilisateurs/InviterUnUtilisateur.tsx
@@ -37,9 +37,9 @@ export default function InviterUnUtilisateur({
     const utilisateurACreer = {
       email,
       nom: form.get('nom') as string,
-      organisation: form.get('structure') as string || sessionUtilisateurViewModel.role.libelle,
+      organisation: form.get('structure') as string,
       prenom: form.get('prenom') as string,
-      role: form.get('attributionRole') as string || sessionUtilisateurViewModel.role.nom,
+      role: form.get('attributionRole') as string,
     }
     const result = await inviterUnUtilisateurAction(utilisateurACreer)
     if (result === 'emailExistant') {

--- a/src/components/MesUtilisateurs/InviterUnUtilisateur.tsx
+++ b/src/components/MesUtilisateurs/InviterUnUtilisateur.tsx
@@ -36,10 +36,10 @@ export default function InviterUnUtilisateur({
     const email = form.get('email') as string
     const utilisateurACreer = {
       email,
-      nom: form.get('nom') as string,
-      organisation: form.get('structure') as string,
-      prenom: form.get('prenom') as string,
-      role: form.get('attributionRole') as string,
+      nom: form.get('nom')?.toString(),
+      organisation: form.get('structure')?.toString() ?? undefined,
+      prenom: form.get('prenom')?.toString(),
+      role: form.get('attributionRole')?.toString() ?? undefined,
     }
     const result = await inviterUnUtilisateurAction(utilisateurACreer)
     if (result === 'emailExistant') {

--- a/src/components/MesUtilisateurs/InviterUnUtilisateur.tsx
+++ b/src/components/MesUtilisateurs/InviterUnUtilisateur.tsx
@@ -106,6 +106,9 @@ export default function InviterUnUtilisateur({
           <span className="color-red">
             *
           </span>
+          <span className="fr-hint-text">
+            Une invitation lui sera envoyée par mail
+          </span>
         </TextInput>
         {
           gestionnaires.length > 1 ?

--- a/src/components/MesUtilisateurs/InviterUnUtilisateur.tsx
+++ b/src/components/MesUtilisateurs/InviterUnUtilisateur.tsx
@@ -8,6 +8,7 @@ import { clientContext } from '../shared/ClientContext'
 import RadioGroup from '../shared/Radio/RadioGroup'
 import TextInput from '../shared/TextInput/TextInput'
 
+// A DEPLACER DANS LE DOMAINE
 const rolesAvecStructure = ['Gestionnaire département', 'Gestionnaire région', 'Gestionnaire groupement', 'Gestionnaire structure']
 
 export default function InviterUnUtilisateur({
@@ -36,10 +37,8 @@ export default function InviterUnUtilisateur({
     const utilisateurACreer = {
       email,
       nom: form.get('nom') as string,
-      // A TESTER
       organisation: form.get('structure') as string || sessionUtilisateurViewModel.role.libelle,
       prenom: form.get('prenom') as string,
-      // A TESTER
       role: form.get('attributionRole') as string || sessionUtilisateurViewModel.role.nom,
     }
     const result = await inviterUnUtilisateurAction(utilisateurACreer)

--- a/src/components/MesUtilisateurs/InviterUnUtilisateur.tsx
+++ b/src/components/MesUtilisateurs/InviterUnUtilisateur.tsx
@@ -3,8 +3,9 @@
 import { FormEvent, ReactElement, useContext, useId, useState } from 'react'
 
 import { inviterUnUtilisateurAction } from '../../app/api/actions/inviterUnUtilisateurAction'
+import Badge from '../shared/Badge/Badge'
 import { clientContext } from '../shared/ClientContext'
-import RadioGroup, { RadioOption } from '../shared/Radio/RadioGroup'
+import RadioGroup from '../shared/Radio/RadioGroup'
 import TextInput from '../shared/TextInput/TextInput'
 
 export default function InviterUnUtilisateur({
@@ -13,13 +14,18 @@ export default function InviterUnUtilisateur({
   labelId,
 }: InviterUnUtilisateurProps): ReactElement {
   const [emailDejaExistant, setEmailDejaExistant] = useState<string | undefined>()
-  const { setBandeauInformations } = useContext(clientContext)
+  const { setBandeauInformations, sessionUtilisateurViewModel } = useContext(clientContext)
   const nomId = useId()
   const prenomId = useId()
   const emailId = useId()
   const structureId = useId()
 
-  const inviterUtilisateur = async (event: FormEvent<HTMLFormElement>): Promise<void> => {
+  const gestionnaires = sessionUtilisateurViewModel.role.rolesGerables.map((roleGerable) => ({
+    id: roleGerable,
+    label: roleGerable,
+  }))
+
+  async function inviterUtilisateur(event: FormEvent<HTMLFormElement>): Promise<void> {
     event.preventDefault()
 
     const form = new FormData(event.currentTarget)
@@ -101,31 +107,46 @@ export default function InviterUnUtilisateur({
             *
           </span>
         </TextInput>
-        <legend
-          aria-describedby="champsObligatoires"
-          className="fr-mb-2w"
-        >
-          Quel rôle souhaitez-vous lui attribuer ?
-          {' '}
-          <span className="color-red">
-            *
-          </span>
-        </legend>
-        <RadioGroup
-          nomGroupe="attributionRole"
-          options={gestionnaires}
-        />
-        <TextInput
-          id={structureId}
-          name="structure"
-          required={true}
-        >
-          Structure
-          {' '}
-          <span className="color-red">
-            *
-          </span>
-        </TextInput>
+        {
+          gestionnaires.length > 1 ?
+            <legend
+              aria-describedby="champsObligatoires"
+              className="fr-mb-2w"
+            >
+              Quel rôle souhaitez-vous lui attribuer ?
+              {' '}
+              <span className="color-red">
+                *
+              </span>
+            </legend> :
+            <p className="fr-mb-1w">
+              Rôle attribué à cet utilisateur :
+            </p>
+        }
+        {
+          gestionnaires.length > 1 ?
+            <RadioGroup
+              nomGroupe="attributionRole"
+              options={gestionnaires}
+            /> :
+            <Badge color="purple-glycine">
+              {gestionnaires[0]?.label}
+            </Badge>
+        }
+        {
+          gestionnaires.length > 1 ?
+            <TextInput
+              id={structureId}
+              name="structure"
+              required={true}
+            >
+              Structure
+              {' '}
+              <span className="color-red">
+                *
+              </span>
+            </TextInput> : null
+        }
         <button
           //aria-controls={ariaControls}
           className="fr-btn fr-my-2w drawer-invitation-button"
@@ -150,22 +171,3 @@ type InviterUnUtilisateurProps = Readonly<{
   drawerId: string
   labelId: string
 }>
-
-const gestionnaires: ReadonlyArray<RadioOption> = [
-  {
-    id: 'Gestionnaire région',
-    label: 'Gestionnaire région',
-  },
-  {
-    id: 'Gestionnaire département',
-    label: 'Gestionnaire département',
-  },
-  {
-    id: 'Gestionnaire groupement',
-    label: 'Gestionnaire groupement',
-  },
-  {
-    id: 'Gestionnaire structure',
-    label: 'Gestionnaire structure',
-  },
-]

--- a/src/components/MesUtilisateurs/InviterUnUtilisateur.tsx
+++ b/src/components/MesUtilisateurs/InviterUnUtilisateur.tsx
@@ -8,6 +8,8 @@ import { clientContext } from '../shared/ClientContext'
 import RadioGroup from '../shared/Radio/RadioGroup'
 import TextInput from '../shared/TextInput/TextInput'
 
+const rolesAvecStructure = ['Gestionnaire département', 'Gestionnaire région', 'Gestionnaire groupement', 'Gestionnaire structure']
+
 export default function InviterUnUtilisateur({
   setIsOpen,
   drawerId,
@@ -15,6 +17,7 @@ export default function InviterUnUtilisateur({
 }: InviterUnUtilisateurProps): ReactElement {
   const [emailDejaExistant, setEmailDejaExistant] = useState<string | undefined>()
   const { setBandeauInformations, sessionUtilisateurViewModel } = useContext(clientContext)
+  const [roleSelectionne, setRoleSelectionne] = useState('')
   const nomId = useId()
   const prenomId = useId()
   const emailId = useId()
@@ -33,9 +36,11 @@ export default function InviterUnUtilisateur({
     const utilisateurACreer = {
       email,
       nom: form.get('nom') as string,
-      organisation: form.get('structure') as string,
+      // A TESTER
+      organisation: form.get('structure') as string || sessionUtilisateurViewModel.role.libelle,
       prenom: form.get('prenom') as string,
-      role: form.get('attributionRole') as string,
+      // A TESTER
+      role: form.get('attributionRole') as string || sessionUtilisateurViewModel.role.nom,
     }
     const result = await inviterUnUtilisateurAction(utilisateurACreer)
     if (result === 'emailExistant') {
@@ -47,6 +52,10 @@ export default function InviterUnUtilisateur({
       }
       fermerEtReinitialiser(event.target as HTMLFormElement)
     }
+  }
+
+  const isStructureDisplayed = (): boolean => {
+    return gestionnaires.length > 1 && rolesAvecStructure.includes(roleSelectionne)
   }
 
   return (
@@ -130,6 +139,9 @@ export default function InviterUnUtilisateur({
           gestionnaires.length > 1 ?
             <RadioGroup
               nomGroupe="attributionRole"
+              onChange={(event) => {
+                setRoleSelectionne(event.target.value)
+              }}
               options={gestionnaires}
             /> :
             <Badge color="purple-glycine">
@@ -137,7 +149,7 @@ export default function InviterUnUtilisateur({
             </Badge>
         }
         {
-          gestionnaires.length > 1 ?
+          isStructureDisplayed() ?
             <TextInput
               id={structureId}
               name="structure"

--- a/src/components/MesUtilisateurs/MesUtilisateurs.test.tsx
+++ b/src/components/MesUtilisateurs/MesUtilisateurs.test.tsx
@@ -708,7 +708,7 @@ describe('mes utilisateurs', () => {
       // GIVEN
       vi.spyOn(inviterAction, 'inviterUnUtilisateurAction').mockResolvedValueOnce('OK')
       const windowDsfr = window.dsfr
-      window.dsfr = () => {
+      window.dsfr = (): {modal: {conceal: Mock}} => {
         return {
           modal: {
             conceal: vi.fn(),

--- a/src/components/MesUtilisateurs/MesUtilisateurs.test.tsx
+++ b/src/components/MesUtilisateurs/MesUtilisateurs.test.tsx
@@ -493,10 +493,31 @@ describe('mes utilisateurs', () => {
   })
 
   describe('quand j’invite un utilisateur', () => {
-    it('quand je clique sur le bouton inviter, alors le drawer s’ouvre', async () => {
+    it('en tant qu’administrateur, quand je clique sur le bouton inviter, alors le drawer s’ouvre avec tous les rôles sélectionnables', async () => {
       // GIVEN
       const mesUtilisateursViewModel = mesUtilisateursPresenter(mesUtilisateursReadModel, '7396c91e-b9f2-4f9d-8547-5e9b3332725b', totalUtilisateur)
-      renderComponent(<MesUtilisateurs mesUtilisateursViewModel={mesUtilisateursViewModel} />)
+      renderComponent(<MesUtilisateurs mesUtilisateursViewModel={mesUtilisateursViewModel} />, {
+        ...clientContextProviderDefaultValue,
+        sessionUtilisateurViewModel: {
+          ...clientContextProviderDefaultValue.sessionUtilisateurViewModel,
+          role: {
+            groupe: 'admin',
+            libelle: 'Rhône',
+            nom: 'Administrateur dispositif',
+            pictogramme: 'maille',
+            rolesGerables: [
+              'Administrateur dispositif',
+              'Gestionnaire département',
+              'Gestionnaire groupement',
+              'Gestionnaire région',
+              'Gestionnaire structure',
+              'Instructeur',
+              'Pilote politique publique',
+              'Support animation',
+            ] as Array<never>,
+          },
+        },
+      })
       const inviter = screen.getByRole('button', { name: 'Inviter une personne' })
 
       // WHEN
@@ -535,6 +556,11 @@ describe('mes utilisateurs', () => {
       )
       expect(roleQuestion).toBeInTheDocument()
 
+      const administrateurDispositif = within(formulaireInvitation).getByLabelText('Administrateur dispositif')
+      expect(administrateurDispositif).toBeRequired()
+      expect(administrateurDispositif).toHaveAttribute('name', 'attributionRole')
+      expect(administrateurDispositif).toHaveAttribute('id', 'Administrateur dispositif')
+
       const gestionnaireRegion = within(formulaireInvitation).getByLabelText('Gestionnaire région')
       expect(gestionnaireRegion).toBeRequired()
       expect(gestionnaireRegion).toHaveAttribute('name', 'attributionRole')
@@ -555,10 +581,89 @@ describe('mes utilisateurs', () => {
       expect(gestionnaireStructure).toHaveAttribute('name', 'attributionRole')
       expect(gestionnaireStructure).toHaveAttribute('id', 'Gestionnaire structure')
 
+      const instructeur = within(formulaireInvitation).getByLabelText('Instructeur')
+      expect(instructeur).toBeRequired()
+      expect(instructeur).toHaveAttribute('name', 'attributionRole')
+      expect(instructeur).toHaveAttribute('id', 'Instructeur')
+
+      const pilotePolitiquePublique = within(formulaireInvitation).getByLabelText('Pilote politique publique')
+      expect(pilotePolitiquePublique).toBeRequired()
+      expect(pilotePolitiquePublique).toHaveAttribute('name', 'attributionRole')
+      expect(pilotePolitiquePublique).toHaveAttribute('id', 'Pilote politique publique')
+
+      const supportAnimation = within(formulaireInvitation).getByLabelText('Support animation')
+      expect(supportAnimation).toBeRequired()
+      expect(supportAnimation).toHaveAttribute('name', 'attributionRole')
+      expect(supportAnimation).toHaveAttribute('id', 'Support animation')
+
       const structure = within(formulaireInvitation).getByLabelText('Structure *')
       expect(structure).toBeRequired()
       expect(structure).toHaveAttribute('name', 'structure')
       expect(structure).toHaveAttribute('type', 'text')
+
+      const envoyerInvitation = within(formulaireInvitation).getByRole('button', { name: 'Envoyer l’invitation' })
+      expect(envoyerInvitation).toHaveAttribute('type', 'submit')
+    })
+
+    it('en tant que gestionnaire département, quand je clique sur le bouton inviter, alors le drawer s’ouvre avec tous le rôle gestionnaire département sélectionné', async () => {
+      // GIVEN
+      const mesUtilisateursViewModel = mesUtilisateursPresenter(mesUtilisateursReadModel, '7396c91e-b9f2-4f9d-8547-5e9b3332725b', totalUtilisateur)
+      renderComponent(<MesUtilisateurs mesUtilisateursViewModel={mesUtilisateursViewModel} />, {
+        ...clientContextProviderDefaultValue,
+        sessionUtilisateurViewModel: {
+          ...clientContextProviderDefaultValue.sessionUtilisateurViewModel,
+          role: {
+            groupe: 'gestionnaire',
+            libelle: 'Rhône',
+            nom: 'Gestionnaire département',
+            pictogramme: 'maille',
+            rolesGerables: ['Gestionnaire département'] as Array<never>,
+          },
+        },
+      })
+      const inviter = screen.getByRole('button', { name: 'Inviter une personne' })
+
+      // WHEN
+      fireEvent.click(inviter)
+
+      // THEN
+      const formulaireInvitation = screen.getByRole('dialog', { name: 'Invitez un utilisateur à rejoindre l’espace de gestion' })
+      const titre = await within(formulaireInvitation).findByRole('heading', { level: 1, name: 'Invitez un utilisateur à rejoindre l’espace de gestion' })
+      expect(titre).toBeInTheDocument()
+
+      const champsObligatoires = within(formulaireInvitation).getByText(
+        matchWithoutMarkup('Les champs avec * sont obligatoires.'),
+        { selector: 'p' }
+      )
+      expect(champsObligatoires).toBeInTheDocument()
+
+      const nom = within(formulaireInvitation).getByLabelText('Nom *')
+      expect(nom).toBeRequired()
+      expect(nom).toHaveAttribute('name', 'nom')
+      expect(nom).toHaveAttribute('type', 'text')
+
+      const prenom = within(formulaireInvitation).getByLabelText('Prénom *')
+      expect(prenom).toBeRequired()
+      expect(prenom).toHaveAttribute('name', 'prenom')
+      expect(prenom).toHaveAttribute('type', 'text')
+
+      const email = within(formulaireInvitation).getByLabelText('Adresse électronique *')
+      expect(email).toBeRequired()
+      expect(email).toHaveAttribute('name', 'email')
+      expect(email).toHaveAttribute('pattern', '.+@.+\\..{2,}')
+      expect(email).toHaveAttribute('type', 'email')
+
+      const roleQuestion = within(formulaireInvitation).getByText(
+        matchWithoutMarkup('Rôle attribué à cet utilisateur :'),
+        { selector: 'p' }
+      )
+      expect(roleQuestion).toBeInTheDocument()
+
+      const role = within(formulaireInvitation).getByText(
+        matchWithoutMarkup('Gestionnaire département'),
+        { selector: 'p' }
+      )
+      expect(role).toBeInTheDocument()
 
       const envoyerInvitation = within(formulaireInvitation).getByRole('button', { name: 'Envoyer l’invitation' })
       expect(envoyerInvitation).toHaveAttribute('type', 'submit')
@@ -584,6 +689,25 @@ describe('mes utilisateurs', () => {
         <MesUtilisateurs mesUtilisateursViewModel={mesUtilisateursViewModel} />,
         {
           ...clientContextProviderDefaultValue,
+          sessionUtilisateurViewModel: {
+            ...clientContextProviderDefaultValue.sessionUtilisateurViewModel,
+            role: {
+              groupe: 'admin',
+              libelle: 'Rhône',
+              nom: 'Administrateur dispositif',
+              pictogramme: 'maille',
+              rolesGerables: [
+                'Administrateur dispositif',
+                'Gestionnaire département',
+                'Gestionnaire groupement',
+                'Gestionnaire région',
+                'Gestionnaire structure',
+                'Instructeur',
+                'Pilote politique publique',
+                'Support animation',
+              ] as Array<never>,
+            },
+          },
           setBandeauInformations,
         }
       )
@@ -631,7 +755,31 @@ describe('mes utilisateurs', () => {
       // GIVEN
       vi.spyOn(inviterAction, 'inviterUnUtilisateurAction').mockResolvedValueOnce('emailExistant')
       const mesUtilisateursViewModel = mesUtilisateursPresenter(mesUtilisateursReadModel, '7396c91e-b9f2-4f9d-8547-5e9b3332725b', totalUtilisateur)
-      renderComponent(<MesUtilisateurs mesUtilisateursViewModel={mesUtilisateursViewModel} />)
+      renderComponent(
+        <MesUtilisateurs mesUtilisateursViewModel={mesUtilisateursViewModel} />,
+        {
+          ...clientContextProviderDefaultValue,
+          sessionUtilisateurViewModel: {
+            ...clientContextProviderDefaultValue.sessionUtilisateurViewModel,
+            role: {
+              groupe: 'admin',
+              libelle: 'Rhône',
+              nom: 'Administrateur dispositif',
+              pictogramme: 'maille',
+              rolesGerables: [
+                'Administrateur dispositif',
+                'Gestionnaire département',
+                'Gestionnaire groupement',
+                'Gestionnaire région',
+                'Gestionnaire structure',
+                'Instructeur',
+                'Pilote politique publique',
+                'Support animation',
+              ] as Array<never>,
+            },
+          },
+        }
+      )
       const inviter = screen.getByRole('button', { name: 'Inviter une personne' })
       fireEvent.click(inviter)
       const formulaireInvitation = screen.getByRole('dialog', { name: 'Invitez un utilisateur à rejoindre l’espace de gestion' })
@@ -670,7 +818,31 @@ describe('mes utilisateurs', () => {
       }
     }
     const mesUtilisateursViewModel = mesUtilisateursPresenter(mesUtilisateursReadModel, '7396c91e-b9f2-4f9d-8547-5e9b3332725b', totalUtilisateur)
-    renderComponent(<MesUtilisateurs mesUtilisateursViewModel={mesUtilisateursViewModel} />)
+    renderComponent(
+      <MesUtilisateurs mesUtilisateursViewModel={mesUtilisateursViewModel} />,
+      {
+        ...clientContextProviderDefaultValue,
+        sessionUtilisateurViewModel: {
+          ...clientContextProviderDefaultValue.sessionUtilisateurViewModel,
+          role: {
+            groupe: 'admin',
+            libelle: 'Rhône',
+            nom: 'Administrateur dispositif',
+            pictogramme: 'maille',
+            rolesGerables: [
+              'Administrateur dispositif',
+              'Gestionnaire département',
+              'Gestionnaire groupement',
+              'Gestionnaire région',
+              'Gestionnaire structure',
+              'Instructeur',
+              'Pilote politique publique',
+              'Support animation',
+            ] as Array<never>,
+          },
+        },
+      }
+    )
     const inviter = screen.getByRole('button', { name: 'Inviter une personne' })
     fireEvent.click(inviter)
     const formulaireInvitation = screen.getByRole('dialog', { name: 'Invitez un utilisateur à rejoindre l’espace de gestion' })

--- a/src/components/MesUtilisateurs/MesUtilisateurs.test.tsx
+++ b/src/components/MesUtilisateurs/MesUtilisateurs.test.tsx
@@ -544,7 +544,7 @@ describe('mes utilisateurs', () => {
       expect(prenom).toHaveAttribute('name', 'prenom')
       expect(prenom).toHaveAttribute('type', 'text')
 
-      const email = within(formulaireInvitation).getByLabelText('Adresse électronique *')
+      const email = within(formulaireInvitation).getByLabelText('Adresse électronique *Une invitation lui sera envoyée par mail')
       expect(email).toBeRequired()
       expect(email).toHaveAttribute('name', 'email')
       expect(email).toHaveAttribute('pattern', '.+@.+\\..{2,}')
@@ -647,7 +647,7 @@ describe('mes utilisateurs', () => {
       expect(prenom).toHaveAttribute('name', 'prenom')
       expect(prenom).toHaveAttribute('type', 'text')
 
-      const email = within(formulaireInvitation).getByLabelText('Adresse électronique *')
+      const email = within(formulaireInvitation).getByLabelText('Adresse électronique *Une invitation lui sera envoyée par mail')
       expect(email).toBeRequired()
       expect(email).toHaveAttribute('name', 'email')
       expect(email).toHaveAttribute('pattern', '.+@.+\\..{2,}')

--- a/src/components/MesUtilisateurs/MesUtilisateurs.test.tsx
+++ b/src/components/MesUtilisateurs/MesUtilisateurs.test.tsx
@@ -544,7 +544,7 @@ describe('mes utilisateurs', () => {
       expect(prenom).toHaveAttribute('name', 'prenom')
       expect(prenom).toHaveAttribute('type', 'text')
 
-      const email = within(formulaireInvitation).getByLabelText('Adresse électronique *Une invitation lui sera envoyée par mail')
+      const email = within(formulaireInvitation).getByLabelText('Adresse électronique *Une invitation lui sera envoyée par e-mail')
       expect(email).toBeRequired()
       expect(email).toHaveAttribute('name', 'email')
       expect(email).toHaveAttribute('pattern', '.+@.+\\..{2,}')
@@ -682,7 +682,7 @@ describe('mes utilisateurs', () => {
       expect(prenom).toHaveAttribute('name', 'prenom')
       expect(prenom).toHaveAttribute('type', 'text')
 
-      const email = within(formulaireInvitation).getByLabelText('Adresse électronique *Une invitation lui sera envoyée par mail')
+      const email = within(formulaireInvitation).getByLabelText('Adresse électronique *Une invitation lui sera envoyée par e-mail')
       expect(email).toBeRequired()
       expect(email).toHaveAttribute('name', 'email')
       expect(email).toHaveAttribute('pattern', '.+@.+\\..{2,}')
@@ -710,7 +710,6 @@ describe('mes utilisateurs', () => {
         .mockResolvedValueOnce('emailExistant')
         .mockResolvedValueOnce('OK')
       const windowDsfr = window.dsfr
-      // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
       window.dsfr = (): {modal: {conceal: Mock}} => {
         return {
           modal: {

--- a/src/components/MesUtilisateurs/MesUtilisateurs.test.tsx
+++ b/src/components/MesUtilisateurs/MesUtilisateurs.test.tsx
@@ -514,7 +514,7 @@ describe('mes utilisateurs', () => {
               'Instructeur',
               'Pilote politique publique',
               'Support animation',
-            ] as Array<never>,
+            ],
           },
         },
       })
@@ -621,7 +621,7 @@ describe('mes utilisateurs', () => {
               'Instructeur',
               'Pilote politique publique',
               'Support animation',
-            ] as Array<never>,
+            ],
           },
         },
       })
@@ -652,7 +652,7 @@ describe('mes utilisateurs', () => {
             libelle: 'Rhône',
             nom: 'Gestionnaire département',
             pictogramme: 'maille',
-            rolesGerables: ['Gestionnaire département'] as Array<never>,
+            rolesGerables: ['Gestionnaire département'],
           },
         },
       })
@@ -704,6 +704,58 @@ describe('mes utilisateurs', () => {
       expect(envoyerInvitation).toHaveAttribute('type', 'submit')
     })
 
+    it('étant donné que je peux choisir un rôle, dans le drawer d’invitation, quand j’envoie le formulaire, alors les données de formulaire sont complétées avec mon rôle et mon organisation', async () => {
+      // GIVEN
+      vi.spyOn(inviterAction, 'inviterUnUtilisateurAction').mockResolvedValueOnce('OK')
+      const windowDsfr = window.dsfr
+      window.dsfr = () => {
+        return {
+          modal: {
+            conceal: vi.fn(),
+          },
+        }
+      }
+      const mesUtilisateursViewModel = mesUtilisateursPresenter(mesUtilisateursReadModel, '7396c91e-b9f2-4f9d-8547-5e9b3332725b', totalUtilisateur)
+      renderComponent(<MesUtilisateurs mesUtilisateursViewModel={mesUtilisateursViewModel} />, {
+        ...clientContextProviderDefaultValue,
+        sessionUtilisateurViewModel: {
+          ...clientContextProviderDefaultValue.sessionUtilisateurViewModel,
+          role: {
+            groupe: 'gestionnaire',
+            libelle: 'Rhône',
+            nom: 'Gestionnaire département',
+            pictogramme: 'maille',
+            rolesGerables: ['Gestionnaire département'],
+          },
+        },
+      })
+      const inviter = screen.getByRole('button', { name: 'Inviter une personne' })
+      fireEvent.click(inviter)
+
+      // WHEN
+      const formulaireInvitation = screen.getByRole('dialog', { name: 'Invitez un utilisateur à rejoindre l’espace de gestion' })
+      const nom = within(formulaireInvitation).getByLabelText('Nom *')
+      fireEvent.change(nom, { target: { value: 'Tartempion' } })
+      const prenom = within(formulaireInvitation).getByLabelText('Prénom *')
+      fireEvent.change(prenom, { target: { value: 'Martin' } })
+      const email = within(formulaireInvitation).getByLabelText(/Adresse électronique/)
+      fireEvent.change(email, { target: { value: 'martin.tartempion@example.com' } })
+      const envoyerInvitation = await within(formulaireInvitation).findByRole('button', { name: 'Envoyer l’invitation' })
+      fireEvent.click(envoyerInvitation)
+
+      // THEN
+      const formulaireInvitationFerme = await screen.findByRole('dialog', { name: 'Invitez un utilisateur à rejoindre l’espace de gestion' })
+      expect(formulaireInvitationFerme).not.toBeVisible()
+      expect(inviterAction.inviterUnUtilisateurAction).toHaveBeenCalledWith({
+        email: 'martin.tartempion@example.com',
+        nom: 'Tartempion',
+        organisation: 'Rhône',
+        prenom: 'Martin',
+        role: 'Gestionnaire département',
+      })
+      window.dsfr = windowDsfr
+    })
+
     it('dans le drawer d’invitation, quand je remplis correctement le formulaire et avec un nouveau mail, alors un message de validation s’affiche', async () => {
       // GIVEN
       vi.spyOn(inviterAction, 'inviterUnUtilisateurAction')
@@ -740,7 +792,7 @@ describe('mes utilisateurs', () => {
                 'Instructeur',
                 'Pilote politique publique',
                 'Support animation',
-              ] as Array<never>,
+              ],
             },
           },
           setBandeauInformations,
@@ -810,7 +862,7 @@ describe('mes utilisateurs', () => {
                 'Instructeur',
                 'Pilote politique publique',
                 'Support animation',
-              ] as Array<never>,
+              ],
             },
           },
         }
@@ -873,7 +925,7 @@ describe('mes utilisateurs', () => {
               'Instructeur',
               'Pilote politique publique',
               'Support animation',
-            ] as Array<never>,
+            ],
           },
         },
       }

--- a/src/components/MesUtilisateurs/MesUtilisateurs.test.tsx
+++ b/src/components/MesUtilisateurs/MesUtilisateurs.test.tsx
@@ -55,6 +55,7 @@ describe('mes utilisateurs', () => {
           libelle: '',
           nom: 'Support animation',
           pictogramme: '',
+          rolesGerables: [],
         },
       },
     })
@@ -90,6 +91,7 @@ describe('mes utilisateurs', () => {
             libelle: 'Rhône',
             nom: 'Gestionnaire groupement',
             pictogramme: 'maille',
+            rolesGerables: [],
           },
         },
       }
@@ -752,6 +754,7 @@ const mesUtilisateursReadModel: Parameters<typeof mesUtilisateursPresenter>[0] =
       groupe: 'admin',
       nom: 'Administrateur dispositif',
       organisation: 'Préfecture du Rhône',
+      rolesGerables: [],
     },
     structureId: null,
     telephone: '0102030405',
@@ -773,6 +776,7 @@ const mesUtilisateursReadModel: Parameters<typeof mesUtilisateursPresenter>[0] =
       groupe: 'gestionnaire',
       nom: 'Gestionnaire structure',
       organisation: 'Hub du Rhône',
+      rolesGerables: [],
     },
     structureId: 1,
     telephone: '',

--- a/src/components/MesUtilisateurs/MesUtilisateurs.test.tsx
+++ b/src/components/MesUtilisateurs/MesUtilisateurs.test.tsx
@@ -596,13 +596,48 @@ describe('mes utilisateurs', () => {
       expect(supportAnimation).toHaveAttribute('name', 'attributionRole')
       expect(supportAnimation).toHaveAttribute('id', 'Support animation')
 
+      const envoyerInvitation = within(formulaireInvitation).getByRole('button', { name: 'Envoyer l’invitation' })
+      expect(envoyerInvitation).toHaveAttribute('type', 'submit')
+    })
+
+    it('en tant qu’administrateur, quand je clique sur un rôle à inviter, alors le champ de structure s’affiche', () => {
+      // GIVEN
+      const mesUtilisateursViewModel = mesUtilisateursPresenter(mesUtilisateursReadModel, '7396c91e-b9f2-4f9d-8547-5e9b3332725b', totalUtilisateur)
+      renderComponent(<MesUtilisateurs mesUtilisateursViewModel={mesUtilisateursViewModel} />, {
+        ...clientContextProviderDefaultValue,
+        sessionUtilisateurViewModel: {
+          ...clientContextProviderDefaultValue.sessionUtilisateurViewModel,
+          role: {
+            groupe: 'admin',
+            libelle: 'Rhône',
+            nom: 'Administrateur dispositif',
+            pictogramme: 'maille',
+            rolesGerables: [
+              'Administrateur dispositif',
+              'Gestionnaire département',
+              'Gestionnaire groupement',
+              'Gestionnaire région',
+              'Gestionnaire structure',
+              'Instructeur',
+              'Pilote politique publique',
+              'Support animation',
+            ] as Array<never>,
+          },
+        },
+      })
+      const inviter = screen.getByRole('button', { name: 'Inviter une personne' })
+      fireEvent.click(inviter)
+
+      // WHEN
+      const formulaireInvitation = screen.getByRole('dialog', { name: 'Invitez un utilisateur à rejoindre l’espace de gestion' })
+      const gestionnaireDepartement = within(formulaireInvitation).getByLabelText('Gestionnaire département')
+      fireEvent.click(gestionnaireDepartement)
+
+      // THEN
       const structure = within(formulaireInvitation).getByLabelText('Structure *')
       expect(structure).toBeRequired()
       expect(structure).toHaveAttribute('name', 'structure')
       expect(structure).toHaveAttribute('type', 'text')
-
-      const envoyerInvitation = within(formulaireInvitation).getByRole('button', { name: 'Envoyer l’invitation' })
-      expect(envoyerInvitation).toHaveAttribute('type', 'submit')
     })
 
     it('en tant que gestionnaire département, quand je clique sur le bouton inviter, alors le drawer s’ouvre avec tous le rôle gestionnaire département sélectionné', async () => {
@@ -723,10 +758,10 @@ describe('mes utilisateurs', () => {
       fireEvent.change(prenom, { target: { value: 'Martin' } })
       const email = within(formulaireInvitation).getByLabelText(/Adresse électronique/)
       fireEvent.change(email, { target: { value: 'martin.tartempion@example.com' } })
-      const structure = within(formulaireInvitation).getByLabelText('Structure *')
-      fireEvent.change(structure, { target: { value: 'La Poste' } })
       const gestionnaireRegion = within(formulaireInvitation).getByLabelText('Gestionnaire région')
       fireEvent.click(gestionnaireRegion)
+      const structure = within(formulaireInvitation).getByLabelText('Structure *')
+      fireEvent.change(structure, { target: { value: 'La Poste' } })
       const envoyerInvitation = await within(formulaireInvitation).findByRole('button', { name: 'Envoyer l’invitation' })
       fireEvent.click(envoyerInvitation)
       const messageDErreur = await within(formulaireInvitation).findByText('Cet utilisateur dispose déjà d’un compte', { selector: 'p' })
@@ -791,10 +826,10 @@ describe('mes utilisateurs', () => {
       fireEvent.change(prenom, { target: { value: 'Martin' } })
       const email = within(formulaireInvitation).getByLabelText(/Adresse électronique/)
       fireEvent.change(email, { target: { value: 'martin.tartempion@example.com' } })
-      const structure = within(formulaireInvitation).getByLabelText('Structure *')
-      fireEvent.change(structure, { target: { value: 'La Poste' } })
       const gestionnaireRegion = within(formulaireInvitation).getByLabelText('Gestionnaire région')
       fireEvent.click(gestionnaireRegion)
+      const structure = within(formulaireInvitation).getByLabelText('Structure *')
+      fireEvent.change(structure, { target: { value: 'La Poste' } })
       const envoyerInvitation = await within(formulaireInvitation).findByRole('button', { name: 'Envoyer l’invitation' })
       fireEvent.click(envoyerInvitation)
 
@@ -855,10 +890,10 @@ describe('mes utilisateurs', () => {
     fireEvent.change(prenom, { target: { value: 'Martin' } })
     const email = within(formulaireInvitation).getByLabelText(/Adresse électronique/)
     fireEvent.change(email, { target: { value: 'martin.tartempion@example.com' } })
-    const structure = within(formulaireInvitation).getByLabelText('Structure *')
-    fireEvent.change(structure, { target: { value: 'La Poste' } })
     const gestionnaireRegion = within(formulaireInvitation).getByLabelText('Gestionnaire région')
     fireEvent.click(gestionnaireRegion)
+    const structure = within(formulaireInvitation).getByLabelText('Structure *')
+    fireEvent.change(structure, { target: { value: 'La Poste' } })
     const envoyerInvitation = await within(formulaireInvitation).findByRole('button', { name: 'Envoyer l’invitation' })
     fireEvent.click(envoyerInvitation)
 

--- a/src/components/MesUtilisateurs/MesUtilisateurs.test.tsx
+++ b/src/components/MesUtilisateurs/MesUtilisateurs.test.tsx
@@ -704,58 +704,6 @@ describe('mes utilisateurs', () => {
       expect(envoyerInvitation).toHaveAttribute('type', 'submit')
     })
 
-    it('étant donné que je peux choisir un rôle, dans le drawer d’invitation, quand j’envoie le formulaire, alors les données de formulaire sont complétées avec mon rôle et mon organisation', async () => {
-      // GIVEN
-      vi.spyOn(inviterAction, 'inviterUnUtilisateurAction').mockResolvedValueOnce('OK')
-      const windowDsfr = window.dsfr
-      window.dsfr = (): {modal: {conceal: Mock}} => {
-        return {
-          modal: {
-            conceal: vi.fn(),
-          },
-        }
-      }
-      const mesUtilisateursViewModel = mesUtilisateursPresenter(mesUtilisateursReadModel, '7396c91e-b9f2-4f9d-8547-5e9b3332725b', totalUtilisateur)
-      renderComponent(<MesUtilisateurs mesUtilisateursViewModel={mesUtilisateursViewModel} />, {
-        ...clientContextProviderDefaultValue,
-        sessionUtilisateurViewModel: {
-          ...clientContextProviderDefaultValue.sessionUtilisateurViewModel,
-          role: {
-            groupe: 'gestionnaire',
-            libelle: 'Rhône',
-            nom: 'Gestionnaire département',
-            pictogramme: 'maille',
-            rolesGerables: ['Gestionnaire département'],
-          },
-        },
-      })
-      const inviter = screen.getByRole('button', { name: 'Inviter une personne' })
-      fireEvent.click(inviter)
-
-      // WHEN
-      const formulaireInvitation = screen.getByRole('dialog', { name: 'Invitez un utilisateur à rejoindre l’espace de gestion' })
-      const nom = within(formulaireInvitation).getByLabelText('Nom *')
-      fireEvent.change(nom, { target: { value: 'Tartempion' } })
-      const prenom = within(formulaireInvitation).getByLabelText('Prénom *')
-      fireEvent.change(prenom, { target: { value: 'Martin' } })
-      const email = within(formulaireInvitation).getByLabelText(/Adresse électronique/)
-      fireEvent.change(email, { target: { value: 'martin.tartempion@example.com' } })
-      const envoyerInvitation = await within(formulaireInvitation).findByRole('button', { name: 'Envoyer l’invitation' })
-      fireEvent.click(envoyerInvitation)
-
-      // THEN
-      const formulaireInvitationFerme = await screen.findByRole('dialog', { name: 'Invitez un utilisateur à rejoindre l’espace de gestion' })
-      expect(formulaireInvitationFerme).not.toBeVisible()
-      expect(inviterAction.inviterUnUtilisateurAction).toHaveBeenCalledWith({
-        email: 'martin.tartempion@example.com',
-        nom: 'Tartempion',
-        organisation: 'Rhône',
-        prenom: 'Martin',
-        role: 'Gestionnaire département',
-      })
-      window.dsfr = windowDsfr
-    })
-
     it('dans le drawer d’invitation, quand je remplis correctement le formulaire et avec un nouveau mail, alors un message de validation s’affiche', async () => {
       // GIVEN
       vi.spyOn(inviterAction, 'inviterUnUtilisateurAction')
@@ -763,7 +711,7 @@ describe('mes utilisateurs', () => {
         .mockResolvedValueOnce('OK')
       const windowDsfr = window.dsfr
       // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-      window.dsfr = () => {
+      window.dsfr = (): {modal: {conceal: Mock}} => {
         return {
           modal: {
             conceal: vi.fn(),

--- a/src/components/MesUtilisateurs/MesUtilisateurs.tsx
+++ b/src/components/MesUtilisateurs/MesUtilisateurs.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Image from 'next/image'
-import { ReactElement, useContext, useState } from 'react'
+import { ReactElement, useContext, useRef, useState } from 'react'
 
 import DetailsUtilisateur from './DetailsUtilisateur'
 import FiltrerMesUtilisateurs from './FiltrerMesUtilisateurs'
@@ -25,6 +25,7 @@ export default function MesUtilisateurs(
   const [isModaleSuppressionOpen, setIsModaleSuppressionOpen] = useState(false)
   const [utilisateurASupprimer, setUtilisateurASupprimer] = useState({ prenomEtNom: '', uid: '' })
   const modalId = 'supprimer-un-utilisateur'
+  const drawerInvitationRef = useRef<HTMLDialogElement>(null)
   // Stryker disable next-line BooleanLiteral
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
   const [utilisateurSelectionne, setUtilisateurSelectionne] = useState<DetailsUtilisateurViewModel>({
@@ -67,10 +68,11 @@ export default function MesUtilisateurs(
         isFixedWidth={false}
         isOpen={isDrawerOpen}
         labelId={labelInvitationId}
+        ref={drawerInvitationRef}
         setIsOpen={setIsDrawerOpen}
       >
         <InviterUnUtilisateur
-          drawerId={drawerInvitationId}
+          dialogRef={drawerInvitationRef}
           labelId={labelInvitationId}
           setIsOpen={setIsDrawerOpen}
         />

--- a/src/components/shared/Drawer/Drawer.tsx
+++ b/src/components/shared/Drawer/Drawer.tsx
@@ -1,8 +1,10 @@
-import { Dispatch, PropsWithChildren, ReactNode, SetStateAction } from 'react'
+import { Dispatch, forwardRef, PropsWithChildren, ReactNode, Ref, SetStateAction } from 'react'
 
 import styles from './Drawer.module.css'
 
-export default function Drawer({
+export default forwardRef(Drawer)
+
+function Drawer({
   id,
   isOpen,
   setIsOpen,
@@ -10,7 +12,8 @@ export default function Drawer({
   isFixedWidth,
   labelId,
   children,
-}: DrawerProps): ReactNode {
+}: DrawerProps,
+ref: Ref<HTMLDialogElement>): ReactNode {
   // istanbul ignore next @preserve
   const boxSize = isFixedWidth ? styles['modal-box--fixed-width'] : ''
 
@@ -21,6 +24,7 @@ export default function Drawer({
       className={`fr-modal ${styles['fr-modal']}`}
       id={id}
       open={isOpen}
+      ref={ref}
     >
       <div className={`fr-container ${styles['fr-container']}`}>
         <div className="fr-grid-row fr-grid-row--right">

--- a/src/components/shared/Radio/Radio.tsx
+++ b/src/components/shared/Radio/Radio.tsx
@@ -1,12 +1,13 @@
-import { PropsWithChildren, ReactElement } from 'react'
+import { ChangeEventHandler, PropsWithChildren, ReactElement } from 'react'
 
-export default function Radio({ children, id, nomGroupe }: RadioProps): ReactElement {
+export default function Radio({ children, id, nomGroupe, onChange }: RadioProps): ReactElement {
   return (
     <div className="fr-fieldset__element">
       <div className="fr-radio-group">
         <input
           id={id}
           name={nomGroupe}
+          onChange={onChange}
           required={true}
           type="radio"
           value={id}
@@ -25,4 +26,5 @@ export default function Radio({ children, id, nomGroupe }: RadioProps): ReactEle
 type RadioProps = PropsWithChildren<Readonly<{
   id: string
   nomGroupe: string
+  onChange: ChangeEventHandler<HTMLInputElement>
 }>>

--- a/src/components/shared/Radio/RadioGroup.tsx
+++ b/src/components/shared/Radio/RadioGroup.tsx
@@ -1,8 +1,8 @@
-import { ReactElement } from 'react'
+import { ChangeEventHandler, ReactElement } from 'react'
 
 import Radio from './Radio'
 
-export default function RadioGroup({ nomGroupe, options }: RadioGroupProps): ReactElement {
+export default function RadioGroup({ nomGroupe, options, onChange }: RadioGroupProps): ReactElement {
   return (
     <div role="radiogroup">
       {options.map(({ id, label }) => (
@@ -10,6 +10,7 @@ export default function RadioGroup({ nomGroupe, options }: RadioGroupProps): Rea
           id={id}
           key={id}
           nomGroupe={nomGroupe}
+          onChange={onChange}
         >
           {label}
         </Radio>
@@ -26,4 +27,5 @@ export type RadioOption = Readonly<{
 type RadioGroupProps = Readonly<{
   nomGroupe: string
   options: ReadonlyArray<RadioOption>
+  onChange: ChangeEventHandler<HTMLInputElement>
 }>

--- a/src/components/shared/TextInput/TextInput.tsx
+++ b/src/components/shared/TextInput/TextInput.tsx
@@ -1,9 +1,10 @@
 import React, { PropsWithChildren, ReactElement } from 'react'
 
 export default function TextInput({ defaultValue = '', children, id, name, pattern, required, type = 'text', erreur }: InputProps): ReactElement {
+  const isErreur = Boolean(erreur)
   return (
     // Stryker disable next-line all
-    <div className={`fr-input-group ${erreur !== undefined ? 'fr-input-group--error' : ''}`}>
+    <div className={`fr-input-group ${isErreur ? 'fr-input-group--error' : ''}`}>
       <label
         className="fr-label"
         htmlFor={id}
@@ -21,7 +22,7 @@ export default function TextInput({ defaultValue = '', children, id, name, patte
         type={type}
       />
       {
-        (erreur !== undefined) ?
+        isErreur ?
           <p
             className="fr-error-text"
             id="text-input-error-desc-error"

--- a/src/components/testHelper.tsx
+++ b/src/components/testHelper.tsx
@@ -33,7 +33,7 @@ export const clientContextProviderDefaultValue = {
       libelle: 'Mednum',
       nom: 'Support animation',
       pictogramme: 'support-animation',
-      rolesGerables: [],
+      rolesGerables: [] as ReadonlyArray<string>,
     },
     telephone: '0102030405',
     uid: 'fooId',

--- a/src/components/testHelper.tsx
+++ b/src/components/testHelper.tsx
@@ -33,6 +33,7 @@ export const clientContextProviderDefaultValue = {
       libelle: 'Mednum',
       nom: 'Support animation',
       pictogramme: 'support-animation',
+      rolesGerables: [],
     },
     telephone: '0102030405',
     uid: 'fooId',

--- a/src/domain/Role.ts
+++ b/src/domain/Role.ts
@@ -5,6 +5,7 @@ export class Role extends Model<RoleState> {
   readonly #groupe: Groupe
   readonly #categorie: Categorie
   readonly #organisation: string
+  readonly #rolesGerables: ReadonlyArray<TypologieRole>
 
   constructor(nom: TypologieRole, territoireOuStructure = '') {
     super()
@@ -13,6 +14,7 @@ export class Role extends Model<RoleState> {
     this.#groupe = groupe
     this.#categorie = categorie
     this.#organisation = organisation ?? territoireOuStructure
+    this.#rolesGerables = this.isAdmin() ? Roles : [nom]
   }
 
   state(): RoleState {
@@ -21,6 +23,7 @@ export class Role extends Model<RoleState> {
       groupe: this.#groupe,
       nom: this.#nom,
       organisation: this.#organisation,
+      rolesGerables: this.#rolesGerables,
     }
   }
 
@@ -34,6 +37,7 @@ export type RoleState = Readonly<{
   groupe: Groupe
   nom: TypologieRole
   organisation: string
+  rolesGerables: ReadonlyArray<TypologieRole>
 }>
 
 export const Roles = [

--- a/src/domain/Utilisateur.ts
+++ b/src/domain/Utilisateur.ts
@@ -52,6 +52,18 @@ export class Utilisateur extends Entity<UtilisateurState> {
     }
   }
 
+  duMemeRole(params: Omit<UtilisateurParams, 'role'>): Utilisateur {
+    return new Utilisateur(
+      params.uid,
+      this.#role,
+      params.nom,
+      params.prenom,
+      params.email,
+      params.isSuperAdmin,
+      params.telephone
+    )
+  }
+
   changerPrenom(prenom: string): void {
     this.#prenom = prenom
   }

--- a/src/domain/shared/Model.ts
+++ b/src/domain/shared/Model.ts
@@ -1,25 +1,25 @@
 import { Struct } from '@/shared/lang'
 
-export abstract class Model<S extends Struct> {
-  equals(other: Model<S>): boolean {
+export abstract class Model<State extends Struct> {
+  equals(other: Model<State>): boolean {
     return this.#isSameType(other) && this.#stateEquals(other)
   }
 
-  #isSameType(other: Model<S>): boolean {
+  #isSameType(other: Model<State>): boolean {
     return other instanceof this.constructor
   }
 
-  #stateEquals(other: Model<S>): boolean {
+  #stateEquals(other: Model<State>): boolean {
     return JSON.stringify(other.state()) === JSON.stringify(this.state())
   }
 
-  abstract state(): S
+  abstract state(): State
 }
 
-export abstract class Entity<S extends EntityState> extends Model<S> {
-  protected readonly uid: S['uid']
+export abstract class Entity<State extends EntityState> extends Model<State> {
+  protected readonly uid: State['uid']
 
-  protected constructor(uid: S['uid']) {
+  protected constructor(uid: State['uid']) {
     super()
     this.uid = uid
   }

--- a/src/gateways/PostgreUtilisateurLoader.test.ts
+++ b/src/gateways/PostgreUtilisateurLoader.test.ts
@@ -1,6 +1,7 @@
 import { PostgreUtilisateurLoader } from './PostgreUtilisateurLoader'
 import { departementRecordFactory, epochTime, groupementRecordFactory, regionRecordFactory, structureRecordFactory, utilisateurRecordFactory } from './testHelper'
 import prisma from '../../prisma/prismaClient'
+import { Roles } from '@/domain/Role'
 import { UtilisateursCourantsEtTotalReadModel } from '@/use-cases/queries/RechercherMesUtilisateurs'
 import { UnUtilisateurReadModel } from '@/use-cases/queries/shared/UnUtilisateurReadModel'
 import { utilisateurReadModelFactory } from '@/use-cases/testHelper'
@@ -19,6 +20,7 @@ describe('postgre utilisateur query', () => {
           groupe: 'admin',
           nom: 'Administrateur dispositif',
           organisation: 'Administrateur dispositif',
+          rolesGerables: Roles,
         },
       },
       {
@@ -28,6 +30,7 @@ describe('postgre utilisateur query', () => {
           groupe: 'gestionnaire',
           nom: 'Gestionnaire département',
           organisation: 'Paris',
+          rolesGerables: ['Gestionnaire département'],
         },
       },
       {
@@ -37,6 +40,7 @@ describe('postgre utilisateur query', () => {
           groupe: 'gestionnaire',
           nom: 'Gestionnaire groupement',
           organisation: 'Hubikoop',
+          rolesGerables: ['Gestionnaire groupement'],
         },
       },
       {
@@ -46,6 +50,7 @@ describe('postgre utilisateur query', () => {
           groupe: 'gestionnaire',
           nom: 'Gestionnaire région',
           organisation: 'Île-de-France',
+          rolesGerables: ['Gestionnaire région'],
         },
       },
       {
@@ -55,6 +60,7 @@ describe('postgre utilisateur query', () => {
           groupe: 'gestionnaire',
           nom: 'Gestionnaire structure',
           organisation: 'Solidarnum',
+          rolesGerables: ['Gestionnaire structure'],
         },
       },
       {
@@ -64,6 +70,7 @@ describe('postgre utilisateur query', () => {
           groupe: 'admin',
           nom: 'Instructeur',
           organisation: 'Banque des territoires',
+          rolesGerables: Roles,
         },
       },
       {
@@ -73,6 +80,7 @@ describe('postgre utilisateur query', () => {
           groupe: 'admin',
           nom: 'Pilote politique publique',
           organisation: 'France Numérique Ensemble',
+          rolesGerables: Roles,
         },
       },
       {
@@ -82,6 +90,7 @@ describe('postgre utilisateur query', () => {
           groupe: 'admin',
           nom: 'Support animation',
           organisation: 'Mednum',
+          rolesGerables: Roles,
         },
       },
     ] as const)('quand je cherche un utilisateur $roleReadModel.nom qui existe par son ssoId alors je le trouve', async ({ role, roleReadModel }) => {
@@ -224,6 +233,7 @@ describe('postgre utilisateur query', () => {
               groupe: 'gestionnaire',
               nom: 'Gestionnaire département',
               organisation: 'Paris',
+              rolesGerables: ['Gestionnaire département'],
             },
             structureId: null,
             telephone: '0102030405',
@@ -245,6 +255,7 @@ describe('postgre utilisateur query', () => {
               groupe: 'admin',
               nom: 'Administrateur dispositif',
               organisation: 'Administrateur dispositif',
+              rolesGerables: Roles,
             },
             structureId: null,
             telephone: '0102030405',
@@ -265,6 +276,7 @@ describe('postgre utilisateur query', () => {
           groupe: 'gestionnaire',
           nom: 'Gestionnaire département',
           organisation: 'Rhône',
+          rolesGerables: [],
         },
         uid: ssoId,
       })
@@ -314,6 +326,7 @@ describe('postgre utilisateur query', () => {
           groupe: 'gestionnaire',
           nom: 'Gestionnaire région',
           organisation: 'Auvergne-Rhône-Alpes',
+          rolesGerables: [],
         },
         uid: ssoId,
       })
@@ -360,6 +373,7 @@ describe('postgre utilisateur query', () => {
           groupe: 'gestionnaire',
           nom: 'Gestionnaire groupement',
           organisation: 'Hubikoop',
+          rolesGerables: [],
         },
         uid: ssoId,
       })
@@ -405,6 +419,7 @@ describe('postgre utilisateur query', () => {
           groupe: 'gestionnaire',
           nom: 'Gestionnaire structure',
           organisation: 'Solidarnum',
+          rolesGerables: ['Gestionnaire structure'],
         },
         structureId,
         uid: ssoId,
@@ -682,7 +697,7 @@ describe('postgre utilisateur query', () => {
     const utilisateurAuthentifie = utilisateurReadModelFactory({
       uid: ssoId,
     })
-    const roles: Array<string> = []
+    const roles: ReadonlyArray<string> = []
     const postgreUtilisateurLoader = new PostgreUtilisateurLoader(prisma)
     const codeDepartement = '0'
     const codeRegion = '0'

--- a/src/presenters/sessionUtilisateurPresenter.test.ts
+++ b/src/presenters/sessionUtilisateurPresenter.test.ts
@@ -10,6 +10,7 @@ describe('session utilisateur presenter', () => {
         groupe: 'admin',
         nom: 'Support animation',
         organisation: 'Mednum',
+        rolesGerables: [],
       },
       uid: 'fooId',
     })
@@ -30,6 +31,7 @@ describe('session utilisateur presenter', () => {
         libelle: 'Mednum',
         nom: 'Support animation',
         pictogramme: 'mednum',
+        rolesGerables: [],
       },
       telephone: '0102030405',
       uid: 'fooId',

--- a/src/presenters/sessionUtilisateurPresenter.ts
+++ b/src/presenters/sessionUtilisateurPresenter.ts
@@ -14,6 +14,7 @@ export function createSessionUtilisateurPresenter(
       libelle: role.organisation,
       nom: role.nom,
       pictogramme: role.categorie,
+      rolesGerables: role.rolesGerables,
     },
     telephone: utilisateurReadModel.telephone,
     uid: utilisateurReadModel.uid,
@@ -30,6 +31,7 @@ export type SessionUtilisateurViewModel = Readonly<{
     libelle: string
     nom: string
     pictogramme: string
+    rolesGerables: ReadonlyArray<string>
   }>
   uid: string
   telephone: string

--- a/src/use-cases/commands/InviterUnUtilisateur.test.ts
+++ b/src/use-cases/commands/InviterUnUtilisateur.test.ts
@@ -158,18 +158,11 @@ describe('inviter un utilisateur', () => {
 })
 
 const utilisateursByUid: Readonly<Record<string, Utilisateur>> = {
-  utilisateurAdminUid: Utilisateur.create({
-    email: 'martin.tartempion@example.net',
-    isSuperAdmin: false,
-    nom: 'Tartempion',
-    prenom: 'Martin',
-    role: 'Instructeur',
+  utilisateurAdminUid: utilisateurFactory({
     uid: 'utilisateurAdminUid',
   }),
-  utilisateurGestionnaireUid: Utilisateur.create({
+  utilisateurGestionnaireUid: utilisateurFactory({
     email: 'martina.tartempion@example.net',
-    isSuperAdmin: false,
-    nom: 'Tartempion',
     organisation: 'Bretagne',
     prenom: 'Martine',
     role: 'Gestionnaire région',

--- a/src/use-cases/queries/shared/UnUtilisateurReadModel.ts
+++ b/src/use-cases/queries/shared/UnUtilisateurReadModel.ts
@@ -13,6 +13,7 @@ export type UnUtilisateurReadModel = Readonly<{
     groupe: string
     nom: string
     organisation: string
+    rolesGerables: ReadonlyArray<string>
   }>
   regionCode: string | null
   structureId: number | null

--- a/src/use-cases/testHelper.ts
+++ b/src/use-cases/testHelper.ts
@@ -1,4 +1,5 @@
 import { UnUtilisateurReadModel } from './queries/shared/UnUtilisateurReadModel'
+import { Roles } from '@/domain/Role'
 
 export function utilisateurReadModelFactory(
   override?: Partial<UnUtilisateurReadModel>
@@ -19,6 +20,7 @@ export function utilisateurReadModelFactory(
       groupe: 'admin',
       nom: 'Administrateur dispositif',
       organisation: '',
+      rolesGerables: Roles,
     },
     structureId: null,
     telephone: '0102030405',


### PR DESCRIPTION
- [x] Transmettre au _page controller_ la liste des rôles "invitables" par l'utilisateur courant (pour le conditionnement du titre, on laisse tomber pour le moment et on affiche systématiquement le nom de l'organisation/structure même pour un admin)
- [x] conditionner le formulaire en conséquence : boutons radio ou badge rôle et structure (à voir si le composant badge doit évoluer)
- [x] conditionner l'affichage du sélecteur d'organisation à la sélection d'un rôle
- [x] adapter la _server action_ et potentiellement le *use case* pour prendre en compte le cas gestionnaire, où les infos de rôle et d'organisation ne proviennent pas du formulaire
- [x] uniformiser le _drawer_ (maquette où il manque un label...)
- ~[ ] écriture en base : insérer l'information sur l'organisation et gérer l'éventuelle erreur SQL en cas d'incohérence (FK)~ à faire suite au refacto du domaine