### PR TITLE
Elimination de mutant dans la recherche de mes utilisateurs

### DIFF
--- a/src/use-cases/queries/RechercherMesUtilisateurs.test.ts
+++ b/src/use-cases/queries/RechercherMesUtilisateurs.test.ts
@@ -21,6 +21,9 @@ describe('rechercher mes utilisateurs', () => {
       pageCourante,
       utilisateursParPage,
       utilisateursActives,
+      [],
+      '0',
+      '0',
     ])
   })
 })
@@ -56,9 +59,20 @@ class MesUtilisateursLoaderSpy implements MesUtilisateursLoader {
     utilisateur: UnUtilisateurReadModel,
     pageCourante: number,
     utilisateursParPage: number,
-    utilisateursActives: boolean
+    utilisateursActives: boolean,
+    roles: ReadonlyArray<string>,
+    codeDepartement: string,
+    codeRegion: string
   ): Promise<UtilisateursCourantsEtTotalReadModel> {
-    this.spiedFindMesUtilisateursEtLeTotalArgs = [utilisateur, pageCourante, utilisateursParPage, utilisateursActives]
+    this.spiedFindMesUtilisateursEtLeTotalArgs = [
+      utilisateur,
+      pageCourante,
+      utilisateursParPage,
+      utilisateursActives,
+      roles,
+      codeDepartement,
+      codeRegion,
+    ]
     return Promise.resolve({
       total: 1,
       utilisateursCourants: [],


### PR DESCRIPTION
Le fait d’implémenter à la main un Spy ne détecte pas quand on ajoute des paramètres à une fonction : le test est vert alors que l’implémentation de l’interface n’est pas bonne et rien ne me le dit sauf les tests de mutation…