### PR TITLE
Inversion de controle des server actions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -125,14 +125,8 @@
           {
             "target": ["src/components"],
             "from": ["src"],
-            "except": [
-              "app/api/actions",
-              "components",
-              "presenters",
-              "shared",
-              "use-cases/testHelper.ts"
-            ],
-            "message": "Le front ne doit pas avoir la connaissance du back (sauf les server actions)."
+            "except": ["components", "presenters", "shared", "use-cases/testHelper.ts"],
+            "message": "Le front ne doit pas avoir la connaissance du back."
           }
         ]
       }

--- a/src/app/api/actions/changerMonRoleAction.test.ts
+++ b/src/app/api/actions/changerMonRoleAction.test.ts
@@ -1,12 +1,11 @@
 import * as nextCache from 'next/cache'
-import { ZodIssue } from 'zod'
 
 import { changerMonRoleAction } from './changerMonRoleAction'
 import * as ssoGateway from '@/gateways/NextAuthAuthentificationGateway'
 import { ChangerMonRole } from '@/use-cases/commands/ChangerMonRole'
 
 describe('changer mon rôle action', () => {
-  it('étant donné un nouveau rôle correct quand mon rôle est changé alors cela modifie mon compte', async () => {
+  it('étant donné un nouveau rôle correct, quand mon rôle est changé, alors cela modifie mon compte', async () => {
     // GIVEN
     const sub = 'd96a66b5-8980-4e5c-88a9-aa0ff334a828'
     const path = '/'
@@ -16,7 +15,7 @@ describe('changer mon rôle action', () => {
     vi.spyOn(ChangerMonRole.prototype, 'execute').mockResolvedValueOnce('OK')
 
     // WHEN
-    const result = await changerMonRoleAction({ nouveauRole, path })
+    const messages = await changerMonRoleAction({ nouveauRole, path })
 
     // THEN
     expect(ChangerMonRole.prototype.execute).toHaveBeenCalledWith({
@@ -24,30 +23,29 @@ describe('changer mon rôle action', () => {
       utilisateurUid: sub,
     })
     expect(nextCache.revalidatePath).toHaveBeenCalledWith(path)
-    expect(result).toBe('OK')
+    expect(messages).toStrictEqual(['OK'])
   })
 
-  it('étant donné un nouveau rôle incorrect quand mon rôle est changé alors cela renvoie une erreur', async () => {
+  it('étant donné un nouveau rôle incorrect, quand mon rôle est changé, alors cela renvoie une erreur', async () => {
     // GIVEN
     const nouveauRoleIncorrect = 'fake-role'
 
     // WHEN
-    const result = await changerMonRoleAction({ nouveauRole: nouveauRoleIncorrect, path: '/' })
+    const messages = await changerMonRoleAction({ nouveauRole: nouveauRoleIncorrect, path: '/' })
 
     // THEN
-    expect((result as ReadonlyArray<ZodIssue>)[0].message).toBe('Le rôle n’est pas correct')
+    expect(messages).toStrictEqual(['Le rôle n’est pas correct'])
   })
 
   it('étant donné un path incorrect quand mon rôle est changé alors cela renvoie une erreur', async () => {
     // GIVEN
     const nouveauRole = 'Instructeur'
-    const pathIncorrect = ''
+    const pathIncorrect = ''as __next_route_internal_types__.StaticRoutes
 
     // WHEN
-    // @ts-expect-error
-    const result = await changerMonRoleAction({ nouveauRole, path: pathIncorrect })
+    const messages = await changerMonRoleAction({ nouveauRole, path: pathIncorrect })
 
     // THEN
-    expect((result as ReadonlyArray<ZodIssue>)[0].message).toBe('Le chemin n’est pas correct')
+    expect(messages).toStrictEqual(['Le chemin n’est pas correct'])
   })
 })

--- a/src/app/api/actions/inviterUnUtilisateurAction.test.ts
+++ b/src/app/api/actions/inviterUnUtilisateurAction.test.ts
@@ -1,6 +1,5 @@
 import * as nextCache from 'next/cache'
 import nodemailer from 'nodemailer'
-import { ZodIssue } from 'zod'
 
 import { inviterUnUtilisateurAction } from './inviterUnUtilisateurAction'
 import { utilisateurFactory } from '@/domain/testHelper'
@@ -88,12 +87,12 @@ describe('inviter un utilisateur action', () => {
       vi.spyOn(nextCache, 'revalidatePath').mockImplementationOnce(vi.fn())
 
       // WHEN
-      const result = await inviterUnUtilisateurAction(actionParams)
+      const messages = await inviterUnUtilisateurAction(actionParams)
 
       // THEN
       expect(nextCache.revalidatePath).toHaveBeenCalledWith('/mes-utilisateurs')
       expect(InviterUnUtilisateur.prototype.execute).toHaveBeenCalledWith(expectedCommand)
-      expect(result).toBe('OK')
+      expect(messages).toStrictEqual(['OK'])
     })
   })
 
@@ -112,10 +111,10 @@ describe('inviter un utilisateur action', () => {
     }
 
     // WHEN
-    const result = await inviterUnUtilisateurAction(inviterUnUtilisateurParams)
+    const messages = await inviterUnUtilisateurAction(inviterUnUtilisateurParams)
 
     // THEN
-    expect(result).toBe('emailExistant')
+    expect(messages).toStrictEqual(['emailExistant'])
   })
 
   describe('étant donné une invitation avec des données invalides, quand on invite un utilisateur alors cela renvoie une erreur', () => {
@@ -168,10 +167,10 @@ describe('inviter un utilisateur action', () => {
       }
 
       // WHEN
-      const result = await inviterUnUtilisateurAction(inviterUnUtilisateurParams)
+      const messages = await inviterUnUtilisateurAction(inviterUnUtilisateurParams)
 
       // THEN
-      expect((result as ReadonlyArray<ZodIssue>)[0].message).toBe(expectedError)
+      expect(messages).toStrictEqual([expectedError])
     })
   })
 

--- a/src/app/api/actions/inviterUnUtilisateurAction.ts
+++ b/src/app/api/actions/inviterUnUtilisateurAction.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
-import { z, ZodIssue } from 'zod'
+import { z } from 'zod'
 
 import { emailInvitationGatewayFactory } from './shared/emailInvitationGatewayFactory'
 import prisma from '../../../../prisma/prismaClient'
@@ -12,16 +12,15 @@ import { ResultAsync } from '@/use-cases/CommandHandler'
 import {
   InviterUnUtilisateurCommand,
   InviterUnUtilisateur,
-  InviterUnUtilisateurFailure,
 } from '@/use-cases/commands/InviterUnUtilisateur'
 
 export async function inviterUnUtilisateurAction(
   actionParams: ActionParams
-): ResultAsync<InviterUnUtilisateurFailure | ReadonlyArray<ZodIssue>> {
+): ResultAsync<ReadonlyArray<string>> {
   const validationResult = validator.safeParse(actionParams)
 
   if (validationResult.error) {
-    return validationResult.error.issues
+    return validationResult.error.issues.map(({ message }) => message)
   }
 
   let command: InviterUnUtilisateurCommand = {
@@ -49,7 +48,7 @@ export async function inviterUnUtilisateurAction(
     revalidatePath('/mes-utilisateurs')
   }
 
-  return result
+  return [result]
 }
 
 type ActionParams = Readonly<{

--- a/src/app/api/actions/modifierMesInformationsPersonnellesAction.test.ts
+++ b/src/app/api/actions/modifierMesInformationsPersonnellesAction.test.ts
@@ -1,12 +1,11 @@
 import * as nextCache from 'next/cache'
-import { ZodIssue } from 'zod'
 
 import { modifierMesInformationsPersonnellesAction } from './modifierMesInformationsPersonnellesAction'
 import * as ssoGateway from '@/gateways/NextAuthAuthentificationGateway'
 import { ModifierMesInformationsPersonnelles } from '@/use-cases/commands/ModifierMesInformationsPersonnelles'
 
 describe('modifier mes informations personnelles action', () => {
-  it('si les informations personnelles sont correctes alors c’est valide', async () => {
+  it('si les informations personnelles sont correctes, alors c’est valide', async () => {
     // GIVEN
     const path = '/mes-informations-personnelles'
     const sub = 'fooId'
@@ -15,7 +14,7 @@ describe('modifier mes informations personnelles action', () => {
     vi.spyOn(ModifierMesInformationsPersonnelles.prototype, 'execute').mockResolvedValueOnce('OK')
 
     // WHEN
-    const result = await modifierMesInformationsPersonnellesAction({ email, nom, path, prenom, telephone })
+    const messages = await modifierMesInformationsPersonnellesAction({ email, nom, path, prenom, telephone })
 
     // THEN
     expect(ModifierMesInformationsPersonnelles.prototype.execute).toHaveBeenCalledWith({
@@ -28,15 +27,15 @@ describe('modifier mes informations personnelles action', () => {
       uid: sub,
     })
     expect(nextCache.revalidatePath).toHaveBeenCalledWith(path)
-    expect(result).toBe('OK')
+    expect(messages).toStrictEqual(['OK'])
   })
 
-  it('si l’e-mail est mal formaté alors s’affiche un message d’erreur', async () => {
+  it('si l’e-mail est mal formaté alors, s’affiche un message d’erreur', async () => {
     // WHEN
-    const result = await modifierMesInformationsPersonnellesAction({ email: 'emailNonValide', nom, path, prenom, telephone })
+    const messages = await modifierMesInformationsPersonnellesAction({ email: 'emailNonValide', nom, path, prenom, telephone })
 
     // THEN
-    expect((result as ReadonlyArray<ZodIssue>)[0].message).toBe('L’email doit être valide')
+    expect(messages).toStrictEqual(['L’email doit être valide'])
   })
 
   it('si le nom est vide alors s’affiche un message d’erreur car il doit contenir au moins un caractère', async () => {
@@ -44,10 +43,10 @@ describe('modifier mes informations personnelles action', () => {
     const nomVide = ''
 
     // WHEN
-    const result = await modifierMesInformationsPersonnellesAction({ email, nom: nomVide, path, prenom, telephone })
+    const messages = await modifierMesInformationsPersonnellesAction({ email, nom: nomVide, path, prenom, telephone })
 
     // THEN
-    expect((result as ReadonlyArray<ZodIssue>)[0].message).toBe('Le nom doit contenir au moins 1 caractère')
+    expect(messages).toStrictEqual(['Le nom doit contenir au moins 1 caractère'])
   })
 
   it('si le prénom est vide alors s’affiche un message d’erreur car il doit contenir au moins un caractère', async () => {
@@ -55,10 +54,16 @@ describe('modifier mes informations personnelles action', () => {
     const prenomVide = ''
 
     // WHEN
-    const result = await modifierMesInformationsPersonnellesAction({ email, nom, path, prenom: prenomVide, telephone })
+    const messages = await modifierMesInformationsPersonnellesAction({
+      email,
+      nom,
+      path,
+      prenom: prenomVide,
+      telephone,
+    })
 
     // THEN
-    expect((result as ReadonlyArray<ZodIssue>)[0].message).toBe('Le prénom doit contenir au moins 1 caractère')
+    expect(messages).toStrictEqual(['Le prénom doit contenir au moins 1 caractère'])
   })
 
   it('si le path est vide alors cela renvoie une erreur car il doit contenir au moins un caractère', async () => {
@@ -66,7 +71,7 @@ describe('modifier mes informations personnelles action', () => {
     const pathIncorrect = ''
 
     // WHEN
-    const result = await modifierMesInformationsPersonnellesAction({
+    const messages = await modifierMesInformationsPersonnellesAction({
       email,
       nom,
       // @ts-expect-error
@@ -76,7 +81,7 @@ describe('modifier mes informations personnelles action', () => {
     })
 
     // THEN
-    expect((result as ReadonlyArray<ZodIssue>)[0].message).toBe('Le chemin n’est pas correct')
+    expect(messages).toStrictEqual(['Le chemin n’est pas correct'])
   })
 
   it.each([
@@ -84,9 +89,9 @@ describe('modifier mes informations personnelles action', () => {
     '+1234',
     '+1234567890123478',
     '1234567890123478',
-  ])('si le téléphone est mal formaté alors s’affiche un message d’erreur', async (telephoneMalFormate) => {
+  ])('si le téléphone est mal formaté, alors s’affiche un message d’erreur', async (telephoneMalFormate) => {
     // WHEN
-    const result = await modifierMesInformationsPersonnellesAction({
+    const messages = await modifierMesInformationsPersonnellesAction({
       email,
       nom,
       path,
@@ -95,10 +100,10 @@ describe('modifier mes informations personnelles action', () => {
     })
 
     // THEN
-    expect((result as ReadonlyArray<ZodIssue>)[0].message).toBe('Le téléphone doit être au format 0102030405 ou +33102030405')
+    expect(messages).toStrictEqual(['Le téléphone doit être au format 0102030405 ou +33102030405'])
   })
 
-  it('si le téléphone est vide alors c’est valide car il n’est pas obligatoire', async () => {
+  it('si le téléphone est vide, alors c’est valide car il n’est pas obligatoire', async () => {
     // GIVEN
     const sub = 'fooId'
     const telephoneVide = ''
@@ -107,7 +112,7 @@ describe('modifier mes informations personnelles action', () => {
     vi.spyOn(ModifierMesInformationsPersonnelles.prototype, 'execute').mockResolvedValueOnce('OK')
 
     // WHEN
-    const result = await modifierMesInformationsPersonnellesAction({
+    const messages = await modifierMesInformationsPersonnellesAction({
       email,
       nom,
       path,
@@ -116,7 +121,7 @@ describe('modifier mes informations personnelles action', () => {
     })
 
     // THEN
-    expect(result).toBe('OK')
+    expect(messages).toStrictEqual(['OK'])
   })
 
   const email = 'martin.tartempion@example.com'

--- a/src/app/api/actions/reinviterUnUtilisateurAction.test.ts
+++ b/src/app/api/actions/reinviterUnUtilisateurAction.test.ts
@@ -1,5 +1,4 @@
 import * as nextCache from 'next/cache'
-import { ZodIssue } from 'zod'
 
 import { reinviterUnUtilisateurAction } from './reinviterUnUtilisateurAction'
 import * as ssoGateway from '@/gateways/NextAuthAuthentificationGateway'
@@ -15,7 +14,7 @@ describe('reinviter un utilisateur action', () => {
     vi.spyOn(nextCache, 'revalidatePath').mockImplementationOnce(vi.fn())
 
     // WHEN
-    const result = await reinviterUnUtilisateurAction({
+    const messages = await reinviterUnUtilisateurAction({
       path,
       uidUtilisateurAReinviter: 'uidUtilisateurAReinviter',
     })
@@ -26,17 +25,17 @@ describe('reinviter un utilisateur action', () => {
       uidUtilisateurAReinviter: 'uidUtilisateurAReinviter',
       uidUtilisateurCourant: 'uidUtilisateurCourant',
     })
-    expect(result).toBe('OK')
+    expect(messages).toStrictEqual(['OK'])
   })
 
   it('étant donné que l’uid utilisateur a réinviter est invalide quand la réinvitation est demandée alors cela renvoie un message d’erreur', async () => {
     // WHEN
-    const result = await reinviterUnUtilisateurAction({
+    const messages = await reinviterUnUtilisateurAction({
       path: '/',
       uidUtilisateurAReinviter: '',
     })
 
     // THEN
-    expect((result[0] as ZodIssue).message).toBe('L’identifiant de l’utilisateur à réinviter doit être renseigné')
+    expect(messages).toStrictEqual(['L’identifiant de l’utilisateur à réinviter doit être renseigné'])
   })
 })

--- a/src/app/api/actions/supprimerMonCompteAction.test.ts
+++ b/src/app/api/actions/supprimerMonCompteAction.test.ts
@@ -3,16 +3,17 @@ import * as ssoGateway from '@/gateways/NextAuthAuthentificationGateway'
 import { SupprimerMonCompte } from '@/use-cases/commands/SupprimerMonCompte'
 
 describe('supprimer mon compte action', () => {
-  it('quand mon compte est supprimé alors cela modifie mon compte', async () => {
+  it('quand mon compte est supprimé, alors cela modifie mon compte', async () => {
     // GIVEN
     const sub = 'fooId'
     vi.spyOn(ssoGateway, 'getSubSession').mockResolvedValueOnce(sub)
     vi.spyOn(SupprimerMonCompte.prototype, 'execute').mockResolvedValueOnce('OK')
 
     // WHEN
-    await supprimerMonCompteAction()
+    const messages = await supprimerMonCompteAction()
 
     // THEN
     expect(SupprimerMonCompte.prototype.execute).toHaveBeenCalledWith({ utilisateurUid: sub })
+    expect(messages).toStrictEqual(['OK'])
   })
 })

--- a/src/app/api/actions/supprimerMonCompteAction.ts
+++ b/src/app/api/actions/supprimerMonCompteAction.ts
@@ -4,9 +4,11 @@ import prisma from '../../../../prisma/prismaClient'
 import { getSubSession } from '@/gateways/NextAuthAuthentificationGateway'
 import { PrismaUtilisateurRepository } from '@/gateways/PrismaUtilisateurRepository'
 import { ResultAsync } from '@/use-cases/CommandHandler'
-import { SuppressionCompteFailure, SupprimerMonCompte } from '@/use-cases/commands/SupprimerMonCompte'
+import { SupprimerMonCompte } from '@/use-cases/commands/SupprimerMonCompte'
 
-export async function supprimerMonCompteAction(): ResultAsync<SuppressionCompteFailure> {
-  return new SupprimerMonCompte(new PrismaUtilisateurRepository(prisma))
+export async function supprimerMonCompteAction(): ResultAsync<ReadonlyArray<string>> {
+  const message = await new SupprimerMonCompte(new PrismaUtilisateurRepository(prisma))
     .execute({ utilisateurUid: await getSubSession() })
+
+  return [message]
 }

--- a/src/app/api/actions/supprimerUnUtilisateurAction.test.ts
+++ b/src/app/api/actions/supprimerUnUtilisateurAction.test.ts
@@ -1,5 +1,4 @@
 import * as nextCache from 'next/cache'
-import { ZodIssue } from 'zod'
 
 import { supprimerUnUtilisateurAction } from './supprimerUnUtilisateurAction'
 import * as ssoGateway from '@/gateways/NextAuthAuthentificationGateway'
@@ -16,7 +15,7 @@ describe('supprimer un utilisateur action', () => {
     vi.spyOn(SupprimerUnUtilisateur.prototype, 'execute').mockResolvedValueOnce('OK')
 
     // WHEN
-    const result = await supprimerUnUtilisateurAction({ path, utilisateurASupprimerUid })
+    const messages = await supprimerUnUtilisateurAction({ path, utilisateurASupprimerUid })
 
     // THEN
     expect(SupprimerUnUtilisateur.prototype.execute).toHaveBeenCalledWith({
@@ -24,19 +23,18 @@ describe('supprimer un utilisateur action', () => {
       utilisateurCourantUid: sub,
     })
     expect(nextCache.revalidatePath).toHaveBeenCalledWith(path)
-    expect(result).toBe('OK')
+    expect(messages).toStrictEqual(['OK'])
   })
 
   it('étant donné un path incorrect, quand la suppression d’un utilisateur est passée, alors cela renvoie une erreur', async () => {
     // GIVEN
     const utilisateurASupprimerUid = 'barId'
-    const pathIncorrect = ''
+    const pathIncorrect = '' as __next_route_internal_types__.StaticRoutes
 
     // WHEN
-    // @ts-expect-error
-    const result = await supprimerUnUtilisateurAction({ path: pathIncorrect, utilisateurASupprimerUid })
+    const messages = await supprimerUnUtilisateurAction({ path: pathIncorrect, utilisateurASupprimerUid })
 
     // THEN
-    expect((result as ReadonlyArray<ZodIssue>)[0].message).toBe('Le chemin n’est pas correct')
+    expect(messages).toStrictEqual(['Le chemin n’est pas correct'])
   })
 })

--- a/src/components/MesInformationsPersonnelles/ModifierMonCompte.tsx
+++ b/src/components/MesInformationsPersonnelles/ModifierMonCompte.tsx
@@ -2,7 +2,6 @@
 
 import { Dispatch, FormEvent, ReactElement, RefObject, SetStateAction, useContext, useId, useState } from 'react'
 
-import { modifierMesInformationsPersonnellesAction } from '../../app/api/actions/modifierMesInformationsPersonnellesAction'
 import { clientContext } from '../shared/ClientContext'
 import TextInput from '../shared/TextInput/TextInput'
 import { emailPattern, telephonePattern } from '@/shared/patterns'
@@ -17,7 +16,7 @@ export default function ModifierMonCompte({
   setIsOpen,
   telephone,
 }: ModifierMonCompteProps): ReactElement {
-  const { pathname } = useContext(clientContext)
+  const { modifierMesInformationsPersonnellesAction, pathname } = useContext(clientContext)
   const [etatBoutonEnregistrer, setEtatBoutonEnregistrer] = useState({
     enAttente: false,
     texte: 'Enregistrer',

--- a/src/components/MesInformationsPersonnelles/SupprimerMonCompte.tsx
+++ b/src/components/MesInformationsPersonnelles/SupprimerMonCompte.tsx
@@ -1,12 +1,13 @@
 import { signOut } from 'next-auth/react'
-import { Dispatch, FormEvent, ReactElement, SetStateAction, useId, useState } from 'react'
+import { Dispatch, FormEvent, ReactElement, SetStateAction, useContext, useId, useState } from 'react'
 
 import styles from './SupprimerMonCompte.module.css'
-import { supprimerMonCompteAction } from '../../app/api/actions/supprimerMonCompteAction'
+import { clientContext } from '../shared/ClientContext'
 import Modal from '../shared/Modal/Modal'
 import { emailPattern } from '@/shared/patterns'
 
 export default function SupprimerMonCompte({ id, email, isOpen, setIsOpen }: SupprimerMonCompteProps): ReactElement {
+  const { supprimerMonCompteAction } = useContext(clientContext)
   const [emailValidationInfo, setEmailValidationInfo] =
     useState<EmailValidationInfo>(emailValidationInfoByState.invalid)
   const [etatBoutonSuppression, setEtatBoutonSuppression] = useState<EtatBoutonSuppression>({

--- a/src/components/MesUtilisateurs/InviterUnUtilisateur.tsx
+++ b/src/components/MesUtilisateurs/InviterUnUtilisateur.tsx
@@ -6,7 +6,6 @@ import OrganisationInput from './OrganisationInput'
 import departements from '../../../ressources/departements.json'
 import groupements from '../../../ressources/groupements.json'
 import regions from '../../../ressources/regions.json'
-import { inviterUnUtilisateurAction } from '../../app/api/actions/inviterUnUtilisateurAction'
 import Badge from '../shared/Badge/Badge'
 import { clientContext } from '../shared/ClientContext'
 import { Notification } from '../shared/Notification/Notification'
@@ -40,7 +39,7 @@ export default function InviterUnUtilisateur({
   dialogRef,
 }: InviterUnUtilisateurProps): ReactElement {
   const [emailDejaExistant, setEmailDejaExistant] = useState('')
-  const { sessionUtilisateurViewModel } = useContext(clientContext)
+  const { inviterUnUtilisateurAction, sessionUtilisateurViewModel } = useContext(clientContext)
   const [roleSelectionne, setRoleSelectionne] = useState('')
   const [organisation, setOrganisation] = useState<string>('')
   const nomId = useId()
@@ -169,11 +168,11 @@ export default function InviterUnUtilisateur({
 
     const form = new FormData(event.currentTarget)
     const [nom, prenom, email, role, codeOrganisation] = [...form.values()].map((value) => value as string)
-    const result = await inviterUnUtilisateurAction({ codeOrganisation, email, nom, prenom, role })
-    if (result === 'emailExistant') {
+    const messages = await inviterUnUtilisateurAction({ codeOrganisation, email, nom, prenom, role })
+    if (messages[0] === 'emailExistant') {
       setEmailDejaExistant('Cet utilisateur dispose déjà d’un compte')
     } else {
-      if (result === 'OK') {
+      if (messages[0] === 'OK') {
         Notification('success', { description: email, title: 'Invitation envoyée à ' })
         setEmailDejaExistant('')
       }

--- a/src/components/MesUtilisateurs/ReinviterUnUtilisateur.tsx
+++ b/src/components/MesUtilisateurs/ReinviterUnUtilisateur.tsx
@@ -2,7 +2,6 @@ import { Dispatch, ReactElement, RefObject, SetStateAction, useContext } from 'r
 
 import { clientContext } from '../shared/ClientContext'
 import { Notification } from '../shared/Notification/Notification'
-import { reinviterUnUtilisateurAction } from '@/app/api/actions/reinviterUnUtilisateurAction'
 
 export default function ReinviterUnUtilisateur({
   utilisateur,
@@ -11,7 +10,7 @@ export default function ReinviterUnUtilisateur({
   setIsOpen,
   dialogRef,
 }: DetailsUtilisateurProps): ReactElement {
-  const { pathname } = useContext(clientContext)
+  const { pathname, reinviterUnUtilisateurAction } = useContext(clientContext)
 
   return (
     <div>

--- a/src/components/MesUtilisateurs/SupprimerUnUtilisateur.tsx
+++ b/src/components/MesUtilisateurs/SupprimerUnUtilisateur.tsx
@@ -2,7 +2,6 @@ import { Dispatch, ReactElement, SetStateAction, useContext, useId } from 'react
 
 import { clientContext } from '../shared/ClientContext'
 import Modal from '../shared/Modal/Modal'
-import { supprimerUnUtilisateurAction } from '@/app/api/actions/supprimerUnUtilisateurAction'
 
 export default function SupprimerUnUtilisateur({
   id,
@@ -10,7 +9,7 @@ export default function SupprimerUnUtilisateur({
   utilisateurASupprimer,
   setIsOpen,
 }: SupprimerUnUtilisateurProps): ReactElement {
-  const { pathname } = useContext(clientContext)
+  const { pathname, supprimerUnUtilisateurAction } = useContext(clientContext)
   const modaleTitreId = useId()
 
   return (

--- a/src/components/shared/ClientContext.tsx
+++ b/src/components/shared/ClientContext.tsx
@@ -1,10 +1,17 @@
 // Stryker disable all
+/* eslint-disable import/no-restricted-paths */
 'use client'
 
 import { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { createContext, ReactElement, PropsWithChildren, useMemo } from 'react'
 
+import { changerMonRoleAction } from '@/app/api/actions/changerMonRoleAction'
+import { inviterUnUtilisateurAction } from '@/app/api/actions/inviterUnUtilisateurAction'
+import { modifierMesInformationsPersonnellesAction } from '@/app/api/actions/modifierMesInformationsPersonnellesAction'
+import { reinviterUnUtilisateurAction } from '@/app/api/actions/reinviterUnUtilisateurAction'
+import { supprimerMonCompteAction } from '@/app/api/actions/supprimerMonCompteAction'
+import { supprimerUnUtilisateurAction } from '@/app/api/actions/supprimerUnUtilisateurAction'
 import { SessionUtilisateurViewModel } from '@/presenters/sessionUtilisateurPresenter'
 
 export default function ClientContext({
@@ -19,11 +26,17 @@ export default function ClientContext({
 
   const clientContextProviderValue = useMemo(
     () => ({
+      changerMonRoleAction,
+      inviterUnUtilisateurAction,
+      modifierMesInformationsPersonnellesAction,
       pathname,
+      reinviterUnUtilisateurAction,
       roles,
       router,
       searchParams,
       sessionUtilisateurViewModel,
+      supprimerMonCompteAction,
+      supprimerUnUtilisateurAction,
       utilisateursParPage,
     }),
     [pathname, roles, router, searchParams, sessionUtilisateurViewModel, utilisateursParPage]
@@ -39,11 +52,17 @@ export default function ClientContext({
 export const clientContext = createContext<ClientContextProviderValue>({} as ClientContextProviderValue)
 
 export type ClientContextProviderValue = Readonly<{
-  pathname: __next_route_internal_types__.StaticRoutes,
+  changerMonRoleAction: typeof changerMonRoleAction
+  inviterUnUtilisateurAction: typeof inviterUnUtilisateurAction,
+  modifierMesInformationsPersonnellesAction: typeof modifierMesInformationsPersonnellesAction
+  pathname: __next_route_internal_types__.StaticRoutes
+  reinviterUnUtilisateurAction: typeof reinviterUnUtilisateurAction,
   roles: ReadonlyArray<string>
   router: AppRouterInstance
   searchParams: URLSearchParams
   sessionUtilisateurViewModel: SessionUtilisateurViewModel
+  supprimerMonCompteAction: typeof supprimerMonCompteAction
+  supprimerUnUtilisateurAction: typeof supprimerUnUtilisateurAction
   utilisateursParPage: number
 }>
 

--- a/src/components/testHelper.tsx
+++ b/src/components/testHelper.tsx
@@ -18,8 +18,11 @@ export function renderComponent(
   clientContextProviderValueOverride?: Partial<ClientContextProviderValue>
 ): RenderResult {
   const clientContextProviderDefaultValue = {
-    bandeauInformations: {},
+    changerMonRoleAction: vi.fn(),
+    inviterUnUtilisateurAction: vi.fn(),
+    modifierMesInformationsPersonnellesAction: vi.fn(),
     pathname: '/' as __next_route_internal_types__.StaticRoutes,
+    reinviterUnUtilisateurAction: vi.fn(),
     roles: Roles,
     router: {
       back: vi.fn(),
@@ -31,7 +34,8 @@ export function renderComponent(
     },
     searchParams: new URLSearchParams(),
     sessionUtilisateurViewModel: sessionUtilisateurViewModelFactory(),
-    setBandeauInformations: vi.fn(),
+    supprimerMonCompteAction: vi.fn(),
+    supprimerUnUtilisateurAction: vi.fn(),
     utilisateursParPage: 10,
   }
 

--- a/src/components/transverse/EnTete/EnTete.test.tsx
+++ b/src/components/transverse/EnTete/EnTete.test.tsx
@@ -2,7 +2,6 @@ import { fireEvent, screen, waitFor, within } from '@testing-library/react'
 import * as nextAuth from 'next-auth/react'
 
 import EnTete from './EnTete'
-import * as changerAction from '@/app/api/actions/changerMonRoleAction'
 import { renderComponent } from '@/components/testHelper'
 
 describe('en-tête : en tant qu’utilisateur authentifié', () => {
@@ -105,8 +104,8 @@ describe('en-tête : en tant qu’utilisateur authentifié', () => {
 
     it('quand je change de rôle dans le sélecteur de rôle alors mon rôle change et la page courante est rafraîchie', async () => {
       // GIVEN
-      vi.spyOn(changerAction, 'changerMonRoleAction').mockResolvedValueOnce('OK')
-      const menuUtilisateur = ouvrirLeMenuUtilisateur()
+      const changerMonRoleAction = vi.fn(async () => Promise.resolve(['OK']))
+      const menuUtilisateur = ouvrirLeMenuUtilisateur(changerMonRoleAction)
       const role = within(menuUtilisateur).getByRole('combobox', { name: 'Rôle' })
 
       // WHEN
@@ -114,22 +113,22 @@ describe('en-tête : en tant qu’utilisateur authentifié', () => {
 
       // THEN
       await waitFor(() => {
-        expect(changerAction.changerMonRoleAction).toHaveBeenCalledWith({ nouveauRole: 'Instructeur', path: '/' })
+        expect(changerMonRoleAction).toHaveBeenCalledWith({ nouveauRole: 'Instructeur', path: '/' })
       })
     })
   })
 })
 
-function monCompte(): HTMLElement {
-  renderComponent(<EnTete />)
+function monCompte(spiedChangerMonRoleAction = async (): Promise<Array<string>> => Promise.resolve(['OK'])): HTMLElement {
+  renderComponent(<EnTete />, { changerMonRoleAction: spiedChangerMonRoleAction })
 
   const menu = screen.getByRole('list', { name: 'menu' })
   const menuItems = within(menu).getAllByRole('listitem')
   return within(menuItems[3]).getByRole('button', { name: 'Martin Tartempion' })
 }
 
-function ouvrirLeMenuUtilisateur(): HTMLElement {
-  fireEvent.click(monCompte())
+function ouvrirLeMenuUtilisateur(spiedChangerMonRoleAction = async (): Promise<Array<string>> => Promise.resolve(['OK'])): HTMLElement {
+  fireEvent.click(monCompte(spiedChangerMonRoleAction))
 
   return screen.getByRole('dialog')
 }

--- a/src/components/transverse/EnTete/MenuUtilisateur/SelecteurRole/SelecteurRole.tsx
+++ b/src/components/transverse/EnTete/MenuUtilisateur/SelecteurRole/SelecteurRole.tsx
@@ -2,11 +2,10 @@
 
 import { FormEvent, ReactElement, useContext } from 'react'
 
-import { changerMonRoleAction } from '../../../../../app/api/actions/changerMonRoleAction'
 import { clientContext } from '@/components/shared/ClientContext'
 
 export default function SelecteurRole({ ariaControlsId }: SelecteurRoleProps): ReactElement {
-  const { pathname, roles, sessionUtilisateurViewModel } = useContext(clientContext)
+  const { changerMonRoleAction, pathname, roles, sessionUtilisateurViewModel } = useContext(clientContext)
 
   return (
     <div className="fr-select-group">


### PR DESCRIPTION
Proposition d'inversion de controler des server actions.
L'idée m'est venu grâce à la [documentation](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations#passing-actions-as-props).
Cela permet de :
- retirer des spyOn et donc simplifier l'écriture de test
- notre context devient de plus en plus notre injecteur de dépendance
- réduire le couplage entre les controllers et les components
- surement améliorer le temps des mutations testing