### PR TITLE
refactor(Model): la méthode state devient un accesseur

### DIFF
--- a/src/domain/Administrateur.ts
+++ b/src/domain/Administrateur.ts
@@ -1,8 +1,8 @@
 import { Utilisateur, UtilisateurState } from './Utilisateur'
 
 export class Administrateur extends Utilisateur {
-  override state(): AdministrateurState {
-    return super.state()
+  override get state(): AdministrateurState {
+    return super.state
   }
 
   override peutGerer(): boolean {

--- a/src/domain/GestionnaireDepartement.ts
+++ b/src/domain/GestionnaireDepartement.ts
@@ -30,10 +30,10 @@ export class GestionnaireDepartement extends Utilisateur {
     this.#departement = departement
   }
 
-  override state(): GestionnaireDepartementState {
+  override get state(): GestionnaireDepartementState {
     return {
-      ...super.state(),
-      departement: this.#departement.state(),
+      ...super.state,
+      departement: this.#departement.state,
     }
   }
 

--- a/src/domain/GestionnaireGroupement.ts
+++ b/src/domain/GestionnaireGroupement.ts
@@ -30,10 +30,10 @@ export class GestionnaireGroupement extends Utilisateur {
     this.#groupementUid = groupementUid
   }
 
-  override state(): GestionnaireGroupementState {
+  override get state(): GestionnaireGroupementState {
     return {
-      ...super.state(),
-      groupementUid: this.#groupementUid.state(),
+      ...super.state,
+      groupementUid: this.#groupementUid.state,
     }
   }
 

--- a/src/domain/GestionnaireRegion.ts
+++ b/src/domain/GestionnaireRegion.ts
@@ -30,10 +30,10 @@ export class GestionnaireRegion extends Utilisateur {
     this.#region = region
   }
 
-  override state(): GestionnaireRegionState {
+  override get state(): GestionnaireRegionState {
     return {
-      ...super.state(),
-      region: this.#region.state(),
+      ...super.state,
+      region: this.#region.state,
     }
   }
 

--- a/src/domain/GestionnaireStructure.ts
+++ b/src/domain/GestionnaireStructure.ts
@@ -30,10 +30,10 @@ export class GestionnaireStructure extends Utilisateur {
     this.#structureUid = structureUid
   }
 
-  override state(): GestionnaireStructureState {
+  override get state(): GestionnaireStructureState {
     return {
-      ...super.state(),
-      structureUid: this.#structureUid.state(),
+      ...super.state,
+      structureUid: this.#structureUid.state,
     }
   }
 

--- a/src/domain/Utilisateur.ts
+++ b/src/domain/Utilisateur.ts
@@ -40,18 +40,18 @@ export abstract class Utilisateur extends Entity<UtilisateurState> {
     this.#inviteLe = inviteLe
   }
 
-  override state(): UtilisateurState {
+  override get state(): UtilisateurState {
     return {
       derniereConnexion: this.#derniereConnexion.toJSON(),
-      emailDeContact: this.#emailDeContact.state().value,
+      emailDeContact: this.#emailDeContact.state.value,
       inviteLe: this.#inviteLe.toJSON(),
       isActive: this.#derniereConnexion.getTime() !== 0,
       isSuperAdmin: this.#isSuperAdmin,
-      nom: this.#nom.state().value,
-      prenom: this.#prenom.state().value,
-      role: this.#role.state(),
-      telephone: this.#telephone.state().value,
-      uid: this.uid.state(),
+      nom: this.#nom.state.value,
+      prenom: this.#prenom.state.value,
+      role: this.#role.state,
+      telephone: this.#telephone.state.value,
+      uid: this.uid.state,
     }
   }
 

--- a/src/domain/UtilisateurFactory.test.ts
+++ b/src/domain/UtilisateurFactory.test.ts
@@ -124,7 +124,7 @@ describe('utilisateur factory', () => {
     const utilisateur = new UtilisateurFactory(utilisateurParams).create('Instructeur')
 
     // THEN
-    expect(utilisateur.state().isActive).toBe(expectedIsActive)
+    expect(utilisateur.state.isActive).toBe(expectedIsActive)
   })
 
   it.each([
@@ -154,6 +154,6 @@ describe('utilisateur factory', () => {
     const utilisateur = new UtilisateurFactory(utilisateurParams).create('Instructeur')
 
     // THEN
-    expect(utilisateur.state().telephone).toBe(expectedTelephone)
+    expect(utilisateur.state.telephone).toBe(expectedTelephone)
   })
 })

--- a/src/domain/UtilisateurFactory.ts
+++ b/src/domain/UtilisateurFactory.ts
@@ -41,7 +41,7 @@ export class UtilisateurFactory {
   }
 
   static avecNouvelUid(utilisateur: Utilisateur, uid: string): Utilisateur {
-    const state = utilisateur.state()
+    const state = utilisateur.state
     return new UtilisateurFactory({
       departement: state.departement,
       derniereConnexion: new Date(state.derniereConnexion),

--- a/src/domain/shared/Model.ts
+++ b/src/domain/shared/Model.ts
@@ -1,11 +1,11 @@
 import { Struct } from '@/shared/lang'
 
 abstract class Model {
-  equals(other: this): boolean {
-    return JSON.stringify(other.state()) === JSON.stringify(this.state())
-  }
+  abstract get state(): Struct
 
-  abstract state(): Struct
+  equals(other: this): boolean {
+    return JSON.stringify(other.state) === JSON.stringify(this.state)
+  }
 }
 
 export abstract class ValueObject<State extends Struct> extends Model {
@@ -17,7 +17,7 @@ export abstract class ValueObject<State extends Struct> extends Model {
     Object.freeze(this)
   }
 
-  override state(): State {
+  override get state(): State {
     return this.#state
   }
 }
@@ -32,7 +32,7 @@ export abstract class Entity<State extends EntityState> extends Model {
     this.uid = uid
   }
 
-  abstract override state(): State
+  abstract override get state(): State
 }
 
 type EntityState = Readonly<{ uid: UidState }> & Struct

--- a/src/gateways/PrismaUtilisateurLoader.ts
+++ b/src/gateways/PrismaUtilisateurLoader.ts
@@ -124,7 +124,7 @@ export class PrismaUtilisateurLoader implements MesUtilisateursLoader {
 }
 
 function transform(utilisateurRecord: UtilisateurEtSesRelationsRecord): UnUtilisateurReadModel {
-  const role = new Role(toTypologieRole(utilisateurRecord.role), organisation(utilisateurRecord)).state()
+  const role = new Role(toTypologieRole(utilisateurRecord.role), organisation(utilisateurRecord)).state
 
   return {
     departementCode: utilisateurRecord.departementCode,

--- a/src/gateways/PrismaUtilisateurRepository.test.ts
+++ b/src/gateways/PrismaUtilisateurRepository.test.ts
@@ -174,11 +174,11 @@ describe('utilisateur repository', () => {
         const result = await repository.find(uidUtilisateurValue)
 
         // THEN
-        expect(result?.state()).toStrictEqual(
+        expect(result?.state).toStrictEqual(
           utilisateurFactory({
-            uid: uidUtilisateur.state(),
+            uid: uidUtilisateur.state,
             ...expected,
-          }).state()
+          }).state
         )
       })
 
@@ -216,7 +216,7 @@ describe('utilisateur repository', () => {
         const result = await repository.find(uidUtilisateurValue)
 
         // THEN
-        expect(result?.state().isActive).toBe(expectedIsActive)
+        expect(result?.state.isActive).toBe(expectedIsActive)
       })
     })
   })
@@ -453,7 +453,7 @@ describe('utilisateur repository', () => {
         data: structureRecordFactory({ id: structureId }),
       })
       const utilisateur = utilisateurFactory({
-        departement: departementFactory({ code: departementCode }).state(),
+        departement: departementFactory({ code: departementCode }).state,
         role: 'Gestionnaire département',
         uid: { email: 'martin.tartempion@example.net', value: ssoIdDifferent },
       })

--- a/src/gateways/PrismaUtilisateurRepository.ts
+++ b/src/gateways/PrismaUtilisateurRepository.ts
@@ -14,7 +14,7 @@ export class PrismaUtilisateurRepository implements UtilisateurRepository {
   }
 
   async add(utilisateur: Utilisateur): Promise<boolean> {
-    const utilisateurState = utilisateur.state()
+    const utilisateurState = utilisateur.state
 
     try {
       await this.#activeRecord.create({
@@ -80,7 +80,7 @@ export class PrismaUtilisateurRepository implements UtilisateurRepository {
   }
 
   async drop(utilisateur: Utilisateur): Promise<boolean> {
-    return this.#drop(utilisateur.state().uid.value)
+    return this.#drop(utilisateur.state.uid.value)
   }
 
   async dropByUid(uid: UtilisateurUidState['value']): Promise<boolean> {
@@ -88,7 +88,7 @@ export class PrismaUtilisateurRepository implements UtilisateurRepository {
   }
 
   async update(utilisateur: Utilisateur): Promise<void> {
-    const utilisateurState = utilisateur.state()
+    const utilisateurState = utilisateur.state
 
     await this.#activeRecord.update({
       data: {
@@ -106,7 +106,7 @@ export class PrismaUtilisateurRepository implements UtilisateurRepository {
   }
 
   async updateUid(utilisateur: Utilisateur): Promise<void> {
-    const utilisateurState = utilisateur.state()
+    const utilisateurState = utilisateur.state
 
     await this.#activeRecord.update({
       data: {

--- a/src/use-cases/commands/ChangerMonRole.test.ts
+++ b/src/use-cases/commands/ChangerMonRole.test.ts
@@ -21,11 +21,11 @@ describe('changer mon rôle', () => {
 
     // THEN
     expect(result).toBe('OK')
-    expect(spiedUtilisateur.state()).toStrictEqual(utilisateurFactory({
+    expect(spiedUtilisateur.state).toStrictEqual(utilisateurFactory({
       isSuperAdmin: true,
       role: 'Pilote politique publique',
       uid: { email: 'martin.tartempion@example.fr', value: 'utilisateurSuperAdminUid' },
-    }).state())
+    }).state)
   })
 
   it('n’ayant pas le rôle super admin quand un utilisateur change de rôle alors le rôle est n’est pas modifié', async () => {

--- a/src/use-cases/commands/CorrigerNomPrenomSiAbsents.test.ts
+++ b/src/use-cases/commands/CorrigerNomPrenomSiAbsents.test.ts
@@ -194,10 +194,10 @@ describe('corriger nom prenom si absents', () => {
       // THEN
       expect(result).toBe('okAvecMiseAJour')
       expect(spiedUidToFind).toBe('fooId')
-      expect(spiedUtilisateurToUpdate?.state()).toStrictEqual(utilisateurFactory({
+      expect(spiedUtilisateurToUpdate?.state).toStrictEqual(utilisateurFactory({
         nom: nomApresCorrection,
         prenom: prenomApresCorrection,
-      }).state())
+      }).state)
     }
   )
 })

--- a/src/use-cases/commands/InviterUnUtilisateur.test.ts
+++ b/src/use-cases/commands/InviterUnUtilisateur.test.ts
@@ -146,7 +146,7 @@ describe('inviter un utilisateur', () => {
         })
         expect(result).toBe('OK')
         expect(spiedUidToFind).toBe(command.uidUtilisateurCourant)
-        expect(spiedUtilisateurToAdd?.state()).toStrictEqual(expectedUtilisateurInvite.state())
+        expect(spiedUtilisateurToAdd?.state).toStrictEqual(expectedUtilisateurInvite.state)
         expect(spiedDestinataire).toBe('martine.dugenoux@example.com')
         expect(spiedIsSuperAdmin).toBe(utilisateurCourant.isSuperAdmin)
       }
@@ -229,7 +229,7 @@ describe('inviter un utilisateur', () => {
     // THEN
     expect(result).toBe('emailExistant')
     expect(spiedUidToFind).toBe('utilisateurAdminUid')
-    expect(spiedUtilisateurToAdd?.state()).toStrictEqual(utilisateurACreer.state())
+    expect(spiedUtilisateurToAdd?.state).toStrictEqual(utilisateurACreer.state)
     expect(spiedDestinataire).toBe('')
     expect(spiedIsSuperAdmin).toBeNull()
   })

--- a/src/use-cases/commands/InviterUnUtilisateur.ts
+++ b/src/use-cases/commands/InviterUnUtilisateur.ts
@@ -26,7 +26,7 @@ export class InviterUnUtilisateur implements CommandHandler<InviterUnUtilisateur
     if (!utilisateurCourant) {
       return 'KO'
     }
-    const utilisateurCourantState = utilisateurCourant.state()
+    const utilisateurCourantState = utilisateurCourant.state
     const utilisateurACreer = new UtilisateurFactory({
       departement: utilisateurCourantState.departement,
       emailDeContact: command.email,
@@ -48,7 +48,7 @@ export class InviterUnUtilisateur implements CommandHandler<InviterUnUtilisateur
     }
     const isUtilisateurCreated = await this.#repository.add(utilisateurACreer)
     if (isUtilisateurCreated) {
-      const emailGateway = this.#emailGatewayFactory(utilisateurCourant.state().isSuperAdmin)
+      const emailGateway = this.#emailGatewayFactory(utilisateurCourant.state.isSuperAdmin)
       await emailGateway.send(command.email)
       return 'OK'
     }

--- a/src/use-cases/commands/MettreAJourUidALaPremiereConnexion.test.ts
+++ b/src/use-cases/commands/MettreAJourUidALaPremiereConnexion.test.ts
@@ -21,12 +21,12 @@ describe('mettre à jour l’identifiant unique à la première connexion', () =
     // THEN
     expect(result).toBe('ok')
     expect(spiedUidToFind).toBe('martin.tartempion@example.net')
-    expect(spiedUtilisateurToUpdate?.state()).toStrictEqual(utilisateurFactory({
+    expect(spiedUtilisateurToUpdate?.state).toStrictEqual(utilisateurFactory({
       uid: {
         email: emailAsUid,
         value: uid,
       },
-    }).state())
+    }).state)
   })
 
   it('quand l’utilisateur se connecte pour la première fois mais qu’il n’existe pas, alors un message d’erreur est renvoyé', async () => {

--- a/src/use-cases/commands/ModifierMesInformationsPersonnelles.test.ts
+++ b/src/use-cases/commands/ModifierMesInformationsPersonnelles.test.ts
@@ -73,7 +73,7 @@ describe('modifier mes informations personnelles', () => {
         telephone: '0102030406',
       })
       expect(result).toBe('OK')
-      expect(utilisateurApresMiseAJour.state()).toStrictEqual(utilisateur.state())
+      expect(utilisateurApresMiseAJour.state).toStrictEqual(utilisateur.state)
     })
   })
 })

--- a/src/use-cases/commands/ReinviterUnUtilisateur.test.ts
+++ b/src/use-cases/commands/ReinviterUnUtilisateur.test.ts
@@ -25,12 +25,12 @@ describe('réinviter un utilisateur', () => {
 
     // THEN
     expect(result).toBe('OK')
-    expect(spiedUtilisateurToUpdate?.state()).toStrictEqual(utilisateurFactory({
+    expect(spiedUtilisateurToUpdate?.state).toStrictEqual(utilisateurFactory({
       inviteLe: date,
       role: 'Gestionnaire structure',
       uid: { email: 'uidUtilisateurAReinviterInactif', value: 'uidUtilisateurAReinviterInactif' },
-    }).state())
-    expect(spiedDestinataire).toBe(spiedUtilisateurToUpdate?.state().emailDeContact)
+    }).state)
+    expect(spiedDestinataire).toBe(spiedUtilisateurToUpdate?.state.emailDeContact)
   })
 
   it('étant donné que l’utilisateur courant ne peut pas gérer l’utilisateur à réinviter, quand il le réinvite, alors il y a une erreur', async () => {

--- a/src/use-cases/commands/ReinviterUnUtilisateur.ts
+++ b/src/use-cases/commands/ReinviterUnUtilisateur.ts
@@ -23,7 +23,7 @@ export class ReinviterUnUtilisateur implements CommandHandler<ReinviterUnUtilisa
     if (!utilisateurAReinviter) {
       return 'utilisateurAReinviterInexistant'
     }
-    if (utilisateurAReinviter.state().isActive) {
+    if (utilisateurAReinviter.state.isActive) {
       return 'utilisateurAReinviterDejaActif'
     }
     if (!utilisateurCourant.peutGerer(utilisateurAReinviter)) {
@@ -32,8 +32,8 @@ export class ReinviterUnUtilisateur implements CommandHandler<ReinviterUnUtilisa
 
     utilisateurAReinviter.changerLaDateDInvitation(this.#date)
     await this.#repository.update(utilisateurAReinviter)
-    const emailGateway = this.#emailGatewayFactory(utilisateurCourant.state().isSuperAdmin)
-    await emailGateway.send(utilisateurAReinviter.state().emailDeContact)
+    const emailGateway = this.#emailGatewayFactory(utilisateurCourant.state.isSuperAdmin)
+    await emailGateway.send(utilisateurAReinviter.state.emailDeContact)
     return 'OK'
   }
 }
@@ -50,4 +50,3 @@ export type ReinviterUnUtilisateurCommand = Readonly<{
 }>
 
 interface Repository extends FindUtilisateurRepository, UpdateUtilisateurRepository {}
-

--- a/src/use-cases/commands/SupprimerUnUtilisateur.test.ts
+++ b/src/use-cases/commands/SupprimerUnUtilisateur.test.ts
@@ -82,7 +82,7 @@ describe('supprimer un utilisateur', () => {
       'utilisateurASupprimerExistantUid',
     ])
     expect(spiedUtilisateurToDrop).not.toBeNull()
-    expect(spiedUtilisateurToDrop?.state()).toStrictEqual(utilisateursByUid.utilisateurASupprimerExistantUid.state())
+    expect(spiedUtilisateurToDrop?.state).toStrictEqual(utilisateursByUid.utilisateurASupprimerExistantUid.state)
     expect(result).toBe('compteASupprimerDejaSupprime')
   })
 
@@ -103,7 +103,7 @@ describe('supprimer un utilisateur', () => {
       'utilisateurCourantExistantAutreUid',
       'utilisateurASupprimerExistantUid',
     ])
-    expect(spiedUtilisateurToDrop?.state()).toStrictEqual(utilisateursByUid.utilisateurASupprimerExistantUid.state())
+    expect(spiedUtilisateurToDrop?.state).toStrictEqual(utilisateursByUid.utilisateurASupprimerExistantUid.state)
     expect(result).toBe('OK')
   })
 })


### PR DESCRIPTION
Je propose de faire de la méthode `state` de `Model` un [accesseur](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get). Concrètement, ce que ça change est que l'on appelle plus `model.state()` mais `model.state`, en vertu du [principe d'accès universel](https://martinfowler.com/bliki/UniformAccessPrinciple.html).

# Contrat du dev

## Qualité

- [x] Relire le code
- [x] Recetter l'application
- [x] Regarder le commentaire de sonarcloud et corriger s'il est pertinent

> **Et n'oublie pas de vérifier ce que tu as fait en production !**
