### PR TITLE
style(méthodes): signatures sous forme de fonction, non de propriété

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -161,6 +161,7 @@
     "@typescript-eslint/consistent-type-imports": "off",
     "@typescript-eslint/explicit-member-accessibility": "off",
     "@typescript-eslint/init-declarations": "off",
+    "@typescript-eslint/method-signature-style": ["error", "method"],
     "@typescript-eslint/naming-convention": "off",
     "@typescript-eslint/max-params": "off",
     "@typescript-eslint/no-magic-numbers": "off",

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -36,5 +36,5 @@ export default function GlobalError({ error, reset }: ErrorProps): ReactElement 
 
 type ErrorProps = Readonly<{
   error: Error & { digest?: string }
-  reset: () => void
+  reset(): void
 }>

--- a/src/components/MesUtilisateurs/FiltrerParZonesGeographiques.tsx
+++ b/src/components/MesUtilisateurs/FiltrerParZonesGeographiques.tsx
@@ -91,5 +91,5 @@ function DropdownIndicator(): ReactElement {
 }
 
 type FiltrerParZonesGeographiquesProps = Readonly<{
-  setZoneGeographique: (zoneGeographique: ZoneGeographique) => void
+  setZoneGeographique(zoneGeographique: ZoneGeographique): void
 }>

--- a/src/components/MesUtilisateurs/OrganisationInput.tsx
+++ b/src/components/MesUtilisateurs/OrganisationInput.tsx
@@ -82,9 +82,9 @@ type OrganisationInputProps = Readonly<{
   label: string
   options: ReadonlyArray<{value: string, label: string}>
   organisation: string
-  setOrganisation: (organisation: string) => void
   required: boolean
   additionalSearchParams?: URLSearchParams
+  setOrganisation(organisation: string): void
 }>
 
 // istanbul ignore next @preserve

