### PR TITLE
Gateways : remplacement des dépendances à PrismaClient par celles aux Prisma.XXXRecord

### DIFF
--- a/src/app/(connecte)/(avec-menu)/gouvernance/[codeDepartement]/page.tsx
+++ b/src/app/(connecte)/(avec-menu)/gouvernance/[codeDepartement]/page.tsx
@@ -13,7 +13,7 @@ export default async function GouvernanceController({ params }: Props): Promise<
     notFound()
   }
 
-  const gouvernanceReadModel = await new PrismaGouvernanceLoader(prisma).find(codeDepartement)
+  const gouvernanceReadModel = await new PrismaGouvernanceLoader(prisma.departementRecord).find(codeDepartement)
 
   if (gouvernanceReadModel === null) {
     notFound()

--- a/src/app/(connecte)/(sans-menu)/mes-informations-personnelles/page.tsx
+++ b/src/app/(connecte)/(sans-menu)/mes-informations-personnelles/page.tsx
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
 }
 
 export default async function MesInformationsPersonnellesController(): Promise<ReactElement> {
-  const mesInformationsPersonnellesQuery = new PrismaMesInformationsPersonnellesLoader(prisma)
+  const mesInformationsPersonnellesQuery = new PrismaMesInformationsPersonnellesLoader(prisma.utilisateurRecord)
   const mesInformationsPersonnellesReadModel = await mesInformationsPersonnellesQuery.findByUid(await getSubSession())
   const mesInformationsPersonnellesViewModel =
     mesInformationsPersonnellesPresenter(mesInformationsPersonnellesReadModel)

--- a/src/app/(connecte)/(sans-menu)/mes-utilisateurs/page.tsx
+++ b/src/app/(connecte)/(sans-menu)/mes-utilisateurs/page.tsx
@@ -32,7 +32,7 @@ export default async function MesUtilisateursController({ searchParams }: Props)
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const idStructure = isNullishOrEmpty(structureAwaited) ? {} : { idStructure: +structureAwaited! }
 
-  const utilisateurLoader = new PrismaUtilisateurLoader(prisma)
+  const utilisateurLoader = new PrismaUtilisateurLoader(prisma.utilisateurRecord)
   const rechercherMesUtilisateurs = new RechercherMesUtilisateurs(utilisateurLoader)
   const { utilisateursCourants, total } =
     await rechercherMesUtilisateurs.get({

--- a/src/app/(connecte)/layout.tsx
+++ b/src/app/(connecte)/layout.tsx
@@ -25,8 +25,8 @@ export default async function Layout({ children }: PropsWithChildren): Promise<R
     redirect('/connexion')
   }
 
-  const utilisateurRepository = new PrismaUtilisateurRepository(prisma)
-  const utilisateurLoader = new PrismaUtilisateurLoader(prisma)
+  const utilisateurRepository = new PrismaUtilisateurRepository(prisma.utilisateurRecord)
+  const utilisateurLoader = new PrismaUtilisateurLoader(prisma.utilisateurRecord)
   let utilisateurReadModel: UnUtilisateurReadModel | null
 
   try {

--- a/src/app/api/actions/changerMonRoleAction.ts
+++ b/src/app/api/actions/changerMonRoleAction.ts
@@ -19,7 +19,7 @@ export async function changerMonRoleAction(
     return validationResult.error.issues.map(({ message }) => message)
   }
 
-  const message = await new ChangerMonRole(new PrismaUtilisateurRepository(prisma))
+  const message = await new ChangerMonRole(new PrismaUtilisateurRepository(prisma.utilisateurRecord))
     .execute({
       nouveauRole: validationResult.data.nouveauRole,
       uidUtilisateurCourant: await getSubSession(),

--- a/src/app/api/actions/inviterUnUtilisateurAction.ts
+++ b/src/app/api/actions/inviterUnUtilisateurAction.ts
@@ -21,7 +21,7 @@ export async function inviterUnUtilisateurAction(
   }
 
   const message = await new InviterUnUtilisateur(
-    new PrismaUtilisateurRepository(prisma),
+    new PrismaUtilisateurRepository(prisma.utilisateurRecord),
     emailInvitationGatewayFactory
   ).execute({
     email: validationResult.data.email,

--- a/src/app/api/actions/modifierMesInformationsPersonnellesAction.ts
+++ b/src/app/api/actions/modifierMesInformationsPersonnellesAction.ts
@@ -19,16 +19,17 @@ export async function modifierMesInformationsPersonnellesAction(
     return validationResult.error.issues.map(({ message }) => message)
   }
 
-  const message = await new ModifierMesInformationsPersonnelles(new PrismaUtilisateurRepository(prisma))
-    .execute({
-      modification: {
-        emailDeContact: validationResult.data.emailDeContact,
-        nom: validationResult.data.nom,
-        prenom: validationResult.data.prenom,
-        telephone: validationResult.data.telephone,
-      },
-      uidUtilisateurCourant: await getSubSession(),
-    })
+  const message = await new ModifierMesInformationsPersonnelles(
+    new PrismaUtilisateurRepository(prisma.utilisateurRecord)
+  ).execute({
+    modification: {
+      emailDeContact: validationResult.data.emailDeContact,
+      nom: validationResult.data.nom,
+      prenom: validationResult.data.prenom,
+      telephone: validationResult.data.telephone,
+    },
+    uidUtilisateurCourant: await getSubSession(),
+  })
 
   revalidatePath(actionParams.path)
 

--- a/src/app/api/actions/reinviterUnUtilisateurAction.ts
+++ b/src/app/api/actions/reinviterUnUtilisateurAction.ts
@@ -20,7 +20,7 @@ export async function reinviterUnUtilisateurAction(
   }
 
   const message = await new ReinviterUnUtilisateur(
-    new PrismaUtilisateurRepository(prisma),
+    new PrismaUtilisateurRepository(prisma.utilisateurRecord),
     emailInvitationGatewayFactory
   ).execute({
     uidUtilisateurAReinviter: validationResult.data.uidUtilisateurAReinviter,

--- a/src/app/api/actions/supprimerMonCompteAction.ts
+++ b/src/app/api/actions/supprimerMonCompteAction.ts
@@ -7,7 +7,7 @@ import { ResultAsync } from '@/use-cases/CommandHandler'
 import { SupprimerMonCompte } from '@/use-cases/commands/SupprimerMonCompte'
 
 export async function supprimerMonCompteAction(): ResultAsync<ReadonlyArray<string>> {
-  const message = await new SupprimerMonCompte(new PrismaUtilisateurRepository(prisma))
+  const message = await new SupprimerMonCompte(new PrismaUtilisateurRepository(prisma.utilisateurRecord))
     .execute({ uidUtilisateurCourant: await getSubSession() })
 
   return [message]

--- a/src/app/api/actions/supprimerUnUtilisateurAction.ts
+++ b/src/app/api/actions/supprimerUnUtilisateurAction.ts
@@ -18,7 +18,7 @@ export async function supprimerUnUtilisateurAction(
     return validationResult.error.issues.map(({ message }) => message)
   }
 
-  const message = await new SupprimerUnUtilisateur(new PrismaUtilisateurRepository(prisma))
+  const message = await new SupprimerUnUtilisateur(new PrismaUtilisateurRepository(prisma.utilisateurRecord))
     .execute({
       uidUtilisateurASupprimer: actionParams.uidUtilisateurASupprimer,
       uidUtilisateurCourant: await getSubSession(),

--- a/src/app/api/structures/route.ts
+++ b/src/app/api/structures/route.ts
@@ -15,7 +15,7 @@ export async function GET(request: NextRequest): Promise<NextResponse<Structures
   if (isNullishOrEmpty(search)) {
     return NextResponse.json(null, { status: 400 })
   }
-  const rechercherLesStructures = new RechercherLesStructures(new PrismaStructureLoader(prisma))
+  const rechercherLesStructures = new RechercherLesStructures(new PrismaStructureLoader(prisma.structureRecord))
   const structuresReadModel = await rechercherLesStructures.get({
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     match: search!,

--- a/src/gateways/NextAuthAuthentificationGateway.ts
+++ b/src/gateways/NextAuthAuthentificationGateway.ts
@@ -32,7 +32,7 @@ const nextAuthOptions = {
     },
     async signIn({ profile }): Promise<boolean> {
       if (profile) {
-        const utilisateurRepository = new PrismaUtilisateurRepository(prisma)
+        const utilisateurRepository = new PrismaUtilisateurRepository(prisma.utilisateurRecord)
         if (profile.sub !== undefined) {
           await new MettreAJourDateDeDerniereConnexion(utilisateurRepository, new Date()).execute({
             uidUtilisateurCourant: profile.sub,

--- a/src/gateways/PrismaGouvernanceLoader.test.ts
+++ b/src/gateways/PrismaGouvernanceLoader.test.ts
@@ -22,7 +22,7 @@ describe('gouvernance loader', () => {
       }),
     })
     const codeDepartement = '93'
-    const gouvernanceLoader = new PrismaGouvernanceLoader(prisma)
+    const gouvernanceLoader = new PrismaGouvernanceLoader(prisma.departementRecord)
 
     // WHEN
     const gouvernanceReadModel = await gouvernanceLoader.find(codeDepartement)
@@ -109,7 +109,7 @@ describe('gouvernance loader', () => {
       }),
     })
     const codeDepartementInexistant = 'zzz'
-    const gouvernanceLoader = new PrismaGouvernanceLoader(prisma)
+    const gouvernanceLoader = new PrismaGouvernanceLoader(prisma.departementRecord)
 
     // WHEN
     const gouvernanceReadModel = await gouvernanceLoader.find(codeDepartementInexistant)

--- a/src/gateways/PrismaGouvernanceLoader.ts
+++ b/src/gateways/PrismaGouvernanceLoader.ts
@@ -1,16 +1,16 @@
-import { DepartementRecord, PrismaClient } from '@prisma/client'
+import { DepartementRecord, Prisma } from '@prisma/client'
 
 import { UneGouvernanceReadModel, UneGouvernanceReadModelLoader } from '@/use-cases/queries/RecupererUneGouvernance'
 
 export class PrismaGouvernanceLoader implements UneGouvernanceReadModelLoader {
-  readonly #prisma: PrismaClient
+  readonly #dataResource: Prisma.DepartementRecordDelegate
 
-  constructor(prisma: PrismaClient) {
-    this.#prisma = prisma
+  constructor(dataResource: Prisma.DepartementRecordDelegate) {
+    this.#dataResource = dataResource
   }
 
   async find(codeDepartement: string): Promise<UneGouvernanceReadModel | null> {
-    const gouvernanceRecord = await this.#prisma.departementRecord.findUnique({
+    const gouvernanceRecord = await this.#dataResource.findUnique({
       where: {
         code: codeDepartement,
       },

--- a/src/gateways/PrismaMesInformationsPersonnellesLoader.test.ts
+++ b/src/gateways/PrismaMesInformationsPersonnellesLoader.test.ts
@@ -48,7 +48,7 @@ describe('mes informations personnelles loader', () => {
         ssoId: ssoIdExistant,
       }),
     })
-    const mesInformationsPersonnellesLoader = new PrismaMesInformationsPersonnellesLoader(prisma)
+    const mesInformationsPersonnellesLoader = new PrismaMesInformationsPersonnellesLoader(prisma.utilisateurRecord)
 
     // WHEN
     const mesInformationsPersonnellesReadModel = await mesInformationsPersonnellesLoader.findByUid(ssoIdExistant)
@@ -83,7 +83,7 @@ describe('mes informations personnelles loader', () => {
         structureId,
       }),
     })
-    const mesInformationsPersonnellesLoader = new PrismaMesInformationsPersonnellesLoader(prisma)
+    const mesInformationsPersonnellesLoader = new PrismaMesInformationsPersonnellesLoader(prisma.utilisateurRecord)
 
     // WHEN
     const mesInformationsPersonnellesReadModel = await mesInformationsPersonnellesLoader.findByUid(ssoIdExistant)
@@ -116,7 +116,7 @@ describe('mes informations personnelles loader', () => {
     await prisma.utilisateurRecord.create({
       data: utilisateurRecordFactory(),
     })
-    const mesInformationsPersonnellesGateway = new PrismaMesInformationsPersonnellesLoader(prisma)
+    const mesInformationsPersonnellesGateway = new PrismaMesInformationsPersonnellesLoader(prisma.utilisateurRecord)
 
     // WHEN
     const utilisateurReadModel =

--- a/src/gateways/PrismaMesInformationsPersonnellesLoader.ts
+++ b/src/gateways/PrismaMesInformationsPersonnellesLoader.ts
@@ -1,18 +1,18 @@
-import { PrismaClient } from '@prisma/client'
+import { Prisma } from '@prisma/client'
 
 import { UtilisateurEtSesRelationsRecord, toTypologieRole } from './shared/RoleMapper'
 import { UtilisateurNonTrouveError } from '@/use-cases/queries/RechercherUnUtilisateur'
 import { MesInformationsPersonnellesReadModel, MesInformationsPersonnellesLoader } from '@/use-cases/queries/RecupererMesInformationsPersonnelles'
 
 export class PrismaMesInformationsPersonnellesLoader implements MesInformationsPersonnellesLoader {
-  readonly #prisma: PrismaClient
+  readonly dataResource: Prisma.UtilisateurRecordDelegate
 
-  constructor(prisma: PrismaClient) {
-    this.#prisma = prisma
+  constructor(dataResource: Prisma.UtilisateurRecordDelegate) {
+    this.dataResource = dataResource
   }
 
   async findByUid(uid: string): Promise<MesInformationsPersonnellesReadModel> {
-    const utilisateurRecord = await this.#prisma.utilisateurRecord.findUnique({
+    const utilisateurRecord = await this.dataResource.findUnique({
       include: {
         relationDepartement: true,
         relationGroupement: true,

--- a/src/gateways/PrismaStructureLoader.test.ts
+++ b/src/gateways/PrismaStructureLoader.test.ts
@@ -55,7 +55,7 @@ describe('structures loader', () => {
     ])('alors $intention', async ({ match, expected }) => {
       // GIVEN
       await createStructures()
-      const structureLoader = new PrismaStructureLoader(prisma)
+      const structureLoader = new PrismaStructureLoader(prisma.structureRecord)
 
       // WHEN
       const structureReadModel = await structureLoader.findStructures(match)
@@ -67,7 +67,7 @@ describe('structures loader', () => {
     it('et un département, alors seules les structures appartenant à ce département sont remontées', async () => {
       // GIVEN
       await createStructures()
-      const structureLoader = new PrismaStructureLoader(prisma)
+      const structureLoader = new PrismaStructureLoader(prisma.structureRecord)
 
       // WHEN
       const structureReadModel = await structureLoader.findStructuresByDepartement('ris', '06')
@@ -85,7 +85,7 @@ describe('structures loader', () => {
     it('et une région, alors seules les structures appartenant à un département appartenant à cette région sont remontées', async () => {
       // GIVEN
       await createStructures()
-      const structureLoader = new PrismaStructureLoader(prisma)
+      const structureLoader = new PrismaStructureLoader(prisma.structureRecord)
 
       // WHEN
       const structureReadModel = await structureLoader.findStructuresByRegion('ris', '93')

--- a/src/gateways/PrismaStructureLoader.ts
+++ b/src/gateways/PrismaStructureLoader.ts
@@ -1,12 +1,12 @@
-import { StructureRecord, PrismaClient, Prisma } from '@prisma/client'
+import { Prisma, StructureRecord } from '@prisma/client'
 
 import { StructureLoader, StructuresReadModel } from '../use-cases/queries/RechercherLesStructures'
 
 export class PrismaStructureLoader implements StructureLoader {
-  readonly #prisma: PrismaClient
+  readonly #dataResource: Prisma.StructureRecordDelegate
 
-  constructor(prisma: PrismaClient) {
-    this.#prisma = prisma
+  constructor(dataResource: Prisma.StructureRecordDelegate) {
+    this.#dataResource = dataResource
   }
 
   async findStructures(match: string): Promise<StructuresReadModel> {
@@ -35,7 +35,7 @@ export class PrismaStructureLoader implements StructureLoader {
     match: string,
     where: Prisma.StructureRecordWhereInput = {}
   ): Promise<ReadonlyArray<StructureRecord>> {
-    return this.#prisma.structureRecord.findMany({
+    return this.#dataResource.findMany({
       orderBy: {
         nom: 'asc',
       },

--- a/src/gateways/PrismaUtilisateurLoader.test.ts
+++ b/src/gateways/PrismaUtilisateurLoader.test.ts
@@ -126,7 +126,7 @@ describe('prisma utilisateur query', () => {
           structureId: 10,
         }),
       })
-      const utilisateurLoader = new PrismaUtilisateurLoader(prisma)
+      const utilisateurLoader = new PrismaUtilisateurLoader(prisma.utilisateurRecord)
 
       // WHEN
       const utilisateurReadModel = await utilisateurLoader.findByUid(ssoIdExistant)
@@ -157,7 +157,7 @@ describe('prisma utilisateur query', () => {
       await prisma.utilisateurRecord.create({
         data: utilisateurRecordFactory({ ssoId: '1234567890' }),
       })
-      const utilisateurLoader = new PrismaUtilisateurLoader(prisma)
+      const utilisateurLoader = new PrismaUtilisateurLoader(prisma.utilisateurRecord)
 
       // WHEN
       const utilisateurReadModel =
@@ -173,7 +173,7 @@ describe('prisma utilisateur query', () => {
       await prisma.utilisateurRecord.create({
         data: utilisateurRecordFactory({ isSupprime: true, ssoId: ssoIdExistant }),
       })
-      const utilisateurLoader = new PrismaUtilisateurLoader(prisma)
+      const utilisateurLoader = new PrismaUtilisateurLoader(prisma.utilisateurRecord)
 
       // WHEN
       const utilisateurReadModel =
@@ -813,7 +813,7 @@ describe('prisma utilisateur query', () => {
       uid: ssoId,
     })
     const roles: ReadonlyArray<string> = []
-    const utilisateurLoader = new PrismaUtilisateurLoader(prisma)
+    const utilisateurLoader = new PrismaUtilisateurLoader(prisma.utilisateurRecord)
     const codeDepartement = '0'
     const codeRegion = '0'
   })

--- a/src/gateways/PrismaUtilisateurLoader.ts
+++ b/src/gateways/PrismaUtilisateurLoader.ts
@@ -1,4 +1,4 @@
-import { $Enums, Prisma, PrismaClient } from '@prisma/client'
+import { $Enums, Prisma } from '@prisma/client'
 
 import { organisation, toTypologieRole, UtilisateurEtSesRelationsRecord } from './shared/RoleMapper'
 import { Role } from '@/domain/Role'
@@ -8,10 +8,10 @@ import { UtilisateurNonTrouveError } from '@/use-cases/queries/RechercherUnUtili
 import { UnUtilisateurReadModel } from '@/use-cases/queries/shared/UnUtilisateurReadModel'
 
 export class PrismaUtilisateurLoader implements MesUtilisateursLoader {
-  readonly #prisma: PrismaClient
+  readonly #dataResource: Prisma.UtilisateurRecordDelegate
 
-  constructor(prisma: PrismaClient) {
-    this.#prisma = prisma
+  constructor(dataResource: Prisma.UtilisateurRecordDelegate) {
+    this.#dataResource = dataResource
   }
 
   async findMesUtilisateursEtLeTotal(
@@ -89,14 +89,14 @@ export class PrismaUtilisateurLoader implements MesUtilisateursLoader {
       }
     }
 
-    const total = await this.#prisma.utilisateurRecord.count({
+    const total = await this.#dataResource.count({
       where: {
         ...where,
         isSupprime: false,
       },
     })
 
-    const utilisateursRecord = await this.#prisma.utilisateurRecord.findMany({
+    const utilisateursRecord = await this.#dataResource.findMany({
       include: {
         relationDepartement: true,
         relationGroupement: true,
@@ -121,7 +121,7 @@ export class PrismaUtilisateurLoader implements MesUtilisateursLoader {
   }
 
   async findByUid(uid: string): Promise<UnUtilisateurReadModel> {
-    const utilisateurRecord = await this.#prisma.utilisateurRecord.findUnique({
+    const utilisateurRecord = await this.#dataResource.findUnique({
       include: {
         relationDepartement: true,
         relationGroupement: true,

--- a/src/gateways/PrismaUtilisateurRepository.test.ts
+++ b/src/gateways/PrismaUtilisateurRepository.test.ts
@@ -1,4 +1,4 @@
-import { Prisma, PrismaClient } from '@prisma/client'
+import { Prisma } from '@prisma/client'
 
 import { PrismaUtilisateurRepository } from './PrismaUtilisateurRepository'
 import {
@@ -23,7 +23,7 @@ describe('utilisateur repository', () => {
   afterEach(async () => prisma.$queryRaw`ROLLBACK TRANSACTION`)
 
   describe('recherche d’un utilisateur', () => {
-    const repository = new PrismaUtilisateurRepository(prisma)
+    const repository = new PrismaUtilisateurRepository(prisma.utilisateurRecord)
 
     it('l’utilisateur n’existe pas : pas de donnée', async () => {
       // GIVEN
@@ -259,7 +259,7 @@ describe('utilisateur repository', () => {
 
         // WHEN
         const result = await dropFn(
-          new PrismaUtilisateurRepository(prisma),
+          new PrismaUtilisateurRepository(prisma.utilisateurRecord),
           ssoIdUtilisateurExistant
         )
 
@@ -299,7 +299,7 @@ describe('utilisateur repository', () => {
 
         // WHEN
         const result = await dropFn(
-          new PrismaUtilisateurRepository(prisma),
+          new PrismaUtilisateurRepository(prisma.utilisateurRecord),
           ssoIdUtilisateurSupprime
         )
 
@@ -319,7 +319,7 @@ describe('utilisateur repository', () => {
 
         // WHEN
         const result = await dropFn(
-          new PrismaUtilisateurRepository(prisma),
+          new PrismaUtilisateurRepository(prisma.utilisateurRecord),
           ssoIdUtilisateurExistant
         )
 
@@ -334,22 +334,18 @@ describe('utilisateur repository', () => {
       it('erreur inattendue : non gérée', async () => {
         // GIVEN
         const prismaClientKnownRequestErrorOnUpdateStub = {
-          utilisateurRecord: {
+          async update(): Promise<never> {
             // Sonar ne voit pas que c'est une Error car le fichier Prisma est dans node_module
-            async update(): Promise<never> {
-              return Promise.reject( // NOSONAR
-                new Prisma.PrismaClientKnownRequestError('', { clientVersion: '', code: 'P1000' })
-              )
-            },
+            return Promise.reject( // NOSONAR
+              new Prisma.PrismaClientKnownRequestError('', { clientVersion: '', code: 'P1000' })
+            )
           },
-        } as unknown as typeof prisma
+        } as unknown as Prisma.UtilisateurRecordDelegate
         const prismaClientUnknownRequestErrorOnUpdateStub = {
-          utilisateurRecord: {
-            async update(): Promise<never> {
-              return Promise.reject(new Error('error'))
-            },
+          async update(): Promise<never> {
+            return Promise.reject(new Error('error'))
           },
-        } as unknown as typeof prisma
+        } as unknown as Prisma.UtilisateurRecordDelegate
 
         // WHEN
         const unhandledKnownRequestError = dropFn(
@@ -369,7 +365,7 @@ describe('utilisateur repository', () => {
   })
 
   describe('mise à jour d’un utilisateur', () => {
-    const repository = new PrismaUtilisateurRepository(prisma)
+    const repository = new PrismaUtilisateurRepository(prisma.utilisateurRecord)
 
     it('changement du rôle, du nom, du prénom, de la date d’invitation, de la date de dernière connexion et de l’email', async () => {
       // GIVEN
@@ -409,7 +405,7 @@ describe('utilisateur repository', () => {
   describe('mise à jour de l’identifiant unique d’un utilisateur', () => {
     it('changement de l’identifiant unique', async () => {
       // GIVEN
-      const repository = new PrismaUtilisateurRepository(prisma)
+      const repository = new PrismaUtilisateurRepository(prisma.utilisateurRecord)
       await prisma.utilisateurRecord.create({
         data: utilisateurRecordFactory({
           ssoEmail: 'martine.dugenoux@example.org',
@@ -433,7 +429,7 @@ describe('utilisateur repository', () => {
   })
 
   describe('ajout d’un utilisateur', () => {
-    const repository = new PrismaUtilisateurRepository(prisma)
+    const repository = new PrismaUtilisateurRepository(prisma.utilisateurRecord)
     const structureId = 10
     const departementCode = '75'
     const groupementId = 10
@@ -499,26 +495,22 @@ describe('utilisateur repository', () => {
     it('erreur non gérée', async () => {
       // GIVEN
       const prismaClientAuthenticationFailedErrorStub = {
-        utilisateurRecord: {
-          async create(): Promise<never> {
-            // Sonar ne voit pas que c'est une Error car le fichier Prisma est dans node_module
-            return Promise.reject( // NOSONAR
-              new Prisma.PrismaClientKnownRequestError('authentication failed', {
-                clientVersion: '',
-                code: 'P1000',
-              })
-            )
-          },
+        async create(): Promise<never> {
+          // Sonar ne voit pas que c'est une Error car le fichier Prisma est dans node_module
+          return Promise.reject( // NOSONAR
+            new Prisma.PrismaClientKnownRequestError('authentication failed', {
+              clientVersion: '',
+              code: 'P1000',
+            })
+          )
         },
-      } as unknown as PrismaClient
+      } as unknown as Prisma.UtilisateurRecordDelegate
 
       const prismaClientGenericErrorStub = {
-        utilisateurRecord: {
-          async create(): Promise<never> {
-            return Promise.reject(new Error('generic error'))
-          },
+        async create(): Promise<never> {
+          return Promise.reject(new Error('generic error'))
         },
-      } as unknown as PrismaClient
+      } as unknown as Prisma.UtilisateurRecordDelegate
 
       const repositoryGenericError = new PrismaUtilisateurRepository(prismaClientGenericErrorStub)
       const repositoryAuthenticationError = new PrismaUtilisateurRepository(

--- a/src/gateways/PrismaUtilisateurRepository.ts
+++ b/src/gateways/PrismaUtilisateurRepository.ts
@@ -1,4 +1,4 @@
-import { Prisma, PrismaClient } from '@prisma/client'
+import { Prisma } from '@prisma/client'
 
 import { fromTypologieRole, toTypologieRole, UtilisateurEtSesRelationsRecord } from './shared/RoleMapper'
 import { DepartementState } from '@/domain/Departement'
@@ -7,17 +7,17 @@ import { UtilisateurFactory } from '@/domain/UtilisateurFactory'
 import { UtilisateurRepository } from '@/use-cases/commands/shared/UtilisateurRepository'
 
 export class PrismaUtilisateurRepository implements UtilisateurRepository {
-  readonly #activeRecord: Prisma.UtilisateurRecordDelegate
+  readonly #dataResource: Prisma.UtilisateurRecordDelegate
 
-  constructor(dbClient: PrismaClient) {
-    this.#activeRecord = dbClient.utilisateurRecord
+  constructor(dataResource: Prisma.UtilisateurRecordDelegate) {
+    this.#dataResource = dataResource
   }
 
   async add(utilisateur: Utilisateur): Promise<boolean> {
     const utilisateurState = utilisateur.state
 
     try {
-      await this.#activeRecord.create({
+      await this.#dataResource.create({
         data: {
           dateDeCreation: utilisateurState.inviteLe,
           departementCode: utilisateurState.departement?.code,
@@ -48,7 +48,7 @@ export class PrismaUtilisateurRepository implements UtilisateurRepository {
   }
 
   async find(uid: UtilisateurUidState['value']): Promise<Utilisateur | null> {
-    const record = await this.#activeRecord.findUnique({
+    const record = await this.#dataResource.findUnique({
       include: {
         relationDepartement: true,
         relationGroupement: true,
@@ -90,7 +90,7 @@ export class PrismaUtilisateurRepository implements UtilisateurRepository {
   async update(utilisateur: Utilisateur): Promise<void> {
     const utilisateurState = utilisateur.state
 
-    await this.#activeRecord.update({
+    await this.#dataResource.update({
       data: {
         derniereConnexion: utilisateurState.derniereConnexion,
         emailDeContact: utilisateurState.emailDeContact,
@@ -109,7 +109,7 @@ export class PrismaUtilisateurRepository implements UtilisateurRepository {
   async updateUid(utilisateur: Utilisateur): Promise<void> {
     const utilisateurState = utilisateur.state
 
-    await this.#activeRecord.update({
+    await this.#dataResource.update({
       data: {
         ssoId: utilisateurState.uid.value,
       },
@@ -120,7 +120,7 @@ export class PrismaUtilisateurRepository implements UtilisateurRepository {
   }
 
   async #drop(ssoId: string): Promise<boolean> {
-    return this.#activeRecord
+    return this.#dataResource
       .update({
         data: {
           isSupprime: true,


### PR DESCRIPTION
Cela permet de réduire la portée des resources auxquelles les gateways ont accès. Par exemple, un gateway de structures a besoin de la resource de données "structure", et ainsi ne doit pas pouvoir intéragir avec une resource de données "utilisateurs".

# Contrat du dev

## Qualité

- [x] Relire le code
- ~~[ ] Relire le ticket~~
- [x] Recetter l'application
- [x] Regarder le commentaire de sonarcloud et corriger s'il est pertinent
- ~~[ ] Ajouter des variables d'environnement sur la production au besoin~~

## Accessibilité

- ~~[ ] Vérifier l'accessibilité avec a11y.css~~
- ~~[ ] Vérifier l'accessibilité avec WAVE~~
- ~~[ ] Vérifier l'accessibilité avec Axe~~
- ~~[ ] Vérifier l'accessibilité avec headingMap~~
- ~~[ ] Naviguer au clavier~~
- ~~[ ] Vérifier le constraste en mode sombre~~

## Facultatif mais fortement conseillé

- [x] Lancer les tests de mutation

> **Et n'oublie pas de vérifier ce que tu as fait en production !**
