### PR TITLE
Changement de configuration dans vitest : environment par environmentMatchGlobs pour ne pas avoir jsdom pour les tests du back et gagner du temps

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -47,7 +47,7 @@ export default defineConfig({
         statements: [90, 100],
       },
     },
-    environment: 'jsdom',
+    environmentMatchGlobs: [['src/components/**', 'jsdom']],
     globals: true,
     include: ['src/**/*.test.ts?(x)'],
     sequence: { shuffle: true },


### PR DESCRIPTION
Documentation de [environmentOptions](https://vitest.dev/config/#environmentmatchglobs)

- Duration 19.00s (transform 3.82s, setup 24.21s, collect 28.31s, tests 21.82s, environment 34.26s, prepare 6.81s)
- Duration 17.74s (transform 4.64s, setup 27.52s, collect 33.91s, tests 24.79s, environment 15.69s, prepare 7.95s)
- on gagne du coup 2 petites secs mais au moins, le jsdom n'est utilisé que pour les tests React

# Contrat du dev

## Qualité

- [x] Relire le code
- [x] Relire le ticket
- [x] [Relire les critères d'acceptation](https://github.com/anct-cnum/suite-gestionnaire-numerique/discussions/252)
- [x] Vérifier le coverage
- [x] Recetter l'application
- [x] Regarder le commentaire de sonarcloud et corriger s'il est pertinent
- [x] Ajouter des variables d'environnement sur la production au besoin

## Accessibilité

- [x] Vérifier l'accessibilité avec a11y.css, WAVE, Axe, headingMap
- [x] Naviguer au clavier
- [x] Vérifier le constraste en mode sombre

## Facultatif mais fortement conseillé

- [x] Lancer les tests de mutation

> **Et n'oublie pas de vérifier ce que tu as fait en production !**
