### PR TITLE
Migration de champs pour une structure

### DIFF
--- a/custom.d.ts
+++ b/custom.d.ts
@@ -6,6 +6,24 @@ declare global {
       }
     }
   }
+
+  namespace PrismaJson {
+    interface Contact {
+      email: string
+      fonction: string
+      nom: string
+      prenom: string
+      telephone: string
+    }
+    interface Adresse {
+      code_postal: string
+      indice_repetition_voie: string
+      libelle_commune: string
+      libelle_voie: string
+      numero_voie: string
+      type_voie: string
+    }
+  }
 }
 
 export default global

--- a/custom.d.ts
+++ b/custom.d.ts
@@ -8,21 +8,13 @@ declare global {
   }
 
   namespace PrismaJson {
-    interface Contact {
+    type Contact = Readonly<{
       email: string
       fonction: string
       nom: string
       prenom: string
       telephone: string
-    }
-    interface Adresse {
-      code_postal: string
-      indice_repetition_voie: string
-      libelle_commune: string
-      libelle_voie: string
-      numero_voie: string
-      type_voie: string
-    }
+    }>
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "mongodb": "^6.10.0",
     "next": "14.2.15",
     "next-auth": "^4.24.10",
+    "prisma-json-types-generator": "^3.1.1",
     "react": "^18",
     "react-dom": "^18",
     "react-select": "^5.8.2",

--- a/prisma/migrations/20241029135940_ajout_de_champs_a_la_structure/migration.sql
+++ b/prisma/migrations/20241029135940_ajout_de_champs_a_la_structure/migration.sql
@@ -1,0 +1,26 @@
+/*
+  Warnings:
+
+  - Added the required column `adresse` to the `structure` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `contact` to the `structure` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `departementCode` to the `structure` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `identifiantEtablissement` to the `structure` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `regionCode` to the `structure` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `statut` to the `structure` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `type` to the `structure` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "structure" ADD COLUMN     "adresse" JSONB NOT NULL,
+ADD COLUMN     "contact" JSONB NOT NULL,
+ADD COLUMN     "departementCode" TEXT NOT NULL,
+ADD COLUMN     "identifiantEtablissement" TEXT NOT NULL,
+ADD COLUMN     "regionCode" TEXT NOT NULL,
+ADD COLUMN     "statut" TEXT NOT NULL,
+ADD COLUMN     "type" TEXT NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "structure" ADD CONSTRAINT "structure_departementCode_fkey" FOREIGN KEY ("departementCode") REFERENCES "departement"("code") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "structure" ADD CONSTRAINT "structure_regionCode_fkey" FOREIGN KEY ("regionCode") REFERENCES "region"("code") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20241030110516_ajout_de_champs_a_la_structure/migration.sql
+++ b/prisma/migrations/20241030110516_ajout_de_champs_a_la_structure/migration.sql
@@ -2,25 +2,24 @@
   Warnings:
 
   - Added the required column `adresse` to the `structure` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `codePostal` to the `structure` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `commune` to the `structure` table without a default value. This is not possible if the table is not empty.
   - Added the required column `contact` to the `structure` table without a default value. This is not possible if the table is not empty.
   - Added the required column `departementCode` to the `structure` table without a default value. This is not possible if the table is not empty.
   - Added the required column `identifiantEtablissement` to the `structure` table without a default value. This is not possible if the table is not empty.
-  - Added the required column `regionCode` to the `structure` table without a default value. This is not possible if the table is not empty.
   - Added the required column `statut` to the `structure` table without a default value. This is not possible if the table is not empty.
   - Added the required column `type` to the `structure` table without a default value. This is not possible if the table is not empty.
 
 */
 -- AlterTable
-ALTER TABLE "structure" ADD COLUMN     "adresse" JSONB NOT NULL,
+ALTER TABLE "structure" ADD COLUMN     "adresse" TEXT NOT NULL,
+ADD COLUMN     "codePostal" TEXT NOT NULL,
+ADD COLUMN     "commune" TEXT NOT NULL,
 ADD COLUMN     "contact" JSONB NOT NULL,
 ADD COLUMN     "departementCode" TEXT NOT NULL,
 ADD COLUMN     "identifiantEtablissement" TEXT NOT NULL,
-ADD COLUMN     "regionCode" TEXT NOT NULL,
 ADD COLUMN     "statut" TEXT NOT NULL,
 ADD COLUMN     "type" TEXT NOT NULL;
 
 -- AddForeignKey
 ALTER TABLE "structure" ADD CONSTRAINT "structure_departementCode_fkey" FOREIGN KEY ("departementCode") REFERENCES "departement"("code") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "structure" ADD CONSTRAINT "structure_regionCode_fkey" FOREIGN KEY ("regionCode") REFERENCES "region"("code") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2,6 +2,10 @@ generator client {
   provider = "prisma-client-js"
 }
 
+generator json {
+  provider = "prisma-json-types-generator"
+}
+
 datasource db {
   provider = "postgresql"
   url = env("DATABASE_URL")
@@ -26,6 +30,7 @@ model DepartementRecord {
   regionCode String
   nom String
 
+  structures StructureRecord[]
   utilisateurs UtilisateurRecord[]
 
   relationRegion RegionRecord @relation(fields: [regionCode], references: [code])
@@ -37,8 +42,9 @@ model RegionRecord {
   code String @id
   nom String
 
-  utilisateurs UtilisateurRecord[]
   departements DepartementRecord[]
+  structures StructureRecord[]
+  utilisateurs UtilisateurRecord[]
 
   @@map("region")
 }
@@ -48,9 +54,22 @@ model StructureRecord {
 
   // TODO: à supprimer après la migration finale
   idMongo String
+  /// [Contact]
+  contact Json
+  departementCode String
+  // SIRET ou RIDET
+  identifiantEtablissement String
+  /// [Adresse]
+  adresse Json
   nom String
+  regionCode String
+  statut String
+  type String
 
   utilisateurs UtilisateurRecord[]
+
+  relationDepartement DepartementRecord @relation(fields: [departementCode], references: [code])
+  relationRegion RegionRecord @relation(fields: [regionCode], references: [code])
 
   @@map("structure")
 }
@@ -74,10 +93,10 @@ model UtilisateurRecord {
   ssoId String @unique @default("")
   telephone String @db.VarChar(13)
 
-  relationStructures StructureRecord? @relation(fields: [structureId], references: [id])
-  relationGroupements GroupementRecord? @relation(fields: [groupementId], references: [id])
-  relationDepartements DepartementRecord? @relation(fields: [departementCode], references: [code])
-  relationRegions RegionRecord? @relation(fields: [regionCode], references: [code])
+  relationStructure StructureRecord? @relation(fields: [structureId], references: [id])
+  relationGroupement GroupementRecord? @relation(fields: [groupementId], references: [id])
+  relationDepartement DepartementRecord? @relation(fields: [departementCode], references: [code])
+  relationRegion RegionRecord? @relation(fields: [regionCode], references: [code])
 
   @@map("utilisateur")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,7 +43,6 @@ model RegionRecord {
   nom String
 
   departements DepartementRecord[]
-  structures StructureRecord[]
   utilisateurs UtilisateurRecord[]
 
   @@map("region")
@@ -52,24 +51,23 @@ model RegionRecord {
 model StructureRecord {
   id Int @id @default(autoincrement())
 
-  // TODO: à supprimer après la migration finale
-  idMongo String
+  adresse String
+  codePostal String
+  commune String
   /// [Contact]
   contact Json
   departementCode String
   // SIRET ou RIDET
   identifiantEtablissement String
-  /// [Adresse]
-  adresse Json
+  // TODO: à supprimer après la migration finale
+  idMongo String
   nom String
-  regionCode String
   statut String
   type String
 
   utilisateurs UtilisateurRecord[]
 
   relationDepartement DepartementRecord @relation(fields: [departementCode], references: [code])
-  relationRegion RegionRecord @relation(fields: [regionCode], references: [code])
 
   @@map("structure")
 }

--- a/seeds/structure.ts
+++ b/seeds/structure.ts
@@ -35,7 +35,26 @@ async function retrieveStructuresCoNum(): Promise<Array<StructureCoNumRecord>> {
         {
           $project: {
             _id: 1,
+            codeDepartement: 1,
+            codeRegion: 1,
+            contact: 1,
+            insee: 1,
             nom: 1,
+            reseau: 1,
+            ridet: 1,
+            siret: 1,
+            statut: 1,
+            type: 1,
+          },
+        },
+        {
+          $match: {
+            // il y a 126 structures avec statut REFUS_COSELEC qui n'ont pas de SIRET donc on ne les prend pas
+            siret: { $ne: null },
+            statut: {
+              // On ne prend pas les autres statuts car on ne veut pas garder d'historique
+              $in: ['ABANDON', 'CREEE', 'REFUS_COORDINATEUR', 'REFUS_COSELEC', 'VALIDATION_COSELEC'],
+            },
           },
         },
       ])
@@ -54,17 +73,47 @@ function transformStructuresCoNumToStructures(
 ): Array<Prisma.StructureRecordUncheckedCreateInput> {
   return structuresCoNumRecord.map((structureCoNumRecord): Prisma.StructureRecordUncheckedCreateInput => {
     return {
+      // Le champ insee est rempli à partir du moment où la structure est validée par le COSELEC
+      // @ts-expect-error
+      adresse: structureCoNumRecord.insee?.adresse ?? {},
+      contact: structureCoNumRecord.contact,
+      // On ne peut pas changer directement le 00 en 978 en production car beaucoup de logique est basée dessus
+      departementCode: structureCoNumRecord.codeDepartement === '00' ? '978' : structureCoNumRecord.codeDepartement,
       idMongo: structureCoNumRecord._id,
+      identifiantEtablissement: structureCoNumRecord.siret || structureCoNumRecord.ridet,
       nom: structureCoNumRecord.nom,
+      regionCode: structureCoNumRecord.codeRegion,
+      statut: structureCoNumRecord.statut,
+      type: structureCoNumRecord.type,
     }
   })
 }
 
 function uneStructureDeTest(): Prisma.StructureRecordUncheckedCreateInput {
   return {
+    adresse: {
+      code_postal: '84200',
+      indice_repetition_voie: 'BIS',
+      libelle_commune: 'PARIS',
+      libelle_voie: 'CHARLES DE GAULLE',
+      numero_voie: '3',
+      type_voie: 'AVENUE',
+    },
+    contact: {
+      email: 'contact@example.com',
+      fonction: 'Président',
+      nom: 'Dupont',
+      prenom: 'Tartempion',
+      telephone: '0102030405',
+    },
+    departementCode: 'zzz',
     id: 10_000_000,
     idMongo: 'zzz',
+    identifiantEtablissement: 'toto',
     nom: 'SGN structure',
+    regionCode: 'zz',
+    statut: 'VALIDATION_COSELEC',
+    type: 'COMMUNE',
   }
 }
 
@@ -76,5 +125,22 @@ async function migrateStructures(structuresRecord: Array<Prisma.StructureRecordU
 
 type StructureCoNumRecord = Readonly<{
   _id: string
+  codeDepartement: string
+  codeRegion: string
+  contact: {
+    email: string
+    fonction: string
+    nom: string
+    prenom: string
+    telephone: string
+  }
+  insee?: Readonly<{
+    adresse: PrismaJson.Adresse
+  }>
   nom: string
+  reseau: string
+  ridet: string
+  siret: string
+  statut: string
+  type: string
 }>

--- a/seeds/utilisateur.ts
+++ b/seeds/utilisateur.ts
@@ -162,8 +162,10 @@ async function transformUtilisateursCoNumToUtilisateurs(
       role = 'gestionnaire_structure'
 
       const structure = structures.find((structureId) => structureId.idMongo === utilisateurCoNumRecord.entityId)
-      // @ts-expect-error
-      structureId = structure.id
+
+      if (structure) {
+        structureId = structure.id
+      }
     } else if (isGestionnaireRegion) {
       role = 'gestionnaire_region'
 
@@ -272,7 +274,7 @@ function decodeJwt(token: string): Token {
   return JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString()) as Token
 }
 
-async function retrieveStructures(): Promise<Array<Prisma.StructureRecordUncheckedCreateInput>> {
+async function retrieveStructures(): Promise<Array<Partial<Prisma.StructureRecordUncheckedCreateInput>>> {
   return prisma.structureRecord.findMany({
     select: {
       id: true,

--- a/seeds/utilisateur.ts
+++ b/seeds/utilisateur.ts
@@ -163,9 +163,8 @@ async function transformUtilisateursCoNumToUtilisateurs(
 
       const structure = structures.find((structureId) => structureId.idMongo === utilisateurCoNumRecord.entityId)
 
-      if (structure) {
-        structureId = structure.id
-      }
+      // @ts-expect-error
+      structureId = structure.id
     } else if (isGestionnaireRegion) {
       role = 'gestionnaire_region'
 

--- a/src/components/MesInformationsPersonnelles/MesInformationsPersonnelles.test.tsx
+++ b/src/components/MesInformationsPersonnelles/MesInformationsPersonnelles.test.tsx
@@ -95,7 +95,6 @@ describe('mes informations personnelles : en tant qu’utilisateur authentifié'
     afficherMesInformationsPersonnelles({
       ...mesInformationsPersonnellesReadModelParDefaut,
       role,
-      // @ts-expect-error
       structure: {
         adresse: '201 bis rue de la plaine, 69000 Lyon',
         contact: {
@@ -400,7 +399,8 @@ describe('mes informations personnelles : en tant qu’utilisateur authentifié'
 })
 
 function afficherMesInformationsPersonnelles(
-  mesInformationsPersonnellesReadModel = mesInformationsPersonnellesReadModelParDefaut
+  mesInformationsPersonnellesReadModel: Parameters<typeof mesInformationsPersonnellesPresenter>[0]
+  = mesInformationsPersonnellesReadModelParDefaut
 ) {
   const mesInformationsPersonnellesViewModel =
     mesInformationsPersonnellesPresenter(mesInformationsPersonnellesReadModel)

--- a/src/components/MesInformationsPersonnelles/MesInformationsPersonnelles.test.tsx
+++ b/src/components/MesInformationsPersonnelles/MesInformationsPersonnelles.test.tsx
@@ -63,7 +63,7 @@ describe('mes informations personnelles : en tant qu’utilisateur authentifié'
 
   it('quand j’affiche mes informations personnelles mais avec un téléphone non renseigné alors il s’affiche cette notion', () => {
     // WHEN
-    afficherMesInformationsPersonnelles({ ...mesInformationsPersonnellesReadModelParDefaut, informationsPersonnellesTelephone: '' })
+    afficherMesInformationsPersonnelles({ ...mesInformationsPersonnellesReadModelParDefaut, telephone: '' })
 
     // THEN
     const mesInformationsPersonnelles = screen.getByRole('region', { name: 'Mes informations personnelles' })
@@ -92,7 +92,23 @@ describe('mes informations personnelles : en tant qu’utilisateur authentifié'
     'Gestionnaire groupement',
   ])('étant un %s quand j’affiche mes informations personnelles alors l’encart "structure" s’affiche', (role) => {
     // WHEN
-    afficherMesInformationsPersonnelles({ ...mesInformationsPersonnellesReadModelParDefaut, role })
+    afficherMesInformationsPersonnelles({
+      ...mesInformationsPersonnellesReadModelParDefaut,
+      role,
+      // @ts-expect-error
+      structure: {
+        adresse: '201 bis rue de la plaine, 69000 Lyon',
+        contact: {
+          email: 'manon.verminac@example.com',
+          fonction: 'Chargée de mission',
+          nom: 'Verninac',
+          prenom: 'Manon',
+        },
+        numeroDeSiret: '62520260000023',
+        raisonSociale: 'Préfecture du Rhône',
+        typeDeStructure: 'Administration',
+      },
+    })
 
     // THEN
     const maStructure = screen.getByRole('region', { name: 'Ma structure' })
@@ -106,10 +122,12 @@ describe('mes informations personnelles : en tant qu’utilisateur authentifié'
     expect(typeDeStructureLabel).toBeInTheDocument()
     const typeDeStructure = within(maStructure).getByText('Administration')
     expect(typeDeStructure).toBeInTheDocument()
-    const numeroDeSiretLabel = within(maStructure).getByText(matchWithoutMarkup('Numéro de SIRET'))
+    const numeroDeSiretLabel = within(maStructure).getByText(matchWithoutMarkup('Numéro de SIRET/RIDET'))
     expect(numeroDeSiretLabel).toBeInTheDocument()
     const abreviationSiret = within(numeroDeSiretLabel).getByText('SIRET', { selector: 'abbr' })
     expect(abreviationSiret).toHaveAttribute('title', 'Système d’Identification du Répertoire des ÉTablissements')
+    const abreviationRidet = within(numeroDeSiretLabel).getByText('RIDET', { selector: 'abbr' })
+    expect(abreviationRidet).toHaveAttribute('title', 'Répertoire d’Identification des Entreprises et des ÉTablissements')
     const numeroDeSiret = within(maStructure).getByText('62520260000023')
     expect(numeroDeSiret).toBeInTheDocument()
     const adresseLabel = within(maStructure).getByText('Adresse')
@@ -323,7 +341,7 @@ describe('mes informations personnelles : en tant qu’utilisateur authentifié'
 
     it('alors le téléphone n’est pas rempli s’il est non renseigné', () => {
       // GIVEN
-      afficherMesInformationsPersonnelles({ ...mesInformationsPersonnellesReadModelParDefaut, informationsPersonnellesTelephone: '' })
+      afficherMesInformationsPersonnelles({ ...mesInformationsPersonnellesReadModelParDefaut, telephone: '' })
 
       // WHEN
       ouvrirDrawer()
@@ -394,17 +412,9 @@ function afficherMesInformationsPersonnelles(
 }
 
 const mesInformationsPersonnellesReadModelParDefaut = {
-  contactEmail: 'manon.verminac@example.com',
-  contactFonction: 'Chargée de mission',
-  contactNom: 'Verninac',
-  contactPrenom: 'Manon',
-  informationsPersonnellesEmail: 'julien.deschamps@example.com',
-  informationsPersonnellesNom: 'Deschamps',
-  informationsPersonnellesPrenom: 'Julien',
-  informationsPersonnellesTelephone: '0405060708',
+  email: 'julien.deschamps@example.com',
+  nom: 'Deschamps',
+  prenom: 'Julien',
   role: 'Administrateur dispositif',
-  structureAdresse: '201 bis rue de la plaine, 69000 Lyon',
-  structureNumeroDeSiret: '62520260000023',
-  structureRaisonSociale: 'Préfecture du Rhône',
-  structureTypeDeStructure: 'Administration',
+  telephone: '0405060708',
 }

--- a/src/components/MesInformationsPersonnelles/MesInformationsPersonnelles.tsx
+++ b/src/components/MesInformationsPersonnelles/MesInformationsPersonnelles.tsx
@@ -54,24 +54,24 @@ export default function MesInformationsPersonnelles(
           <div className="fr-grid-row fr-grid-row--center fr-grid-row--gutters">
             <InformationPersonnelle
               label="Nom"
-              value={mesInformationsPersonnellesViewModel.informationsPersonnellesNom}
+              value={mesInformationsPersonnellesViewModel.nom}
             />
             <InformationPersonnelle
               label="Prénom"
-              value={mesInformationsPersonnellesViewModel.informationsPersonnellesPrenom}
+              value={mesInformationsPersonnellesViewModel.prenom}
             />
             <InformationPersonnelle
               label="Adresse électronique"
-              value={mesInformationsPersonnellesViewModel.informationsPersonnellesEmail}
+              value={mesInformationsPersonnellesViewModel.email}
             />
             <InformationPersonnelle
               label="Téléphone professionnel"
-              value={mesInformationsPersonnellesViewModel.informationsPersonnellesTelephone}
+              value={mesInformationsPersonnellesViewModel.telephone}
             />
           </div>
         </section>
         {
-          mesInformationsPersonnellesViewModel.isStructure ? (
+          mesInformationsPersonnellesViewModel.structure ? (
             <section
               aria-labelledby="maStructure"
               className="grey-border fr-p-4w fr-mb-4w"
@@ -86,11 +86,11 @@ export default function MesInformationsPersonnelles(
               <div className="fr-grid-row fr-grid-row--center fr-grid-row--gutters">
                 <InformationPersonnelle
                   label="Raison sociale"
-                  value={mesInformationsPersonnellesViewModel.structureRaisonSociale}
+                  value={mesInformationsPersonnellesViewModel.structure.raisonSociale}
                 />
                 <InformationPersonnelle
                   label="Type de structure"
-                  value={mesInformationsPersonnellesViewModel.structureTypeDeStructure}
+                  value={mesInformationsPersonnellesViewModel.structure.typeDeStructure}
                 />
                 <InformationPersonnelle
                   label={
@@ -100,13 +100,19 @@ export default function MesInformationsPersonnelles(
                       <abbr title="Système d’Identification du Répertoire des ÉTablissements">
                         SIRET
                       </abbr>
+                      {/**/}
+                      /
+                      {/**/}
+                      <abbr title="Répertoire d’Identification des Entreprises et des ÉTablissements">
+                        RIDET
+                      </abbr>
                     </>
                   }
-                  value={mesInformationsPersonnellesViewModel.structureNumeroDeSiret}
+                  value={mesInformationsPersonnellesViewModel.structure.numeroDeSiret}
                 />
                 <InformationPersonnelle
                   label="Adresse"
-                  value={mesInformationsPersonnellesViewModel.structureAdresse}
+                  value={mesInformationsPersonnellesViewModel.structure.adresse}
                 />
               </div>
               <hr className="fr-mt-3w" />
@@ -116,19 +122,19 @@ export default function MesInformationsPersonnelles(
               <div className="fr-grid-row fr-grid-row--center fr-grid-row--gutters">
                 <InformationPersonnelle
                   label="Nom"
-                  value={mesInformationsPersonnellesViewModel.contactNom}
+                  value={mesInformationsPersonnellesViewModel.structure.contact.nom}
                 />
                 <InformationPersonnelle
                   label="Prénom"
-                  value={mesInformationsPersonnellesViewModel.contactPrenom}
+                  value={mesInformationsPersonnellesViewModel.structure.contact.prenom}
                 />
                 <InformationPersonnelle
                   label="Fonction dans la structure"
-                  value={mesInformationsPersonnellesViewModel.contactFonction}
+                  value={mesInformationsPersonnellesViewModel.structure.contact.fonction}
                 />
                 <InformationPersonnelle
                   label="Adresse électronique"
-                  value={mesInformationsPersonnellesViewModel.contactEmail}
+                  value={mesInformationsPersonnellesViewModel.structure.contact.email}
                 />
               </div>
             </section>
@@ -186,7 +192,7 @@ export default function MesInformationsPersonnelles(
           </button>
         </section>
         <SupprimerMonCompte
-          email={mesInformationsPersonnellesViewModel.informationsPersonnellesEmail}
+          email={mesInformationsPersonnellesViewModel.email}
           id={supprimerMonCompteModalId}
           isOpen={isModalOpen}
           setIsOpen={setIsModalOpen}
@@ -202,11 +208,11 @@ export default function MesInformationsPersonnelles(
         setIsOpen={setIsDrawerOpen}
       >
         <ModifierMonCompte
-          email={mesInformationsPersonnellesViewModel.informationsPersonnellesEmail}
+          email={mesInformationsPersonnellesViewModel.email}
           id={drawerId}
           labelId={labelId}
-          nom={mesInformationsPersonnellesViewModel.informationsPersonnellesNom}
-          prenom={mesInformationsPersonnellesViewModel.informationsPersonnellesPrenom}
+          nom={mesInformationsPersonnellesViewModel.nom}
+          prenom={mesInformationsPersonnellesViewModel.prenom}
           setIsOpen={setIsDrawerOpen}
           telephone={mesInformationsPersonnellesViewModel.telephoneBrut}
         />

--- a/src/domain/Structure.ts
+++ b/src/domain/Structure.ts
@@ -22,3 +22,28 @@ export type StructureState = Readonly<{
   id: number
   nom: string
 }>
+
+const Types = [
+  'COLLECTIVITE',
+  'COMMUNE',
+  'DEPARTEMENT',
+  'EPCI',
+  'GIP',
+  'PRIVATE',
+  'REGION',
+] as const
+
+export type TypologieType = (typeof Types)[number]
+
+const Statuts = [
+  'ABANDON',
+  'ANNULEE',
+  'CREEE',
+  'DOUBLON',
+  'EXAMEN_COMPLEMENTAIRE_COSELEC',
+  'REFUS_COORDINATEUR',
+  'REFUS_COSELEC',
+  'VALIDATION_COSELEC',
+] as const
+
+export type TypologieStatut = (typeof Statuts)[number]

--- a/src/gateways/PostgreMesInformationsPersonnellesLoader.test.ts
+++ b/src/gateways/PostgreMesInformationsPersonnellesLoader.test.ts
@@ -5,7 +5,7 @@ import prisma from '../../prisma/prismaClient'
 import { TypologieRole } from '@/domain/Role'
 import { MesInformationsPersonnellesReadModel } from '@/use-cases/queries/RecupererMesInformationsPersonnelles'
 
-describe('postgre mes informations personnelles', () => {
+describe('mes informations personnelles loader', () => {
   beforeEach(async () => prisma.$queryRaw`START TRANSACTION`)
 
   afterEach(async () => prisma.$queryRaw`ROLLBACK TRANSACTION`)
@@ -20,16 +20,8 @@ describe('postgre mes informations personnelles', () => {
       roleLabel: 'Gestionnaire département' as TypologieRole,
     },
     {
-      role: 'gestionnaire_groupement' as Role,
-      roleLabel: 'Gestionnaire groupement' as TypologieRole,
-    },
-    {
       role: 'gestionnaire_region' as Role,
       roleLabel: 'Gestionnaire région' as TypologieRole,
-    },
-    {
-      role: 'gestionnaire_structure' as Role,
-      roleLabel: 'Gestionnaire structure' as TypologieRole,
     },
     {
       role: 'instructeur' as Role,
@@ -43,46 +35,124 @@ describe('postgre mes informations personnelles', () => {
       role: 'support_animation' as Role,
       roleLabel: 'Support animation' as TypologieRole,
     },
-  ])('quand je cherche un utilisateur $roleLabel qui existe par son ssoId alors je retourne ses informations personnelles',
-    async ({ role, roleLabel }) => {
+    {
+      role: 'gestionnaire_groupement' as Role,
+      roleLabel: 'Gestionnaire groupement' as TypologieRole,
+    },
+  ])('cherchant un utilisateur $roleLabel qui existe par son ssoId alors cela retourne ses informations personnelles sans notion de structure', async ({ role, roleLabel }) => {
     // GIVEN
-      const ssoIdExistant = '7396c91e-b9f2-4f9d-8547-5e7b3302725b'
-      const date = new Date()
-      await prisma.utilisateurRecord.create({
-        data: {
-          dateDeCreation: date,
-          email: 'martin.tartempion@example.net',
-          inviteLe: date,
-          nom: 'Tartempion',
-          prenom: 'Martin',
-          role,
-          ssoId: ssoIdExistant,
+    const ssoIdExistant = '7396c91e-b9f2-4f9d-8547-5e7b3302725b'
+    const date = new Date(0)
+    await prisma.utilisateurRecord.create({
+      data: {
+        dateDeCreation: date,
+        email: 'martin.tartempion@example.net',
+        inviteLe: date,
+        nom: 'Tartempion',
+        prenom: 'Martin',
+        role,
+        ssoId: ssoIdExistant,
+        telephone: '0102030405',
+      },
+    })
+    const mesInformationsPersonnellesLoader = new PostgreMesInformationsPersonnellesLoader(prisma)
+
+    // WHEN
+    const mesInformationsPersonnellesReadModel = await mesInformationsPersonnellesLoader.findByUid(ssoIdExistant)
+
+    // THEN
+    expect(mesInformationsPersonnellesReadModel).toStrictEqual<MesInformationsPersonnellesReadModel>({
+      email: 'martin.tartempion@example.net',
+      nom: 'Tartempion',
+      prenom: 'Martin',
+      role: roleLabel,
+      telephone: '0102030405',
+    })
+  })
+
+  it('cherchant un utilisateur $roleLabel qui existe par son ssoId alors cela retourne ses informations personnelles avec sa notion de structure', async () => {
+    // GIVEN
+    const ssoIdExistant = '7396c91e-b9f2-4f9d-8547-5e7b3302725b'
+    const date = new Date(0)
+    await prisma.regionRecord.create({
+      data: {
+        code: '84',
+        nom: 'Auvergne-Rhône-Alpes',
+      },
+    })
+    await prisma.departementRecord.create({
+      data: {
+        code: '69',
+        nom: 'Rhône',
+        regionCode: '84',
+      },
+    })
+    await prisma.structureRecord.create({
+      data: {
+        adresse: {
+          code_postal: '84200',
+          indice_repetition_voie: 'BIS',
+          libelle_commune: 'PARIS',
+          libelle_voie: 'CHARLES DE GAULLE',
+          numero_voie: '3',
+          type_voie: 'AVENUE',
+        },
+        contact: {
+          email: 'manon.verminac@example.com',
+          fonction: 'Chargée de mission',
+          nom: 'Verninac',
+          prenom: 'Manon',
           telephone: '0102030405',
         },
-      })
-      const postgreMesInformationsPersonnellesGateway = new PostgreMesInformationsPersonnellesLoader(prisma)
-
-      // WHEN
-      const mesInformationsPersonnellesReadModel =
-        await postgreMesInformationsPersonnellesGateway.findByUid(ssoIdExistant)
-
-      // THEN
-      expect(mesInformationsPersonnellesReadModel).toStrictEqual<MesInformationsPersonnellesReadModel>({
-        contactEmail: 'manon.verminac@example.com',
-        contactFonction: 'Chargée de mission',
-        contactNom: 'Verninac',
-        contactPrenom: 'Manon',
-        informationsPersonnellesEmail: 'martin.tartempion@example.net',
-        informationsPersonnellesNom: 'Tartempion',
-        informationsPersonnellesPrenom: 'Martin',
-        informationsPersonnellesTelephone: '0102030405',
-        role: roleLabel,
-        structureAdresse: '201 bis rue de la plaine, 69000 Lyon',
-        structureNumeroDeSiret: '62520260000023',
-        structureRaisonSociale: 'Préfecture du Rhône',
-        structureTypeDeStructure: 'Administration',
-      })
+        departementCode: '69',
+        id: 10,
+        idMongo: '123456',
+        identifiantEtablissement: '62520260000023',
+        nom: 'Solidarnum',
+        regionCode: '84',
+        statut: 'VALIDATION_COSELEC',
+        type: 'COMMUNE',
+      },
     })
+    await prisma.utilisateurRecord.create({
+      data: {
+        dateDeCreation: date,
+        email: 'martin.tartempion@example.net',
+        inviteLe: date,
+        nom: 'Tartempion',
+        prenom: 'Martin',
+        role: 'gestionnaire_structure',
+        ssoId: ssoIdExistant,
+        structureId: 10,
+        telephone: '0102030405',
+      },
+    })
+    const mesInformationsPersonnellesLoader = new PostgreMesInformationsPersonnellesLoader(prisma)
+
+    // WHEN
+    const mesInformationsPersonnellesReadModel = await mesInformationsPersonnellesLoader.findByUid(ssoIdExistant)
+
+    // THEN
+    expect(mesInformationsPersonnellesReadModel).toStrictEqual<MesInformationsPersonnellesReadModel>({
+      email: 'martin.tartempion@example.net',
+      nom: 'Tartempion',
+      prenom: 'Martin',
+      role: 'Gestionnaire structure',
+      structure: {
+        adresse: '3 BIS AVENUE CHARLES DE GAULLE, 84200 PARIS',
+        contact: {
+          email: 'manon.verminac@example.com',
+          fonction: 'Chargée de mission',
+          nom: 'Verninac',
+          prenom: 'Manon',
+        },
+        numeroDeSiret: '62520260000023',
+        raisonSociale: 'Solidarnum',
+        typeDeStructure: 'COMMUNE',
+      },
+      telephone: '0102030405',
+    })
+  })
 
   it('quand je cherche un utilisateur qui n’existe pas par son ssoId alors je ne le trouve pas', async () => {
     // GIVEN

--- a/src/gateways/PostgreMesInformationsPersonnellesLoader.test.ts
+++ b/src/gateways/PostgreMesInformationsPersonnellesLoader.test.ts
@@ -89,14 +89,9 @@ describe('mes informations personnelles loader', () => {
     })
     await prisma.structureRecord.create({
       data: {
-        adresse: {
-          code_postal: '84200',
-          indice_repetition_voie: 'BIS',
-          libelle_commune: 'PARIS',
-          libelle_voie: 'CHARLES DE GAULLE',
-          numero_voie: '3',
-          type_voie: 'AVENUE',
-        },
+        adresse: '3 BIS AVENUE CHARLES DE GAULLE',
+        codePostal: '84200',
+        commune: 'PARIS',
         contact: {
           email: 'manon.verminac@example.com',
           fonction: 'Chargée de mission',
@@ -109,7 +104,6 @@ describe('mes informations personnelles loader', () => {
         idMongo: '123456',
         identifiantEtablissement: '62520260000023',
         nom: 'Solidarnum',
-        regionCode: '84',
         statut: 'VALIDATION_COSELEC',
         type: 'COMMUNE',
       },

--- a/src/gateways/PostgreMesInformationsPersonnellesLoader.ts
+++ b/src/gateways/PostgreMesInformationsPersonnellesLoader.ts
@@ -34,7 +34,7 @@ export class PostgreMesInformationsPersonnellesLoader implements MesInformations
 }
 
 function transform(utilisateurRecord: UtilisateurEtSesRelationsRecord): MesInformationsPersonnellesReadModel {
-  const mesInformationsPersonnelles = {
+  let mesInformationsPersonnelles: MesInformationsPersonnellesReadModel = {
     email: utilisateurRecord.email,
     nom: utilisateurRecord.nom,
     prenom: utilisateurRecord.prenom,
@@ -42,19 +42,12 @@ function transform(utilisateurRecord: UtilisateurEtSesRelationsRecord): MesInfor
     telephone: utilisateurRecord.telephone,
   }
 
-  let structure = {}
   if (utilisateurRecord.relationStructure && utilisateurRecord.role === 'gestionnaire_structure') {
-    const adresse = [
-      utilisateurRecord.relationStructure.adresse.numero_voie,
-      utilisateurRecord.relationStructure.adresse.indice_repetition_voie,
-      utilisateurRecord.relationStructure.adresse.type_voie,
-      utilisateurRecord.relationStructure.adresse.libelle_voie + ',',
-      utilisateurRecord.relationStructure.adresse.code_postal,
-      utilisateurRecord.relationStructure.adresse.libelle_commune,
-    ]
-    structure = {
+    const { adresse, codePostal, commune } = utilisateurRecord.relationStructure
+    mesInformationsPersonnelles = {
+      ...mesInformationsPersonnelles,
       structure: {
-        adresse: adresse.join(' '),
+        adresse: `${adresse}, ${codePostal} ${commune}`,
         contact: {
           email: utilisateurRecord.relationStructure.contact.email,
           fonction: utilisateurRecord.relationStructure.contact.fonction,
@@ -68,8 +61,5 @@ function transform(utilisateurRecord: UtilisateurEtSesRelationsRecord): MesInfor
     }
   }
 
-  return {
-    ...mesInformationsPersonnelles,
-    ...structure,
-  }
+  return mesInformationsPersonnelles
 }

--- a/src/gateways/PostgreUtilisateurLoader.test.ts
+++ b/src/gateways/PostgreUtilisateurLoader.test.ts
@@ -746,14 +746,9 @@ function structureRecordFactory(
   override?: Partial<Prisma.StructureRecordUncheckedCreateInput>
 ): Prisma.StructureRecordUncheckedCreateInput {
   return {
-    adresse: {
-      code_postal: '',
-      indice_repetition_voie: '',
-      libelle_commune: '',
-      libelle_voie: '',
-      numero_voie: '',
-      type_voie: '',
-    },
+    adresse: '',
+    codePostal: '',
+    commune: '',
     contact: {
       email: '',
       fonction: '',
@@ -766,7 +761,6 @@ function structureRecordFactory(
     idMongo: '123456',
     identifiantEtablissement: '41816609600069',
     nom: 'Solidarnum',
-    regionCode: '11',
     statut: 'VALIDATION_COSELEC',
     type: 'COMMUNE',
     ...override,

--- a/src/gateways/PostgreUtilisateurLoader.test.ts
+++ b/src/gateways/PostgreUtilisateurLoader.test.ts
@@ -120,24 +120,20 @@ describe('postgre utilisateur query', () => {
     ])('quand je cherche un utilisateur $roleReadModel.nom qui existe par son ssoId alors je le trouve', async ({ departementCode, groupementId, regionCode, role, roleReadModel, structureId }) => {
       // GIVEN
       const ssoIdExistant = '7396c91e-b9f2-4f9d-8547-5e7b3302725b'
+      await prisma.regionRecord.create({
+        data: regionRecordFactory(),
+      })
+      await prisma.departementRecord.create({
+        data: departementRecordFactory(),
+      })
       await prisma.structureRecord.create({
-        data: {
-          id: 10,
-          idMongo: '123456',
-          nom: 'Solidarnum',
-        },
+        data: structureRecordFactory(),
       })
       await prisma.groupementRecord.create({
         data: {
           id: 10,
           nom: 'Hubikoop',
         },
-      })
-      await prisma.regionRecord.create({
-        data: regionRecordFactory(),
-      })
-      await prisma.departementRecord.create({
-        data: departementRecordFactory(),
       })
       await prisma.utilisateurRecord.create({
         data: utilisateurRecordFactory({
@@ -443,12 +439,14 @@ describe('postgre utilisateur query', () => {
         structureId,
         uid: ssoId,
       })
+      await prisma.regionRecord.create({
+        data: regionRecordFactory(),
+      })
+      await prisma.departementRecord.create({
+        data: departementRecordFactory(),
+      })
       await prisma.structureRecord.create({
-        data: {
-          id: structureId,
-          idMongo: '123456',
-          nom: 'Solidarnum',
-        },
+        data: structureRecordFactory({ id: structureId }),
       })
       await prisma.utilisateurRecord.create({
         data: utilisateurRecordFactory({ nom: 'Tartempion', role: 'gestionnaire_structure', ssoId, structureId }),
@@ -740,6 +738,37 @@ function departementRecordFactory(
     code: '75',
     nom: 'Paris',
     regionCode: '11',
+    ...override,
+  }
+}
+
+function structureRecordFactory(
+  override?: Partial<Prisma.StructureRecordUncheckedCreateInput>
+): Prisma.StructureRecordUncheckedCreateInput {
+  return {
+    adresse: {
+      code_postal: '',
+      indice_repetition_voie: '',
+      libelle_commune: '',
+      libelle_voie: '',
+      numero_voie: '',
+      type_voie: '',
+    },
+    contact: {
+      email: '',
+      fonction: '',
+      nom: '',
+      prenom: '',
+      telephone: '',
+    },
+    departementCode: '75',
+    id: 10,
+    idMongo: '123456',
+    identifiantEtablissement: '41816609600069',
+    nom: 'Solidarnum',
+    regionCode: '11',
+    statut: 'VALIDATION_COSELEC',
+    type: 'COMMUNE',
     ...override,
   }
 }

--- a/src/gateways/PostgreUtilisateurLoader.ts
+++ b/src/gateways/PostgreUtilisateurLoader.ts
@@ -69,10 +69,10 @@ export class PostgreUtilisateurLoader implements MesUtilisateursLoader {
 
     const utilisateursRecord = await this.#prisma.utilisateurRecord.findMany({
       include: {
-        relationDepartements: true,
-        relationGroupements: true,
-        relationRegions: true,
-        relationStructures: true,
+        relationDepartement: true,
+        relationGroupement: true,
+        relationRegion: true,
+        relationStructure: true,
       },
       orderBy: {
         nom: 'asc',
@@ -94,10 +94,10 @@ export class PostgreUtilisateurLoader implements MesUtilisateursLoader {
   async findByUid(uid: string): Promise<UnUtilisateurReadModel> {
     const utilisateurRecord = await this.#prisma.utilisateurRecord.findUnique({
       include: {
-        relationDepartements: true,
-        relationGroupements: true,
-        relationRegions: true,
-        relationStructures: true,
+        relationDepartement: true,
+        relationGroupement: true,
+        relationRegion: true,
+        relationStructure: true,
       },
       where: {
         isSupprime: false,

--- a/src/gateways/PostgreUtilisateurRepository.test.ts
+++ b/src/gateways/PostgreUtilisateurRepository.test.ts
@@ -94,19 +94,6 @@ describe('utilisateur repository', () => {
         },
       ])('$desc', async ({ role, roleDataRepresentation, organisation }) => {
         // GIVEN
-        await prisma.structureRecord.create({
-          data: {
-            id: 10,
-            idMongo: '123456',
-            nom: 'Solidarnum',
-          },
-        })
-        await prisma.groupementRecord.create({
-          data: {
-            id: 10,
-            nom: 'Hubikoop',
-          },
-        })
         await prisma.regionRecord.create({
           data: {
             code: '84',
@@ -118,6 +105,39 @@ describe('utilisateur repository', () => {
             code: '69',
             nom: 'Rhône',
             regionCode: '84',
+          },
+        })
+        await prisma.groupementRecord.create({
+          data: {
+            id: 10,
+            nom: 'Hubikoop',
+          },
+        })
+        await prisma.structureRecord.create({
+          data: {
+            adresse: {
+              code_postal: '',
+              indice_repetition_voie: '',
+              libelle_commune: '',
+              libelle_voie: '',
+              numero_voie: '',
+              type_voie: '',
+            },
+            contact: {
+              email: '',
+              fonction: '',
+              nom: '',
+              prenom: '',
+              telephone: '',
+            },
+            departementCode: '69',
+            id: 10,
+            idMongo: '123456',
+            identifiantEtablissement: '41816609600069',
+            nom: 'Solidarnum',
+            regionCode: '84',
+            statut: 'VALIDATION_COSELEC',
+            type: 'COMMUNE',
           },
         })
         await prisma.utilisateurRecord.create({

--- a/src/gateways/PostgreUtilisateurRepository.test.ts
+++ b/src/gateways/PostgreUtilisateurRepository.test.ts
@@ -115,14 +115,9 @@ describe('utilisateur repository', () => {
         })
         await prisma.structureRecord.create({
           data: {
-            adresse: {
-              code_postal: '',
-              indice_repetition_voie: '',
-              libelle_commune: '',
-              libelle_voie: '',
-              numero_voie: '',
-              type_voie: '',
-            },
+            adresse: '',
+            codePostal: '',
+            commune: '',
             contact: {
               email: '',
               fonction: '',
@@ -135,7 +130,6 @@ describe('utilisateur repository', () => {
             idMongo: '123456',
             identifiantEtablissement: '41816609600069',
             nom: 'Solidarnum',
-            regionCode: '84',
             statut: 'VALIDATION_COSELEC',
             type: 'COMMUNE',
           },

--- a/src/gateways/PostgreUtilisateurRepository.ts
+++ b/src/gateways/PostgreUtilisateurRepository.ts
@@ -54,10 +54,10 @@ export class PostgreUtilisateurRepository implements UtilisateurRepository {
   async find(uid: string): Promise<Utilisateur | null> {
     const record = await this.#activeRecord.findUnique({
       include: {
-        relationDepartements: true,
-        relationGroupements: true,
-        relationRegions: true,
-        relationStructures: true,
+        relationDepartement: true,
+        relationGroupement: true,
+        relationRegion: true,
+        relationStructure: true,
       },
       where: {
         isSupprime: false,

--- a/src/gateways/shared/RoleMapper.ts
+++ b/src/gateways/shared/RoleMapper.ts
@@ -11,10 +11,10 @@ import { Groupe, TypologieRole } from '@/domain/Role'
 
 export type UtilisateurEtSesRelationsRecord = UtilisateurRecord &
   Readonly<{
-    relationDepartements: DepartementRecord | null
-    relationGroupements: GroupementRecord | null
-    relationRegions: RegionRecord | null
-    relationStructures: StructureRecord | null
+    relationDepartement: DepartementRecord | null
+    relationGroupement: GroupementRecord | null
+    relationRegion: RegionRecord | null
+    relationStructure: StructureRecord | null
   }>
 
 export type RoleMapping = Readonly<
@@ -31,22 +31,22 @@ export function roleMapper(utilisateurRecord: UtilisateurEtSesRelationsRecord): 
     gestionnaire_departement: {
       groupe: 'gestionnaire',
       nom: 'Gestionnaire département',
-      territoireOuStructure: utilisateurRecord.relationDepartements?.nom ?? '',
+      territoireOuStructure: utilisateurRecord.relationDepartement?.nom ?? '',
     },
     gestionnaire_groupement: {
       groupe: 'gestionnaire',
       nom: 'Gestionnaire groupement',
-      territoireOuStructure: utilisateurRecord.relationGroupements?.nom ?? '',
+      territoireOuStructure: utilisateurRecord.relationGroupement?.nom ?? '',
     },
     gestionnaire_region: {
       groupe: 'gestionnaire',
       nom: 'Gestionnaire région',
-      territoireOuStructure: utilisateurRecord.relationRegions?.nom ?? '',
+      territoireOuStructure: utilisateurRecord.relationRegion?.nom ?? '',
     },
     gestionnaire_structure: {
       groupe: 'gestionnaire',
       nom: 'Gestionnaire structure',
-      territoireOuStructure: utilisateurRecord.relationStructures?.nom ?? '',
+      territoireOuStructure: utilisateurRecord.relationStructure?.nom ?? '',
     },
     instructeur: {
       groupe: 'admin',

--- a/src/presenters/mesInformationsPersonnellesPresenter.ts
+++ b/src/presenters/mesInformationsPersonnellesPresenter.ts
@@ -3,20 +3,18 @@ import { MesInformationsPersonnellesReadModel } from '@/use-cases/queries/Recupe
 export function mesInformationsPersonnellesPresenter(
   mesInformationsPersonnellesReadModel: MesInformationsPersonnellesReadModel
 ): MesInformationsPersonnellesViewModel {
-  const telephone = mesInformationsPersonnellesReadModel.informationsPersonnellesTelephone === '' ?
+  const telephone = mesInformationsPersonnellesReadModel.telephone === '' ?
     'Non renseigné' :
     // Stryker disable next-line Regex
-    mesInformationsPersonnellesReadModel.informationsPersonnellesTelephone.replace(/(\d{2,3})(\d{2})(\d{2})(\d{2})(\d{2})?(\d{2})$/g, '$1 $2 $3 $4 $5 $6')
+    mesInformationsPersonnellesReadModel.telephone.replace(/(\d{2,3})(\d{2})(\d{2})(\d{2})(\d{2})?(\d{2})$/g, '$1 $2 $3 $4 $5 $6')
 
   return {
     ...mesInformationsPersonnellesReadModel,
-    informationsPersonnellesTelephone: telephone,
-    isStructure: mesInformationsPersonnellesReadModel.role === 'Gestionnaire structure' || mesInformationsPersonnellesReadModel.role === 'Gestionnaire groupement',
-    telephoneBrut: mesInformationsPersonnellesReadModel.informationsPersonnellesTelephone,
+    telephone,
+    telephoneBrut: mesInformationsPersonnellesReadModel.telephone,
   }
 }
 
 export type MesInformationsPersonnellesViewModel = MesInformationsPersonnellesReadModel & {
-  isStructure: boolean
   telephoneBrut: string
 }

--- a/src/use-cases/queries/RecupererMesInformationsPersonnelles.ts
+++ b/src/use-cases/queries/RecupererMesInformationsPersonnelles.ts
@@ -3,17 +3,21 @@ export interface MesInformationsPersonnellesLoader {
 }
 
 export type MesInformationsPersonnellesReadModel = Readonly<{
-  contactEmail: string
-  contactFonction: string
-  contactNom: string
-  contactPrenom: string
-  informationsPersonnellesEmail: string
-  informationsPersonnellesNom: string
-  informationsPersonnellesPrenom: string
-  informationsPersonnellesTelephone: string
+  email: string
+  nom: string
+  prenom: string
   role: string
-  structureAdresse: string
-  structureNumeroDeSiret: string
-  structureRaisonSociale: string
-  structureTypeDeStructure: string
+  structure?: Readonly<{
+    adresse: string
+    contact: Readonly<{
+      email: string
+      fonction: string
+      nom: string
+      prenom: string
+    }>
+    numeroDeSiret: string
+    raisonSociale: string
+    typeDeStructure: string
+  }>
+  telephone: string
 }>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2957,6 +2957,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@prisma/debug@npm:5.20.0":
+  version: 5.20.0
+  resolution: "@prisma/debug@npm:5.20.0"
+  checksum: 10c0/820e3e2c25f1a046024383a3a83f28707a99af1e04f46016c78d6b6231a901353755202578ce27760e00a654b357b634a3e79b99bfe710ba6d6a7f480fcdf6b9
+  languageName: node
+  linkType: hard
+
 "@prisma/debug@npm:5.21.1":
   version: 5.21.1
   resolution: "@prisma/debug@npm:5.21.1"
@@ -2991,6 +2998,15 @@ __metadata:
     "@prisma/engines-version": "npm:5.21.1-1.bf0e5e8a04cada8225617067eaa03d041e2bba36"
     "@prisma/get-platform": "npm:5.21.1"
   checksum: 10c0/068663fa15cb204d033b166588157915be11571a1584c914372968248faab0f7c236ec1086aaf194929ece3ae2a3d2d0b28e33dac114a1545e0dee1011dc669c
+  languageName: node
+  linkType: hard
+
+"@prisma/generator-helper@npm:5.20.0":
+  version: 5.20.0
+  resolution: "@prisma/generator-helper@npm:5.20.0"
+  dependencies:
+    "@prisma/debug": "npm:5.20.0"
+  checksum: 10c0/3628b960b0c3dad40b781e9f226d6bf79423fcb4708c408852e265735709346cf037ae42cad5624cae3ea3884e6919098a0dfeba70d8d379b8dd1049a7a59fb0
   languageName: node
   linkType: hard
 
@@ -9618,6 +9634,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prisma-json-types-generator@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "prisma-json-types-generator@npm:3.1.1"
+  dependencies:
+    "@prisma/generator-helper": "npm:5.20.0"
+    tslib: "npm:2.7.0"
+  peerDependencies:
+    prisma: ^5.20
+    typescript: ^5.6.2
+  bin:
+    prisma-json-types-generator: index.js
+  checksum: 10c0/d319343fb0611dbe1da269f3a7ea1b795498fabc948522f04fb2f8ee558c3c27620240dd0d71464337fab450b721c7ebdcd5cd58fca5a1a75edf73d5a8980e6b
+  languageName: node
+  linkType: hard
+
 "prisma@npm:^5.21.1":
   version: 5.21.1
   resolution: "prisma@npm:5.21.1"
@@ -10742,6 +10773,7 @@ __metadata:
     next-auth: "npm:^4.24.10"
     prettier: "npm:^3.3.3"
     prisma: "npm:^5.21.1"
+    prisma-json-types-generator: "npm:^3.1.1"
     react: "npm:^18"
     react-dom: "npm:^18"
     react-select: "npm:^5.8.2"


### PR DESCRIPTION
Les champs migrés sont pour le filtre structure et pour enlever le bouchon qui restait dans mes informations personnelles.

La lib `prisma-json-types-generator` permet de typer les objets JSON.