### PR TITLE
Les jeux de test pour la migration ont été remis en fonction

### DIFF
--- a/seeds/departement.ts
+++ b/seeds/departement.ts
@@ -14,7 +14,7 @@ async function migration() {
 
   const departementsRecord = [
     ...departements,
-    unDepartementDeTest,
+    unDepartementDeTest(),
   ]
 
   await migrateDepartements(departementsRecord)
@@ -24,10 +24,12 @@ async function migration() {
 
 void migration()
 
-const unDepartementDeTest: Prisma.DepartementRecordUncheckedCreateInput = {
-  code: 'zzz',
-  nom: 'SGN département',
-  regionCode: 'zz',
+function unDepartementDeTest(): Prisma.DepartementRecordUncheckedCreateInput {
+  return {
+    code: 'zzz',
+    nom: 'SGN département',
+    regionCode: 'zz',
+  }
 }
 
 async function migrateDepartements(departementsRecord: Array<Prisma.DepartementRecordUncheckedCreateInput>) {

--- a/seeds/groupement.ts
+++ b/seeds/groupement.ts
@@ -12,7 +12,7 @@ async function migration() {
 
   const groupementsRecord = [
     ...groupements,
-    unGroupementDeTest,
+    unGroupementDeTest(),
   ]
   console.log(greenColor, `${groupementsRecord.length} groupements CoNum sont récupérés`)
 
@@ -23,9 +23,11 @@ async function migration() {
 
 void migration()
 
-const unGroupementDeTest: Prisma.GroupementRecordUncheckedCreateInput = {
-  id: 10_000_000,
-  nom: 'SGN Corporation',
+function unGroupementDeTest(): Prisma.GroupementRecordUncheckedCreateInput {
+  return {
+    id: 10_000_000,
+    nom: 'SGN Corporation',
+  }
 }
 
 async function migrateGroupements(groupementsRecord: Array<Prisma.GroupementRecordUncheckedCreateInput>) {

--- a/seeds/region.ts
+++ b/seeds/region.ts
@@ -14,7 +14,7 @@ async function migration() {
 
   const regionsRecord = [
     ...regions,
-    uneRegionDeTest,
+    uneRegionDeTest(),
   ]
 
   await migrateRegions(regionsRecord)
@@ -24,9 +24,11 @@ async function migration() {
 
 void migration()
 
-const uneRegionDeTest: Prisma.RegionRecordUncheckedCreateInput = {
-  code: 'zz',
-  nom: 'SGN région',
+function uneRegionDeTest(): Prisma.RegionRecordUncheckedCreateInput {
+  return {
+    code: 'zz',
+    nom: 'SGN région',
+  }
 }
 
 async function migrateRegions(regionsRecord: Array<Prisma.RegionRecordUncheckedCreateInput>) {

--- a/seeds/structure.ts
+++ b/seeds/structure.ts
@@ -15,7 +15,7 @@ async function migration() {
 
   const structuresRecord = [
     ...transformStructuresCoNumToStructures(structuresCoNumRecord),
-    uneStructureDeTest,
+    uneStructureDeTest(),
   ]
   console.log(greenColor, `${structuresRecord.length} structures CoNum et FNE sont transformés en structures`)
 
@@ -60,10 +60,12 @@ function transformStructuresCoNumToStructures(
   })
 }
 
-const uneStructureDeTest: Prisma.StructureRecordUncheckedCreateInput = {
-  id: 10_000_000,
-  idMongo: 'zzz',
-  nom: 'SGN structure',
+function uneStructureDeTest(): Prisma.StructureRecordUncheckedCreateInput {
+  return {
+    id: 10_000_000,
+    idMongo: 'zzz',
+    nom: 'SGN structure',
+  }
 }
 
 async function migrateStructures(structuresRecord: Array<Prisma.StructureRecordUncheckedCreateInput>) {

--- a/seeds/utilisateur.ts
+++ b/seeds/utilisateur.ts
@@ -20,7 +20,7 @@ async function migration() {
   const utilisateursRecord = [
     ...await transformUtilisateursCoNumToUtilisateurs(utilisateursCoNumRecord),
     ...transformUtilisateursFNEToUtilisateurs(utilisateursFNERecord),
-    unUtilisateurDeTest,
+    unUtilisateurDeTest(),
   ]
   console.log(greenColor, `${utilisateursRecord.length} utilisateurs CoNum et FNE sont transformés en utilisateurs`)
 
@@ -238,23 +238,26 @@ function transformUtilisateursFNEToUtilisateurs(
   })
 }
 
-const now = new Date()
-const unUtilisateurDeTest: Prisma.UtilisateurRecordUncheckedCreateInput = {
-  dateDeCreation: now,
-  departementCode: '11',
-  derniereConnexion: now,
-  email: 'compte.de.test@example.com',
-  groupementId: 18,
-  inviteLe: now,
-  isSuperAdmin: true,
-  isSupprime: false,
-  nom: 'Test',
-  prenom: 'CompteDe',
-  regionCode: '52',
-  role: 'administrateur_dispositif',
-  ssoId: '7396c91e-b9f2-4f9d-8547-5e9b3332725b',
-  structureId: 292,
-  telephone: '0102030405',
+function unUtilisateurDeTest(): Prisma.UtilisateurRecordUncheckedCreateInput {
+  const now = new Date()
+
+  return {
+    dateDeCreation: now,
+    departementCode: '11',
+    derniereConnexion: now,
+    email: 'compte.de.test@example.com',
+    groupementId: 18,
+    inviteLe: now,
+    isSuperAdmin: true,
+    isSupprime: false,
+    nom: 'Test',
+    prenom: 'CompteDe',
+    regionCode: '52',
+    role: 'administrateur_dispositif',
+    ssoId: '7396c91e-b9f2-4f9d-8547-5e9b3332725b',
+    structureId: 292,
+    telephone: '0102030405',
+  }
 }
 
 async function migrateUtilisateurs(utilisateursRecord: Array<Prisma.UtilisateurRecordUncheckedCreateInput>) {


### PR DESCRIPTION
Vu que l'on a transformé les jeux de test en constante faisait que la fonction appelante ne les connaissait pas, il aurait fallu les mettre au dessus mais ce n'est pas dans nos conventions.