### PR TITLE
Simplification de la logique de la pagination pour réduire le nombre de mutant

### DIFF
--- a/src/components/shared/Pagination/Pagination.test.tsx
+++ b/src/components/shared/Pagination/Pagination.test.tsx
@@ -73,6 +73,7 @@ describe('pagination', () => {
 
     // THEN
     const pages = listerLesPages()
+    expect(pages).toHaveLength(7)
 
     const page1 = within(pages[1]).getByRole('link', { name: '1' })
     expect(page1).toHaveAttribute('href', 'http://example.com/mes-utilisateurs?page=0')
@@ -107,6 +108,7 @@ describe('pagination', () => {
 
     // THEN
     const pages = listerLesPages()
+    expect(pages).toHaveLength(7)
 
     const page1 = within(pages[1]).getByRole('link', { name: '2' })
     expect(page1).toHaveAttribute('href', 'http://example.com/mes-utilisateurs?page=1')
@@ -141,6 +143,7 @@ describe('pagination', () => {
 
     // THEN
     const pages = listerLesPages()
+    expect(pages).toHaveLength(7)
 
     const page1 = within(pages[1]).getByRole('link', { name: '2' })
     expect(page1).toHaveAttribute('href', 'http://example.com/mes-utilisateurs?page=1')
@@ -175,6 +178,7 @@ describe('pagination', () => {
 
     // THEN
     const pages = listerLesPages()
+    expect(pages).toHaveLength(7)
 
     const page1 = within(pages[1]).getByRole('link', { name: '318' })
     expect(page1).toHaveAttribute('href', 'http://example.com/mes-utilisateurs?page=317')
@@ -209,6 +213,7 @@ describe('pagination', () => {
 
     // THEN
     const pages = listerLesPages()
+    expect(pages).toHaveLength(7)
 
     const premierePage = within(pages[0]).getByRole('link', { name: 'Première page' })
     expect(premierePage).toHaveAttribute('href', 'http://example.com/mes-utilisateurs?fakeParam=fakeValue')

--- a/src/presenters/paginationPresenter.ts
+++ b/src/presenters/paginationPresenter.ts
@@ -9,34 +9,21 @@ export function pages(
 ): Array<number> {
   const nombreDePages = nombreDePage(nombreDeResultat, utilisateursParPage)
 
-  return new Array(nombreDePages)
-    .fill('')
-    .map((_, index): number => index + 1)
+  return Array
+    .from({ length: nombreDePages }, (_, index) => index + 1)
     .filter((page): boolean => {
-      const debutDePagination = pageCourante < 3
-      const finDePagination = pageCourante > nombreDePages - 4
+      const isDebutDePagination = pageCourante < 3
+      const isFinDePagination = pageCourante > nombreDePages - 4
 
-      if (debutDePagination) {
-        return page === 1
-          || page === 2
-          || page === 3
-          || page === 4
-          || page === 5
+      if (isDebutDePagination) {
+        return page < 6
       }
 
-      if (finDePagination) {
-        return page === nombreDePages - 4
-          || page === nombreDePages - 3
-          || page === nombreDePages - 2
-          || page === nombreDePages - 1
-          || page === nombreDePages
+      if (isFinDePagination) {
+        return page >= nombreDePages - 4
       }
 
-      return pageCourante === page - 1
-        || pageCourante - 1 === page - 1
-        || pageCourante - 2 === page - 1
-        || pageCourante + 1 === page - 1
-        || pageCourante + 2 === page - 1
+      return page >= pageCourante - 1 && page <= pageCourante + 3
     })
 }
 


### PR DESCRIPTION
On passe de 83 mutants à 40 ce qui réduit le temps d'exécution.