--- a/src/components/shared/Modal/Modal.tsx
+++ b/src/components/shared/Modal/Modal.tsx
@@ -41,6 +41,6 @@ export default function Modal({
 type ModalProps = PropsWithChildren<Readonly<{
   id: string,
   isOpen: boolean
-  close: () => void
   labelId: string
+  close(): void
 }>>

--- a/src/use-cases/CommandHandler.ts
+++ b/src/use-cases/CommandHandler.ts
@@ -1,7 +1,7 @@
 import { Result, ResultOk, Struct } from '@/shared/lang'
 
 export interface CommandHandler<Command extends Struct, Failure = string, Success = ResultOk> {
-  execute: (command: Command) => ResultAsync<Failure, Success>
+  execute(command: Command): ResultAsync<Failure, Success>
 }
 
 export type ResultAsync<Failure, Success = ResultOk> = Promise<Result<Failure, Success>>

--- a/src/use-cases/QueryHandler.ts
+++ b/src/use-cases/QueryHandler.ts
@@ -1,5 +1,5 @@
 import { Struct } from '@/shared/lang'
 
 export interface QueryHandler<Query extends Struct, ReadModel> {
-  get: (query: Query) => Promise<ReadModel>
+  get(query: Query): Promise<ReadModel>
 }

--- a/src/use-cases/commands/shared/EmailGateway.ts
+++ b/src/use-cases/commands/shared/EmailGateway.ts
@@ -1,5 +1,5 @@
 export interface EmailGateway {
-  send: (destinataire: string) => Promise<void>
+  send(destinataire: string): Promise<void>
 }
 
 export type EmailGatewayFactory = (isSuperAdmin: boolean) => EmailGateway

--- a/src/use-cases/commands/shared/UtilisateurRepository.ts
+++ b/src/use-cases/commands/shared/UtilisateurRepository.ts
@@ -1,27 +1,27 @@
 import { Utilisateur, UtilisateurUidState } from '@/domain/Utilisateur'
 
 export interface FindUtilisateurRepository {
-  find: (uid: UtilisateurUidState['value']) => Promise<Utilisateur | null>
+  find(uid: UtilisateurUidState['value']): Promise<Utilisateur | null>
 }
 
 export interface DropUtilisateurRepository {
-  drop: (utilisateur: Utilisateur) => Promise<boolean>
+  drop(utilisateur: Utilisateur): Promise<boolean>
 }
 
 export interface DropUtilisateurByUidRepository {
-  dropByUid: (uid: UtilisateurUidState['value']) => Promise<boolean>
+  dropByUid(uid: UtilisateurUidState['value']): Promise<boolean>
 }
 
 export interface UpdateUtilisateurRepository {
-  update: (utilisateur: Utilisateur) => Promise<void>
+  update(utilisateur: Utilisateur): Promise<void>
 }
 
 export interface UpdateUtilisateurUidRepository {
-  updateUid: (utilisateur: Utilisateur) => Promise<void>
+  updateUid(utilisateur: Utilisateur): Promise<void>
 }
 
 export interface AddUtilisateurRepository {
-  add: (utilisateur: Utilisateur) => Promise<boolean>
+  add(utilisateur: Utilisateur): Promise<boolean>
 }
 
 export interface UtilisateurRepository

--- a/src/use-cases/queries/RechercherLesStructures.ts
+++ b/src/use-cases/queries/RechercherLesStructures.ts
@@ -1,5 +1,5 @@
 export interface StructureLoader {
-  findStructures: (query: RechercherStruturesQuery) => Promise<StructuresReadModel>
+  findStructures(query: RechercherStruturesQuery): Promise<StructuresReadModel>
 }
 
 export type StructuresReadModel = ReadonlyArray<UneStructureReadModel>

--- a/src/use-cases/queries/RechercherMesUtilisateurs.ts
+++ b/src/use-cases/queries/RechercherMesUtilisateurs.ts
@@ -53,7 +53,7 @@ export type UtilisateursCourantsEtTotalReadModel = Readonly<{
 }>
 
 export interface MesUtilisateursLoader extends UnUtilisateurLoader {
-  findMesUtilisateursEtLeTotal: (
+  findMesUtilisateursEtLeTotal(
     utilisateur: UnUtilisateurReadModel,
     pageCourante: number,
     utilisateursParPage: number,
@@ -62,5 +62,5 @@ export interface MesUtilisateursLoader extends UnUtilisateurLoader {
     codeDepartement: string,
     codeRegion: string,
     idStructure: number
-  ) => Promise<UtilisateursCourantsEtTotalReadModel>
+  ): Promise<UtilisateursCourantsEtTotalReadModel>
 }

--- a/src/use-cases/queries/RechercherUnUtilisateur.ts
+++ b/src/use-cases/queries/RechercherUnUtilisateur.ts
@@ -1,7 +1,7 @@
 import { UnUtilisateurReadModel } from './shared/UnUtilisateurReadModel'
 
 export interface UnUtilisateurLoader {
-  findByUid: (uid: string) => Promise<UnUtilisateurReadModel>
+  findByUid(uid: string): Promise<UnUtilisateurReadModel>
 }
 
 export class UtilisateurNonTrouveError extends Error {

--- a/src/use-cases/queries/RecupererMesInformationsPersonnelles.ts
+++ b/src/use-cases/queries/RecupererMesInformationsPersonnelles.ts
@@ -1,5 +1,5 @@
 export interface MesInformationsPersonnellesLoader {
-  findByUid: (uid: string) => Promise<MesInformationsPersonnellesReadModel>
+  findByUid(uid: string): Promise<MesInformationsPersonnellesReadModel>
 }
 
 export type MesInformationsPersonnellesReadModel = Readonly<{

--- a/src/use-cases/queries/RecupererUneGouvernance.ts
+++ b/src/use-cases/queries/RecupererUneGouvernance.ts
@@ -1,5 +1,5 @@
 export interface UneGouvernanceReadModelLoader {
-  find: (codeDepartement: string) => Promise<UneGouvernanceReadModel | null>
+  find(codeDepartement: string): Promise<UneGouvernanceReadModel | null>
 }
 
 export type UneGouvernanceReadModel = Readonly<{


### PR DESCRIPTION
Comme expliqué ici : https://typescript-eslint.io/rules/method-signature-style/, on peut déclarer des méthodes de deux façons, avec la syntaxe _method shorthand_ ou la syntaxe propriété avec type de fonction.  
Dans notre base de code, on a tendance à préférer la première, par exemple :
```typescript
find(uid: UtilisateurUidState['value']): Promise<Utilisateur | null>
``` 

mais le _linter_ modifie le code dans les interfaces à la faveur de la seconde :
```typescript
find: (uid: UtilisateurUidState['value']) => Promise<Utilisateur | null>
```

L'objet de cette PR est d'uniformiser les déclarations sous la forme _method shorthand_.

# Contrat du dev

## Qualité

- [x] Relire le code
~~- [ ] Relire le ticket~~
- [x] Recetter l'application
- [x] Regarder le commentaire de sonarcloud et corriger s'il est pertinent
~~- [ ] Ajouter des variables d'environnement sur la production au besoin~~

## Accessibilité

~~- [ ] Vérifier l'accessibilité avec a11y.css~~
~~- [ ] Vérifier l'accessibilité avec WAVE~~
~~- [ ] Vérifier l'accessibilité avec Axe~~
~~- [ ] Vérifier l'accessibilité avec headingMap~~
~~- [ ] Vérifier le constraste en mode sombre~~

## Facultatif mais fortement conseillé

- [x] Lancer les tests de mutation

> **Et n'oublie pas de vérifier ce que tu as fait en production !**
