### PR TITLE
Reinitialisation formulaire ajouter comite apres succes

### DIFF
--- a/src/app/(connecte)/(avec-menu)/gouvernance-vide/[codeDepartement]/page.tsx
+++ b/src/app/(connecte)/(avec-menu)/gouvernance-vide/[codeDepartement]/page.tsx
@@ -33,6 +33,7 @@ export default async function GouvernanceVideController({ params }: PageProps): 
     sectionNoteDeContexte: {
       sousTitre: '',
     },
+    uid: '',
   }
 
   return (

--- a/src/app/api/actions/ajouterUnComiteAction.ts
+++ b/src/app/api/actions/ajouterUnComiteAction.ts
@@ -1,16 +1,19 @@
 'use server'
 
+import { ResultAsync } from '@/use-cases/CommandHandler'
+
 export async function ajouterUnComiteAction(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _actionParams: ActionParams
-): Promise<void> {
-  return Promise.resolve()
+): ResultAsync<ReadonlyArray<string>> {
+  return Promise.resolve(['OK'])
 }
 
 type ActionParams = Readonly<{
-  gouvernanceId: string,
-  type: string,
-  frequence: string,
-  date?: string,
   commentaire?: string
+  date?: string,
+  frequence: string,
+  path: string
+  type: string,
+  uidGouvernance: string,
 }>

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,3 +1,3 @@
-import { handler } from '../../../../gateways/NextAuthAuthentificationGateway'
+import { handler } from '@/gateways/NextAuthAuthentificationGateway'
 
 export { handler as GET, handler as POST }

--- a/src/app/api/structures/route.test.ts
+++ b/src/app/api/structures/route.test.ts
@@ -1,8 +1,8 @@
 import { NextRequest } from 'next/server'
 
 import { GET } from './route'
-import { PrismaStructureLoader } from '../../../gateways/PrismaStructureLoader'
 import * as ssoGateway from '@/gateways/NextAuthAuthentificationGateway'
+import { PrismaStructureLoader } from '@/gateways/PrismaStructureLoader'
 
 describe('route /structures', () => {
   it('devrait retourner une erreur 403 quand on quand l’utilisateur n’est pas authentifié', async () => {

--- a/src/components/Gouvernance/Comitologie/ComitologieRemplie.tsx
+++ b/src/components/Gouvernance/Comitologie/ComitologieRemplie.tsx
@@ -2,11 +2,11 @@
 
 import { ReactElement, useRef, useState } from 'react'
 
-import Drawer from '../../shared/Drawer/Drawer'
-import Table from '../../shared/Table/Table'
 import SectionRemplie from '../SectionRemplie'
 import AjouterUnComite from './AjouterUnComite'
+import Drawer from '@/components/shared/Drawer/Drawer'
 import Icon from '@/components/shared/Icon/Icon'
+import Table from '@/components/shared/Table/Table'
 import { GouvernanceViewModel } from '@/presenters/gouvernancePresenter'
 
 export default function ComitologieRemplie({ comites }: ComitologieRemplieProps): ReactElement {

--- a/src/components/Gouvernance/Comitologie/ComitologieRemplie.tsx
+++ b/src/components/Gouvernance/Comitologie/ComitologieRemplie.tsx
@@ -9,7 +9,7 @@ import Icon from '@/components/shared/Icon/Icon'
 import Table from '@/components/shared/Table/Table'
 import { GouvernanceViewModel } from '@/presenters/gouvernancePresenter'
 
-export default function ComitologieRemplie({ comites }: ComitologieRemplieProps): ReactElement {
+export default function ComitologieRemplie({ comites, uidGouvernance }: ComitologieRemplieProps): ReactElement {
   // Stryker disable next-line BooleanLiteral
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
   const drawerComiteId = 'drawer-comite'
@@ -33,6 +33,7 @@ export default function ComitologieRemplie({ comites }: ComitologieRemplieProps)
           dialogRef={drawerRef}
           labelId={labelComiteId}
           setIsOpen={setIsDrawerOpen}
+          uidGouvernance={uidGouvernance}
         />
       </Drawer>
       <SectionRemplie
@@ -83,4 +84,5 @@ export default function ComitologieRemplie({ comites }: ComitologieRemplieProps)
 
 type ComitologieRemplieProps = Readonly<{
   comites: NonNullable<GouvernanceViewModel['comites']>
+  uidGouvernance: string
 }>

--- a/src/components/Gouvernance/FeuilleDeRoute/FeuilleDeRouteRemplie.tsx
+++ b/src/components/Gouvernance/FeuilleDeRoute/FeuilleDeRouteRemplie.tsx
@@ -3,12 +3,12 @@
 import Link from 'next/link'
 import { ReactElement, useState } from 'react'
 
-import Table from '../../shared/Table/Table'
 import SectionRemplie from '../SectionRemplie'
 import SubSectionTitle from '../SubSectionTitle'
 import DetailsFeuilleDeRoute from './DetailsFeuilleDeRoute'
 import Drawer from '@/components/shared/Drawer/Drawer'
 import Icon from '@/components/shared/Icon/Icon'
+import Table from '@/components/shared/Table/Table'
 import { FeuilleDeRouteViewModel, GouvernanceViewModel } from '@/presenters/gouvernancePresenter'
 
 export default function FeuilleDeRouteRemplie({

--- a/src/components/Gouvernance/FeuilleDeRoute/FeuilleDeRouteRemplie.tsx
+++ b/src/components/Gouvernance/FeuilleDeRoute/FeuilleDeRouteRemplie.tsx
@@ -82,6 +82,7 @@ export default function FeuilleDeRouteRemplie({
         boutonFermeture="Fermer les détails de la feuille de route"
         icon={<Icon icon="survey-line" />}
         id={drawerFeuilleDeRouteId}
+        // Stryker disable next-line BooleanLiteral
         isFixedWidth={false}
         isOpen={isDrawerOpen}
         labelId={labelFeuilleDeRouteId}

--- a/src/components/Gouvernance/Gouvernance.tsx
+++ b/src/components/Gouvernance/Gouvernance.tsx
@@ -66,7 +66,10 @@ export default function Gouvernance({ gouvernanceViewModel }: GouvernanceProps):
       <section aria-labelledby="comitologie">
         {
           gouvernanceViewModel.comites ? (
-            <ComitologieRemplie comites={gouvernanceViewModel.comites} />
+            <ComitologieRemplie
+              comites={gouvernanceViewModel.comites}
+              uidGouvernance={gouvernanceViewModel.uid}
+            />
           ) : (
             <ComitologieVide />
           )

--- a/src/components/Gouvernance/Membre/MembreRempli.tsx
+++ b/src/components/Gouvernance/Membre/MembreRempli.tsx
@@ -1,10 +1,10 @@
 import Link from 'next/link'
 import { Fragment, ReactElement } from 'react'
 
-import Table from '../../shared/Table/Table'
 import SectionRemplie from '../SectionRemplie'
 import SubSectionTitle from '../SubSectionTitle'
 import Badge from '@/components/shared/Badge/Badge'
+import Table from '@/components/shared/Table/Table'
 import { GouvernanceViewModel } from '@/presenters/gouvernancePresenter'
 
 export default function MembreRempli({

--- a/src/components/MesInformationsPersonnelles/MesInformationsPersonnelles.test.tsx
+++ b/src/components/MesInformationsPersonnelles/MesInformationsPersonnelles.test.tsx
@@ -1,9 +1,8 @@
 import { fireEvent, screen, within } from '@testing-library/react'
 import * as nextAuth from 'next-auth/react'
-import { Mock } from 'vitest'
 
 import MesInformationsPersonnelles from './MesInformationsPersonnelles'
-import { matchWithoutMarkup, renderComponent } from '@/components/testHelper'
+import { matchWithoutMarkup, renderComponent, stubbedConceal } from '@/components/testHelper'
 import { mesInformationsPersonnellesPresenter } from '@/presenters/mesInformationsPersonnellesPresenter'
 import { mesInformationsPersonnellesReadModelFactory } from '@/use-cases/testHelper'
 
@@ -394,12 +393,7 @@ describe('mes informations personnelles : en tant qu’utilisateur authentifié'
     it('quand je modifie mes informations personnelles alors elles sont modifiées et le drawer est fermé', async () => {
       // GIVEN
       const modifierMesInformationsPersonnellesAction = vi.fn(async () => Promise.resolve(['OK']))
-      const windowDsfr = window.dsfr
-      window.dsfr = (): {modal: {conceal: Mock}} => ({
-        modal: {
-          conceal: vi.fn(),
-        },
-      })
+      vi.stubGlobal('dsfr', stubbedConceal())
 
       const mesInformationsPersonnellesViewModel =
         mesInformationsPersonnellesPresenter(mesInformationsPersonnellesReadModelFactory())
@@ -429,7 +423,6 @@ describe('mes informations personnelles : en tant qu’utilisateur authentifié'
       expect(boutonModificationActive).toBeEnabled()
       const modifierMesInfosPersosDrawer = screen.queryByRole('dialog', { name: 'Mes informations personnelles' })
       expect(modifierMesInfosPersosDrawer).not.toBeInTheDocument()
-      window.dsfr = windowDsfr
     })
 
     function ouvrirDrawer(): void {

--- a/src/components/MesUtilisateurs/DetailsUtilisateur.tsx
+++ b/src/components/MesUtilisateurs/DetailsUtilisateur.tsx
@@ -1,7 +1,7 @@
 import { ReactElement } from 'react'
 
-import { DetailsUtilisateurViewModel } from '../../presenters/mesUtilisateursPresenter'
 import DrawerTitle from '../shared/DrawerTitle/DrawerTitle'
+import { DetailsUtilisateurViewModel } from '@/presenters/mesUtilisateursPresenter'
 
 export default function DetailsUtilisateur({ utilisateur, labelId }: DetailsUtilisateurProps): ReactElement {
   const donneesPersonnelles: ReadonlyArray<DetailUtilisateur> = [

--- a/src/components/MesUtilisateurs/InviterUnUtilisateur.test.tsx
+++ b/src/components/MesUtilisateurs/InviterUnUtilisateur.test.tsx
@@ -1,9 +1,8 @@
 import { fireEvent, screen, waitFor, within } from '@testing-library/react'
 import { select } from 'react-select-event'
-import { Mock } from 'vitest'
 
 import MesUtilisateurs from './MesUtilisateurs'
-import { renderComponent, matchWithoutMarkup, structuresFetch, rolesAvecStructure } from '@/components/testHelper'
+import { renderComponent, matchWithoutMarkup, structuresFetch, rolesAvecStructure, stubbedConceal } from '@/components/testHelper'
 import { mesUtilisateursPresenter } from '@/presenters/mesUtilisateursPresenter'
 import { sessionUtilisateurViewModelFactory } from '@/presenters/testHelper'
 
@@ -159,12 +158,7 @@ describe('inviter un utilisateur', () => {
   it('en tant qu’administrateur, quand je fais une recherche dans le champ de structure, alors je peux y faire une recherche utilisée dans le formulaire', async () => {
     // GIVEN
     const inviterUnUtilisateurAction = vi.fn(async () => Promise.resolve(['OK']))
-    const windowDsfr = window.dsfr
-    window.dsfr = (): {modal: {conceal: Mock}} => ({
-      modal: {
-        conceal: vi.fn(),
-      },
-    })
+    vi.stubGlobal('dsfr', stubbedConceal())
     vi.stubGlobal('fetch', vi.fn(structuresFetch))
     const mesUtilisateursViewModel = mesUtilisateursPresenter([], 'fooId', totalUtilisateur, rolesAvecStructure)
     renderComponent(<MesUtilisateurs mesUtilisateursViewModel={mesUtilisateursViewModel} />, {
@@ -218,7 +212,6 @@ describe('inviter un utilisateur', () => {
       })
     })
     expect(fetch).toHaveBeenCalledWith('/api/structures?search=ABC')
-    window.dsfr = windowDsfr
   })
 
   it('en tant qu’administrateur, quand je fais une recherche de moins de 3 caractères dans le champ de structure, alors il ne se passe rien', () => {
@@ -328,12 +321,7 @@ describe('inviter un utilisateur', () => {
   it('quand je remplis correctement le formulaire et avec un nouveau mail, alors un message de validation s’affiche et le drawer est réinitialisé', async () => {
     // GIVEN
     const inviterUnUtilisateurAction = vi.fn(async () => Promise.resolve(['OK']))
-    const windowDsfr = window.dsfr
-    window.dsfr = (): {modal: {conceal: Mock}} => ({
-      modal: {
-        conceal: vi.fn(),
-      },
-    })
+    vi.stubGlobal('dsfr', stubbedConceal())
     const mesUtilisateursViewModel = mesUtilisateursPresenter([], 'fooId', totalUtilisateur, rolesAvecStructure)
     renderComponent(
       <MesUtilisateurs mesUtilisateursViewModel={mesUtilisateursViewModel} />, {
@@ -378,14 +366,13 @@ describe('inviter un utilisateur', () => {
     // THEN
     const notification = await screen.findByRole('alert')
     expect(notification).toHaveTextContent('Invitation envoyée à martin.tartempion@example.com')
-    expect(formulaireInvitation).not.toHaveAttribute('open', '')
+    expect(formulaireInvitation).not.toBeVisible()
     expect(nom).toHaveValue('')
     expect(prenom).toHaveValue('')
     expect(email).toHaveValue('')
     roleRadios.forEach((roleRadio) => {
       expect(roleRadio).not.toBeChecked()
     })
-    window.dsfr = windowDsfr
   })
 
   it('quand je remplis avec un e-mail déjà existant puis avec un e-mail inexistant le formulaire d’invitation, alors un message d’invalidation puis de validation s’affiche et le drawer est réinitialisé', async () => {
@@ -399,12 +386,7 @@ describe('inviter un utilisateur', () => {
     const inviterUnUtilisateurAction = vi.fn()
       .mockResolvedValueOnce(['emailExistant'])
       .mockResolvedValueOnce(['OK'])
-    const windowDsfr = window.dsfr
-    window.dsfr = (): {modal: {conceal: Mock}} => ({
-      modal: {
-        conceal: vi.fn(),
-      },
-    })
+    vi.stubGlobal('dsfr', stubbedConceal())
     const mesUtilisateursViewModel = mesUtilisateursPresenter([], 'fooId', totalUtilisateur, rolesAvecStructure)
     renderComponent(
       <MesUtilisateurs mesUtilisateursViewModel={mesUtilisateursViewModel} />, {
@@ -457,7 +439,7 @@ describe('inviter un utilisateur', () => {
     expect(absenceMessageDErreur).not.toBeInTheDocument()
     const notification = await screen.findByRole('alert')
     expect(notification).toHaveTextContent('Invitation envoyée à martin.tartempion@example.com')
-    expect(formulaireInvitation).not.toHaveAttribute('open', '')
+    expect(formulaireInvitation).not.toBeVisible()
     expect(nom).toHaveValue('')
     expect(prenom).toHaveValue('')
     expect(email).toHaveValue('')
@@ -468,7 +450,6 @@ describe('inviter un utilisateur', () => {
       const champSelection = within(formulaireInvitation).queryByLabelText(`${labelChampSelection} *`)
       expect(champSelection).not.toBeInTheDocument()
     })
-    window.dsfr = windowDsfr
   })
 
   it('dans le drawer d’invitation, quand je remplis correctement le formulaire et avec un mail existant, alors il y a un message d’erreur', async () => {
@@ -518,19 +499,13 @@ describe('inviter un utilisateur', () => {
     // THEN
     const erreurEmailDejaExistant = await within(formulaireInvitation).findByText('Cet utilisateur dispose déjà d’un compte', { selector: 'p' })
     expect(erreurEmailDejaExistant).toBeInTheDocument()
-    expect(formulaireInvitation).toHaveAttribute('open', '')
+    expect(formulaireInvitation).toBeVisible()
   })
 
   it('dans le drawer d’invitation, quand je remplis correctement le formulaire mais que l’invitation ne peut pas se faire, alors le drawer se ferme', async () => {
     // GIVEN
     const inviterUnUtilisateurAction = vi.fn(async () => Promise.resolve(['KO']))
-    const windowDsfr = window.dsfr
-    // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-    window.dsfr = () => ({
-      modal: {
-        conceal: vi.fn(),
-      },
-    })
+    vi.stubGlobal('dsfr', stubbedConceal())
     const mesUtilisateursViewModel = mesUtilisateursPresenter([], 'fooId', totalUtilisateur, rolesAvecStructure)
     renderComponent(
       <MesUtilisateurs mesUtilisateursViewModel={mesUtilisateursViewModel} />,
@@ -580,13 +555,12 @@ describe('inviter un utilisateur', () => {
       'dialog',
       { name: 'Invitez un utilisateur à rejoindre l’espace de gestion' }
     )
-    expect(formulaireInvitationApresInvitationEnEchec).not.toHaveAttribute('open', '')
+    expect(formulaireInvitationApresInvitationEnEchec).not.toBeVisible()
     expect(nom).toHaveValue('')
     expect(prenom).toHaveValue('')
     expect(email).toHaveValue('')
     roleRadios.forEach((roleRadio) => {
       expect(roleRadio).not.toBeChecked()
     })
-    window.dsfr = windowDsfr
   })
 })

--- a/src/components/MesUtilisateurs/InviterUnUtilisateur.tsx
+++ b/src/components/MesUtilisateurs/InviterUnUtilisateur.tsx
@@ -151,7 +151,7 @@ export default function InviterUnUtilisateur({
     const form = new FormData(event.currentTarget)
     const [nom, prenom, email, role, codeOrganisation] = [...form.values()].map((value) => value as string)
     const messages = await inviterUnUtilisateurAction({ codeOrganisation, email: email, nom, prenom, role })
-    if (messages[0] === 'emailExistant') {
+    if (messages.includes('emailExistant')) {
       setEmailDejaExistant({
         className: 'fr-input-group--error',
         content: (
@@ -164,7 +164,7 @@ export default function InviterUnUtilisateur({
         ),
       })
     } else {
-      if (messages[0] === 'OK') {
+      if (messages.includes('OK')) {
         Notification('success', { description: email, title: 'Invitation envoyée à ' })
         setEmailDejaExistant(undefined)
       }

--- a/src/components/MesUtilisateurs/MesUtilisateurs.test.tsx
+++ b/src/components/MesUtilisateurs/MesUtilisateurs.test.tsx
@@ -1,8 +1,7 @@
 import { fireEvent, screen, waitFor, within } from '@testing-library/react'
-import { Mock } from 'vitest'
 
 import MesUtilisateurs from './MesUtilisateurs'
-import { renderComponent, rolesAvecStructure } from '@/components/testHelper'
+import { renderComponent, rolesAvecStructure, stubbedConceal } from '@/components/testHelper'
 import { mesUtilisateursPresenter } from '@/presenters/mesUtilisateursPresenter'
 import { sessionUtilisateurViewModelFactory } from '@/presenters/testHelper'
 import { utilisateurReadModelFactory } from '@/use-cases/testHelper'
@@ -250,12 +249,7 @@ describe('mes utilisateurs', () => {
     it('quand je clique sur le bouton "Renvoyer cette invitation" alors le drawer se ferme et il en est notifié', async () => {
       // GIVEN
       const reinviterUnUtilisateurAction = vi.fn(async () => Promise.resolve(['OK']))
-      const windowDsfr = window.dsfr
-      window.dsfr = (): {modal: {conceal: Mock}} => ({
-        modal: {
-          conceal: vi.fn(),
-        },
-      })
+      vi.stubGlobal('dsfr', stubbedConceal())
       const mesUtilisateursViewModel = mesUtilisateursPresenter([utilisateurEnAttenteReadModel], 'fooId', totalUtilisateur, rolesAvecStructure)
       renderComponent(<MesUtilisateurs mesUtilisateursViewModel={mesUtilisateursViewModel} />, { pathname: '/mes-utilisateurs', reinviterUnUtilisateurAction })
       const utilisateurEnAttente = screen.getByRole('button', { name: 'Julien Deschamps' })
@@ -273,7 +267,6 @@ describe('mes utilisateurs', () => {
       expect(drawerRenvoyerInvitation).not.toBeInTheDocument()
       const notification = screen.getByRole('alert')
       expect(notification).toHaveTextContent('Invitation envoyée à julien.deschamps@example.com')
-      window.dsfr = windowDsfr
     })
 
     it('si l’invitation a été envoyée ajourd’hui alors le titre affiché est "Invitation envoyée aujourd’hui"', async() => {

--- a/src/components/shared/ClientContext.tsx
+++ b/src/components/shared/ClientContext.tsx
@@ -6,7 +6,7 @@ import { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.share
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { createContext, ReactElement, PropsWithChildren, useMemo } from 'react'
 
-import { ajouterUnComiteAction } from '../../app/api/actions/ajouterUnComiteAction'
+import { ajouterUnComiteAction } from '@/app/api/actions/ajouterUnComiteAction'
 import { changerMonRoleAction } from '@/app/api/actions/changerMonRoleAction'
 import { inviterUnUtilisateurAction } from '@/app/api/actions/inviterUnUtilisateurAction'
 import { modifierMesInformationsPersonnellesAction } from '@/app/api/actions/modifierMesInformationsPersonnellesAction'

--- a/src/components/shared/Pagination/DernierePage.tsx
+++ b/src/components/shared/Pagination/DernierePage.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import { ReactElement } from 'react'
 
-import { nombreDePage } from '../../../presenters/paginationPresenter'
+import { nombreDePage } from '@/presenters/paginationPresenter'
 
 export default function DernierePage({
   nombreDeResultat,

--- a/src/components/shared/Pagination/Page.tsx
+++ b/src/components/shared/Pagination/Page.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 import { ReactElement } from 'react'
 
-import { pages } from '../../../presenters/paginationPresenter'
+import { pages } from '@/presenters/paginationPresenter'
 
 export default function Page({
   nombreDeResultat,

--- a/src/components/shared/Pagination/Pagination.tsx
+++ b/src/components/shared/Pagination/Pagination.tsx
@@ -5,8 +5,8 @@ import { ReactElement, useContext } from 'react'
 import DernierePage from './DernierePage'
 import Page from './Page'
 import PremierePage from './PremierePage'
-import { fullUrl } from '../../../presenters/paginationPresenter'
 import { clientContext } from '../ClientContext'
+import { fullUrl } from '@/presenters/paginationPresenter'
 
 export default function Pagination({ pathname, totalUtilisateurs }: PaginationProps): ReactElement {
   const { searchParams, utilisateursParPage } = useContext(clientContext)

--- a/src/components/shared/Role/Role.tsx
+++ b/src/components/shared/Role/Role.tsx
@@ -1,6 +1,6 @@
 import { ReactElement } from 'react'
 
-import Badge from '../../shared/Badge/Badge'
+import Badge from '../Badge/Badge'
 
 export default function Role({ role }: RoleProps): ReactElement {
   return (

--- a/src/components/shared/SegmentedControl/SegmentedControl.tsx
+++ b/src/components/shared/SegmentedControl/SegmentedControl.tsx
@@ -1,26 +1,21 @@
-import { PropsWithChildren, ReactElement, useState } from 'react'
+import { PropsWithChildren, ReactElement } from 'react'
 
-export default function SegmentedControl({ options, children, name }: SegmentedControlProps): ReactElement {
-  const [checked, setChecked] = useState(options[0].id)
-
+export default function SegmentedControl({ children, name, options }: SegmentedControlProps): ReactElement {
   return (
     <fieldset className="fr-segmented fr-segmented--sm fr-mb-2w full-width">
       <legend className="fr-segmented__legend">
         {children}
       </legend>
       <div className="fr-segmented__elements full-width">
-        {options.map(({ label, id }) => (
+        {options.map(({ id, isChecked, label }) => (
           <div
             className="fr-segmented__element full-width"
             key={id}
           >
             <input
-              checked={checked === id}
+              defaultChecked={isChecked}
               id={id}
               name={name}
-              onChange={(event) => {
-                setChecked(event.target.value)
-              }}
               type="radio"
               value={id}
             />
@@ -40,7 +35,8 @@ export default function SegmentedControl({ options, children, name }: SegmentedC
 type SegmentedControlProps = PropsWithChildren<Readonly<{
   name: string
   options: ReadonlyArray<{
-    label: string
     id: string
+    isChecked: boolean
+    label: string
   }>
 }>>

--- a/src/components/shared/Statut/Statut.tsx
+++ b/src/components/shared/Statut/Statut.tsx
@@ -1,6 +1,6 @@
 import { ReactElement } from 'react'
 
-import Badge from '../../shared/Badge/Badge'
+import Badge from '../Badge/Badge'
 
 export default function Statut({ color, libelle }: StatutProps): ReactElement {
   return (

--- a/src/components/testHelper.tsx
+++ b/src/components/testHelper.tsx
@@ -1,6 +1,7 @@
 import { render, RenderResult } from '@testing-library/react'
 import { ReactElement } from 'react'
 import { ToastContainer } from 'react-toastify'
+import { Mock } from 'vitest'
 
 import departements from '../../ressources/departements.json'
 import groupements from '../../ressources/groupements.json'
@@ -68,8 +69,7 @@ export async function structuresFetch(): Promise<Response> {
   } as Response)
 }
 
-export
-const rolesAvecStructure: RolesAvecStructure = {
+export const rolesAvecStructure: RolesAvecStructure = {
   'Gestionnaire département': {
     label: 'Département',
     options: departements.map((departement) => ({ label: departement.nom, value: departement.code })),
@@ -86,4 +86,18 @@ const rolesAvecStructure: RolesAvecStructure = {
     label: 'Structure',
     options: [],
   },
+}
+
+export class FrozenDate extends Date {
+  constructor() {
+    super('1996-04-15T03:24:00')
+  }
+}
+
+export function stubbedConceal() {
+  return (): { modal: { conceal: Mock } } => ({
+    modal: {
+      conceal: vi.fn(),
+    },
+  })
 }

--- a/src/components/transverse/MenuLateral/MenuLateral.test.tsx
+++ b/src/components/transverse/MenuLateral/MenuLateral.test.tsx
@@ -17,6 +17,7 @@ describe('menu lateral', () => {
     const tableauDeBord = within(menuItems[0]).getByRole('link', { name: 'Tableau de bord' })
     expect(tableauDeBord).toHaveAttribute('href', '/tableau-de-bord')
     expect(tableauDeBord).toHaveAttribute('aria-current', 'false')
+    expect(menuItems[0]).not.toHaveClass(`fr-sidemenu__item--active ${styles['element-selectionne']}`)
   })
 
   it.each([

--- a/src/components/transverse/PiedDePage/PiedDePage.tsx
+++ b/src/components/transverse/PiedDePage/PiedDePage.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 import { ReactElement } from 'react'
 
-import ExternalLink from '../../shared/ExternalLink/ExternalLink'
+import ExternalLink from '@/components/shared/ExternalLink/ExternalLink'
 
 export default function PiedDePage(): ReactElement {
   return (

--- a/src/gateways/PrismaGouvernanceLoader.test.ts
+++ b/src/gateways/PrismaGouvernanceLoader.test.ts
@@ -77,6 +77,7 @@ describe('gouvernance loader', () => {
         prenomAuteur: 'Jean',
         texte: '<strong>Note privée (interne)</strong><p>lrutrum metus sodales semper velit habitant dignissim lacus suspendisse magna. Gravida eget egestas odio sit aliquam ultricies accumsan. Felis feugiat nisl sem amet feugiat.</p><p>lrutrum metus sodales semper velit habitant dignissim lacus suspendisse magna. Gravida eget egestas odio sit aliquam ultricies accumsan. Felis feugiat nisl sem amet feugiat.</p>',
       },
+      uid: '123456',
     })
   })
 

--- a/src/gateways/PrismaGouvernanceLoader.ts
+++ b/src/gateways/PrismaGouvernanceLoader.ts
@@ -74,5 +74,6 @@ function transform(gouvernanceRecord: DepartementRecord): UneGouvernanceReadMode
       prenomAuteur: 'Jean',
       texte: '<strong>Note privée (interne)</strong><p>lrutrum metus sodales semper velit habitant dignissim lacus suspendisse magna. Gravida eget egestas odio sit aliquam ultricies accumsan. Felis feugiat nisl sem amet feugiat.</p><p>lrutrum metus sodales semper velit habitant dignissim lacus suspendisse magna. Gravida eget egestas odio sit aliquam ultricies accumsan. Felis feugiat nisl sem amet feugiat.</p>',
     },
+    uid: '123456',
   }
 }

--- a/src/presenters/gouvernancePresenter.ts
+++ b/src/presenters/gouvernancePresenter.ts
@@ -22,6 +22,7 @@ export function gouvernancePresenter(
       ...{ noteDeContexte: toNoteDeContexteViewModel(gouvernanceReadModel.noteDeContexte) },
       sousTitre: buildSousTitreNoteDeContexte(gouvernanceReadModel.noteDeContexte),
     },
+    uid: gouvernanceReadModel.uid,
   }
 }
 
@@ -49,6 +50,7 @@ export type GouvernanceViewModel = Readonly<{
     noteDeContexte?: NoteDeContexteViewModel
     sousTitre: string
   }>
+  uid: string
 }>
 
 function isGouvernanceVide(gouvernanceReadModel: UneGouvernanceReadModel): boolean {

--- a/src/use-cases/commands/InviterUnUtilisateur.test.ts
+++ b/src/use-cases/commands/InviterUnUtilisateur.test.ts
@@ -1,9 +1,9 @@
 import { InviterUnUtilisateur, InviterUnUtilisateurCommand } from './InviterUnUtilisateur'
 import { EmailGateway } from './shared/EmailGateway'
 import { AddUtilisateurRepository, FindUtilisateurRepository } from './shared/UtilisateurRepository'
-import { TypologieRole } from '../../domain/Role'
-import { Utilisateur, UtilisateurUidState } from '../../domain/Utilisateur'
+import { TypologieRole } from '@/domain/Role'
 import { utilisateurFactory } from '@/domain/testHelper'
+import { Utilisateur, UtilisateurUidState } from '@/domain/Utilisateur'
 
 describe('inviter un utilisateur', () => {
   beforeEach(() => {

--- a/src/use-cases/commands/InviterUnUtilisateur.ts
+++ b/src/use-cases/commands/InviterUnUtilisateur.ts
@@ -1,7 +1,7 @@
-import { AddUtilisateurRepository, FindUtilisateurRepository } from './shared/UtilisateurRepository'
-import { TypologieRole } from '../../domain/Role'
 import { CommandHandler, ResultAsync } from '../CommandHandler'
 import { EmailGatewayFactory } from './shared/EmailGateway'
+import { AddUtilisateurRepository, FindUtilisateurRepository } from './shared/UtilisateurRepository'
+import { TypologieRole } from '@/domain/Role'
 import { UtilisateurFactory } from '@/domain/UtilisateurFactory'
 
 export class InviterUnUtilisateur implements CommandHandler<InviterUnUtilisateurCommand> {

--- a/src/use-cases/queries/RecupererUneGouvernance.ts
+++ b/src/use-cases/queries/RecupererUneGouvernance.ts
@@ -13,6 +13,7 @@ export type UneGouvernanceReadModel = Readonly<{
     prenomAuteur: string
     texte: string
   }>
+  uid: string
 }>
 
 export type ComiteReadModel = Readonly<{

--- a/src/use-cases/testHelper.ts
+++ b/src/use-cases/testHelper.ts
@@ -93,6 +93,7 @@ export function gouvernanceReadModelFactory(
       prenomAuteur: 'Jean',
       texte: '<strong>Note privée (interne)</strong><p>lrutrum metus sodales semper velit habitant dignissim lacus suspendisse magna. Gravida eget egestas odio sit aliquam ultricies accumsan. Felis feugiat nisl sem amet feugiat.</p>',
     },
+    uid: 'gouvernanceFooId',
     ...override,
   }
 }


### PR DESCRIPTION
Il manquait :
- la réinitialisation du formulaire après soumission
- l'affichage d'une notification quand succès ou erreur de la soumission
- rendre inactif le bouton de soumission après soumission pour éviter de cliquer plusieurs fois

# Contrat du dev

## Qualité

- [x] Relire le code
- [x] Relire le ticket
- [x] Recetter l'application
- [x] Regarder le commentaire de sonarcloud et corriger s'il est pertinent
- [x] Ajouter des variables d'environnement sur la production au besoin

## Accessibilité

- [x] Vérifier l'accessibilité avec a11y.css
- [x] Vérifier l'accessibilité avec WAVE
- [x] Vérifier l'accessibilité avec Axe
- [x] Vérifier l'accessibilité avec headingMap
- [x] Naviguer au clavier
- [x] Vérifier le constraste en mode sombre

## Facultatif mais fortement conseillé

- [x] Lancer les tests de mutation

> **Et n'oublie pas de vérifier ce que tu as fait en production !**
