### PR TITLE
Simplification des tests en créant des petites fonctions helper

### DIFF
--- a/src/components/Connexion/Connexion.test.tsx
+++ b/src/components/Connexion/Connexion.test.tsx
@@ -1,18 +1,17 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import * as nextAuth from 'next-auth/react'
 
 import Connexion from './Connexion'
+import { presserLeBouton } from '../testHelper'
 
 describe('connexion : en tant qu’utilisateur non authentifié', () => {
   it('quand j’affiche une page quelconque alors je peux m’authentifier', () => {
     // GIVEN
     vi.spyOn(nextAuth, 'signIn').mockImplementationOnce(vi.fn())
-
     render(<Connexion idProvider="pro-connect" />)
-    const boutonSeConnecter = screen.getByRole('button', { name: 'S’identifier avec ProConnect' })
 
     // WHEN
-    fireEvent.click(boutonSeConnecter)
+    const boutonSeConnecter = presserLeBouton('S’identifier avec ProConnect')
 
     // THEN
     expect(boutonSeConnecter).toHaveAttribute('type', 'button')

--- a/src/components/Gouvernance/Comitologie/ComitologieRemplie.tsx
+++ b/src/components/Gouvernance/Comitologie/ComitologieRemplie.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { ReactElement } from 'react'
 
 import Table from '@/components/shared/Table/Table'

--- a/src/components/Gouvernance/FeuilleDeRoute/FeuilleDeRoute.test.tsx
+++ b/src/components/Gouvernance/FeuilleDeRoute/FeuilleDeRoute.test.tsx
@@ -1,13 +1,14 @@
-import { fireEvent, within, screen, render } from '@testing-library/react'
+import { within, screen, render } from '@testing-library/react'
 
 import Gouvernance from '../Gouvernance'
+import { presserLeBouton } from '@/components/testHelper'
 import { gouvernancePresenter } from '@/presenters/gouvernancePresenter'
 import { gouvernanceReadModelFactory } from '@/use-cases/testHelper'
 
 describe('feuille de route', () => {
   it('quand je clique sur une feuille de route, alors un drawer s’ouvre avec les détails de la feuille de route', () => {
     // GIVEN
-    const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModelFactory({
+    afficherUneGouvernance({
       feuillesDeRoute: [
         {
           beneficiairesSubvention: [{ nom: 'Préfecture du Rhône', roles: ['Porteur'], type: 'Structure' }, { nom: 'CC des Monts du Lyonnais', roles: ['Porteur'], type: 'Structure' }],
@@ -17,12 +18,11 @@ describe('feuille de route', () => {
           montantSubventionDemande: 115_000,
           montantSubventionFormationAccorde: 5_000,
           nom: 'Feuille de route inclusion 1',
-          porteur: { nom: 'Préfecture du Rhône', roles: ['Co-orteur'], type: 'Administration' },
+          porteur: { nom: 'Préfecture du Rhône', roles: ['Co-porteur'], type: 'Administration' },
           totalActions: 3,
         },
       ],
-    }))
-    render(<Gouvernance gouvernanceViewModel={gouvernanceViewModel} />)
+    })
 
     // WHEN
     jOuvreLesDetailsDUneFeuilleDeRoute()
@@ -77,7 +77,7 @@ describe('feuille de route', () => {
 
   it('quand je suis dans le détail d’une feuille de route, s’il n’y a pas de bénéficiaire de subvention alors un tiret est affiché à la place de la liste des bénéficiaires et les labels sont au singulier', () => {
     // GIVEN
-    const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModelFactory({
+    afficherUneGouvernance({
       feuillesDeRoute: [
         {
           beneficiairesSubvention: [],
@@ -87,12 +87,11 @@ describe('feuille de route', () => {
           montantSubventionDemande: 15_000,
           montantSubventionFormationAccorde: 0,
           nom: 'Feuille de route inclusion 1',
-          porteur: { nom: 'Préfecture du Rhône', roles: ['Co-orteur'], type: 'Administration' },
+          porteur: { nom: 'Préfecture du Rhône', roles: ['Co-porteur'], type: 'Administration' },
           totalActions: 1,
         },
       ],
-    }))
-    render(<Gouvernance gouvernanceViewModel={gouvernanceViewModel} />)
+    })
 
     // WHEN
     jOuvreLesDetailsDUneFeuilleDeRoute()
@@ -109,7 +108,7 @@ describe('feuille de route', () => {
 
   it('quand je clique sur une feuille de route puis que je clique sur fermer, alors le drawer se ferme', () => {
     // GIVEN
-    const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModelFactory({
+    afficherUneGouvernance({
       feuillesDeRoute: [
         {
           beneficiairesSubvention: [{ nom: 'Préfecture du Rhône', roles: ['Porteur'], type: 'Structure' }, { nom: 'CC des Monts du Lyonnais', roles: ['Porteur'], type: 'Structure' }],
@@ -119,27 +118,31 @@ describe('feuille de route', () => {
           montantSubventionDemande: 115_000,
           montantSubventionFormationAccorde: 5_000,
           nom: 'Feuille de route inclusion 1',
-          porteur: { nom: 'Préfecture du Rhône', roles: ['Co-orteur'], type: 'Administration' },
+          porteur: { nom: 'Préfecture du Rhône', roles: ['Co-porteur'], type: 'Administration' },
           totalActions: 3,
         },
       ],
-    }))
-    render(<Gouvernance gouvernanceViewModel={gouvernanceViewModel} />)
+    })
 
     // WHEN
     jOuvreLesDetailsDUneFeuilleDeRoute()
+    const drawer = screen.getByRole('dialog', { name: 'Feuille de route inclusion 1' })
     jeFermeLesDetailsDUneFeuilleDeRoute()
 
     // THEN
-    const drawer = screen.queryByRole('dialog', { name: 'Feuille de route inclusion 1' })
-    expect(drawer).not.toBeInTheDocument()
+    expect(drawer).not.toBeVisible()
   })
 
   function jOuvreLesDetailsDUneFeuilleDeRoute(): void {
-    fireEvent.click(screen.getByRole('button', { name: 'Feuille de route inclusion 1' }))
+    presserLeBouton('Feuille de route inclusion 1')
   }
 
   function jeFermeLesDetailsDUneFeuilleDeRoute(): void {
-    fireEvent.click(screen.getByRole('button', { name: 'Fermer les détails de la feuille de route' }))
+    presserLeBouton('Fermer les détails de la feuille de route')
+  }
+
+  function afficherUneGouvernance(override?: Partial<Parameters<typeof gouvernanceReadModelFactory>[0]>): void {
+    const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModelFactory(override))
+    render(<Gouvernance gouvernanceViewModel={gouvernanceViewModel} />)
   }
 })

--- a/src/components/Gouvernance/Gouvernance.test.tsx
+++ b/src/components/Gouvernance/Gouvernance.test.tsx
@@ -1,7 +1,7 @@
-import { fireEvent, render, screen, within } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 
 import Gouvernance from './Gouvernance'
-import { matchWithoutMarkup } from '../testHelper'
+import { matchWithoutMarkup, presserLeBouton } from '../testHelper'
 import { gouvernancePresenter } from '@/presenters/gouvernancePresenter'
 import { gouvernanceReadModelFactory } from '@/use-cases/testHelper'
 
@@ -76,8 +76,7 @@ describe('gouvernance', () => {
     render(<Gouvernance gouvernanceViewModel={gouvernanceViewModel} />)
 
     // WHEN
-    const ajouterUnComite = screen.getByRole('button', { name: 'Ajouter un comité' })
-    fireEvent.click(ajouterUnComite)
+    jOuvreLeFormulairePourAjouterUnComite()
 
     // THEN
     const ajouterUnComiteDrawer = screen.getByRole('dialog', { name: 'Ajouter un comité' })
@@ -91,11 +90,11 @@ describe('gouvernance', () => {
 
     // WHEN
     jOuvreLeFormulairePourAjouterUnComite()
+    const drawer = screen.getByRole('dialog', { name: 'Ajouter un comité' })
     jeFermeLeFormulairePourAjouterUnComite()
 
     // THEN
-    const drawer = screen.queryByRole('dialog', { name: 'Ajouter un comité' })
-    expect(drawer).not.toBeInTheDocument()
+    expect(drawer).not.toBeVisible()
   })
 
   it('quand j’affiche une gouvernance avec au moins un comité, alors elle s’affiche avec sa section comitologie', () => {
@@ -487,8 +486,7 @@ describe('gouvernance', () => {
     render(<Gouvernance gouvernanceViewModel={gouvernanceViewModel} />)
 
     // WHEN
-    const lirePlus = screen.getByRole('button', { name: 'Lire plus' })
-    fireEvent.click(lirePlus)
+    const lirePlus = jeDeplieLaNoteDeContexte()
 
     // THEN
     expect(lirePlus).toHaveClass('fr-icon-arrow-up-s-line')
@@ -525,10 +523,14 @@ describe('gouvernance', () => {
   })
 
   function jOuvreLeFormulairePourAjouterUnComite(): void {
-    fireEvent.click(screen.getByRole('button', { name: 'Ajouter un comité' }))
+    presserLeBouton('Ajouter un comité')
   }
 
   function jeFermeLeFormulairePourAjouterUnComite(): void {
-    fireEvent.click(screen.getByRole('button', { name: 'Fermer le formulaire de création d’un comité' }))
+    presserLeBouton('Fermer le formulaire de création d’un comité')
+  }
+
+  function jeDeplieLaNoteDeContexte(): HTMLElement {
+    return presserLeBouton('Lire plus')
   }
 })

--- a/src/components/Gouvernance/Membre/Membre.test.tsx
+++ b/src/components/Gouvernance/Membre/Membre.test.tsx
@@ -27,11 +27,11 @@ describe('membres', () => {
 
     // WHEN
     jOuvreLesDetailsDUnMembre()
+    const drawer = screen.getByRole('dialog', { name: 'Préfecture du Rhône' })
     jeFermeLesDetailsDUnMembre()
 
     // THEN
-    const drawer = screen.queryByRole('dialog', { name: 'Préfecture du Rhône' })
-    expect(drawer).not.toBeInTheDocument()
+    expect(drawer).not.toBeVisible()
   })
 
   function afficherGouvernance(): void {

--- a/src/components/MesInformationsPersonnelles/MesInformationsPersonnelles.tsx
+++ b/src/components/MesInformationsPersonnelles/MesInformationsPersonnelles.tsx
@@ -197,7 +197,7 @@ export default function MesInformationsPersonnelles(
           </button>
         </section>
         <SupprimerMonCompte
-          closeDrawer={() => {
+          closeModal={() => {
             setIsModalOpen(false)
           }}
           email={mesInformationsPersonnellesViewModel.emailDeContact}

--- a/src/components/MesInformationsPersonnelles/SupprimerMonCompte.tsx
+++ b/src/components/MesInformationsPersonnelles/SupprimerMonCompte.tsx
@@ -8,7 +8,7 @@ import ModalTitle from '../shared/ModalTitle/ModalTitle'
 import SubmitButton from '../shared/SubmitButton/SubmitButton'
 import { emailPattern } from '@/shared/patterns'
 
-export default function SupprimerMonCompte({ id, email, isOpen, closeDrawer }: Props): ReactElement {
+export default function SupprimerMonCompte({ id, email, isOpen, closeModal }: Props): ReactElement {
   const { supprimerMonCompteAction } = useContext(clientContext)
   const [emailValidationInfo, setEmailValidationInfo] =
     useState<EmailValidationInfo>(emailValidationInfoByState.invalid)
@@ -92,7 +92,7 @@ export default function SupprimerMonCompte({ id, email, isOpen, closeDrawer }: P
 
   function close(): void {
     setEmailValidationInfo(emailValidationInfoByState.invalid)
-    closeDrawer()
+    closeModal()
   }
 
   function handleInput({ currentTarget }: FormEvent<HTMLInputElement>): void {
@@ -118,7 +118,7 @@ type Props = Readonly<{
   id: string
   email: string
   isOpen: boolean
-  closeDrawer(): void
+  closeModal(): void
 }>
 
 type EmailValidationState = 'correct' | 'incorrect' | 'invalid'

--- a/src/components/MesParametres/MesParametres.test.tsx
+++ b/src/components/MesParametres/MesParametres.test.tsx
@@ -3,7 +3,6 @@ import { render, screen, within } from '@testing-library/react'
 import MesParametres from './MesParametres'
 
 describe('mes paramètres : en tant qu’utilisateur authentifié', () => {
-  // GIVEN
   describe('quand je me rends sur la page de visualisation et personnalisation de mes paramètres de compte', () => {
     const titre = 'Mes paramètres de compte'
     const sousTitre = 'Retrouvez ici, vos préférences de communication et d’affichage.'

--- a/src/components/MesUtilisateurs/InviterUnUtilisateur.test.tsx
+++ b/src/components/MesUtilisateurs/InviterUnUtilisateur.test.tsx
@@ -1,41 +1,17 @@
 import { fireEvent, screen, waitFor, within } from '@testing-library/react'
-import { select } from 'react-select-event'
 
 import MesUtilisateurs from './MesUtilisateurs'
-import { renderComponent, matchWithoutMarkup, structuresFetch, rolesAvecStructure, stubbedConceal } from '@/components/testHelper'
+import { renderComponent, matchWithoutMarkup, structuresFetch, rolesAvecStructure, stubbedConceal, presserLeBouton, saisirLeTexte, selectionnerLElement } from '@/components/testHelper'
 import { mesUtilisateursPresenter } from '@/presenters/mesUtilisateursPresenter'
 import { sessionUtilisateurViewModelFactory } from '@/presenters/testHelper'
 
 describe('inviter un utilisateur', () => {
-  const totalUtilisateur = 11
-
   it('en tant qu’administrateur, quand je clique sur le bouton inviter, alors le drawer s’ouvre avec tous les rôles sélectionnables', async () => {
     // GIVEN
-    const mesUtilisateursViewModel = mesUtilisateursPresenter([], 'fooId', totalUtilisateur, rolesAvecStructure)
-    renderComponent(<MesUtilisateurs mesUtilisateursViewModel={mesUtilisateursViewModel} />, {
-      sessionUtilisateurViewModel: sessionUtilisateurViewModelFactory({
-        role: {
-          doesItBelongToGroupeAdmin: true,
-          libelle: 'Rhône',
-          nom: 'Administrateur dispositif',
-          pictogramme: 'maille',
-          rolesGerables: [
-            'Administrateur dispositif',
-            'Gestionnaire département',
-            'Gestionnaire groupement',
-            'Gestionnaire région',
-            'Gestionnaire structure',
-            'Instructeur',
-            'Pilote politique publique',
-            'Support animation',
-          ],
-        },
-      }),
-    })
-    const inviter = screen.getByRole('button', { name: 'Inviter une personne' })
+    afficherMesUtilisateurs()
 
     // WHEN
-    fireEvent.click(inviter)
+    jOuvreLeFormulairePourInviterUnUtilisateur()
 
     // THEN
     const drawerInvitation = screen.getByRole('dialog', { name: 'Invitez un utilisateur à rejoindre l’espace de gestion' })
@@ -121,87 +97,39 @@ describe('inviter un utilisateur', () => {
 
   it('en tant qu’utilisateur, quand je clique sur inviter un utilisateur puis que je clique sur fermer, alors le drawer se ferme', () => {
     // GIVEN
-    const mesUtilisateursViewModel = mesUtilisateursPresenter([], 'fooId', totalUtilisateur, rolesAvecStructure)
-    renderComponent(<MesUtilisateurs mesUtilisateursViewModel={mesUtilisateursViewModel} />)
+    afficherMesUtilisateurs()
 
     // WHEN
     jOuvreLeFormulairePourInviterUnUtilisateur()
+    const drawerInvitation = drawer()
     jeFermeLeFormulairePourInviterUnUtilisateur()
 
     // THEN
-    const drawer = screen.queryByRole('dialog', { name: 'Invitez un utilisateur à rejoindre l’espace de gestion' })
-    expect(drawer).not.toBeInTheDocument()
+    expect(drawerInvitation).not.toBeVisible()
   })
 
   it('en tant qu’administrateur, quand je clique sur un rôle à inviter, alors le champ d’organisation s’affiche', () => {
     // GIVEN
-    const mesUtilisateursViewModel = mesUtilisateursPresenter([], 'fooId', totalUtilisateur, rolesAvecStructure)
-    renderComponent(<MesUtilisateurs mesUtilisateursViewModel={mesUtilisateursViewModel} />, {
-      sessionUtilisateurViewModel: sessionUtilisateurViewModelFactory({
-        role: {
-          doesItBelongToGroupeAdmin: true,
-          libelle: 'Rhône',
-          nom: 'Administrateur dispositif',
-          pictogramme: 'maille',
-          rolesGerables: [
-            'Administrateur dispositif',
-            'Gestionnaire département',
-            'Gestionnaire groupement',
-            'Gestionnaire région',
-            'Gestionnaire structure',
-            'Instructeur',
-            'Pilote politique publique',
-            'Support animation',
-          ],
-        },
-      }),
-    })
-    const inviter = screen.getByRole('button', { name: 'Inviter une personne' })
-    fireEvent.click(inviter)
+    afficherMesUtilisateurs()
 
     // WHEN
-    const formulaireInvitation = screen.getByRole('dialog', { name: 'Invitez un utilisateur à rejoindre l’espace de gestion' })
-    const gestionnaireDepartement = within(formulaireInvitation).getByLabelText('Gestionnaire département')
-    fireEvent.click(gestionnaireDepartement)
+    jOuvreLeFormulairePourInviterUnUtilisateur()
+    jeSelectionneUnGestionnaireDepartement()
 
     // THEN
-    const organisation = within(formulaireInvitation).getByLabelText('Département *')
+    const organisation = screen.getByLabelText('Département *')
     expect(organisation).toBeRequired()
     expect(organisation).toHaveAttribute('type', 'text')
   })
 
   it('en tant qu’administrateur, quand je cherche un département qui n’existe pas, alors un libellé me le signifie', async () => {
     // GIVEN
-    const mesUtilisateursViewModel = mesUtilisateursPresenter([], 'fooId', totalUtilisateur, rolesAvecStructure)
-    renderComponent(<MesUtilisateurs mesUtilisateursViewModel={mesUtilisateursViewModel} />, {
-      sessionUtilisateurViewModel: sessionUtilisateurViewModelFactory({
-        role: {
-          doesItBelongToGroupeAdmin: true,
-          libelle: 'Rhône',
-          nom: 'Administrateur dispositif',
-          pictogramme: 'maille',
-          rolesGerables: [
-            'Administrateur dispositif',
-            'Gestionnaire département',
-            'Gestionnaire groupement',
-            'Gestionnaire région',
-            'Gestionnaire structure',
-            'Instructeur',
-            'Pilote politique publique',
-            'Support animation',
-          ],
-        },
-      }),
-    })
-    const inviter = screen.getByRole('button', { name: 'Inviter une personne' })
-    fireEvent.click(inviter)
-    const formulaireInvitation = screen.getByRole('dialog', { name: 'Invitez un utilisateur à rejoindre l’espace de gestion' })
-    const gestionnaireDepartement = within(formulaireInvitation).getByLabelText('Gestionnaire département')
-    fireEvent.click(gestionnaireDepartement)
+    afficherMesUtilisateurs()
 
     // WHEN
-    const organisation = within(formulaireInvitation).getByLabelText('Département *')
-    fireEvent.change(organisation, { target: { value: 'departementInexistant' } })
+    jOuvreLeFormulairePourInviterUnUtilisateur()
+    jeSelectionneUnGestionnaireDepartement()
+    jeSelectionneUnDepartementInexistant()
 
     // THEN
     const pasDeResulat = await screen.findByText('Pas de résultat')
@@ -213,47 +141,20 @@ describe('inviter un utilisateur', () => {
     const inviterUnUtilisateurAction = vi.fn(async () => Promise.resolve(['OK']))
     vi.stubGlobal('dsfr', stubbedConceal())
     vi.stubGlobal('fetch', vi.fn(structuresFetch))
-    const mesUtilisateursViewModel = mesUtilisateursPresenter([], 'fooId', totalUtilisateur, rolesAvecStructure)
-    renderComponent(<MesUtilisateurs mesUtilisateursViewModel={mesUtilisateursViewModel} />, {
+    afficherMesUtilisateurs({
       inviterUnUtilisateurAction,
       pathname: '/mes-utilisateurs',
-      sessionUtilisateurViewModel: sessionUtilisateurViewModelFactory({
-        role: {
-          doesItBelongToGroupeAdmin: true,
-          libelle: 'Rhône',
-          nom: 'Administrateur dispositif',
-          pictogramme: 'maille',
-          rolesGerables: [
-            'Administrateur dispositif',
-            'Gestionnaire département',
-            'Gestionnaire groupement',
-            'Gestionnaire région',
-            'Gestionnaire structure',
-            'Instructeur',
-            'Pilote politique publique',
-            'Support animation',
-          ],
-        },
-      }),
     })
-    const inviter = screen.getByRole('button', { name: 'Inviter une personne' })
-    fireEvent.click(inviter)
-    const formulaireInvitation = screen.getByRole('dialog', { name: 'Invitez un utilisateur à rejoindre l’espace de gestion' })
-    const nom = within(formulaireInvitation).getByLabelText('Nom *')
-    fireEvent.change(nom, { target: { value: 'Tartempion' } })
-    const prenom = within(formulaireInvitation).getByLabelText('Prénom *')
-    fireEvent.change(prenom, { target: { value: 'Martin' } })
-    const email = within(formulaireInvitation).getByLabelText(/Adresse électronique/)
-    fireEvent.change(email, { target: { value: 'martin.tartempion@example.com' } })
-    const gestionnaireStructure = within(formulaireInvitation).getByLabelText('Gestionnaire structure')
-    fireEvent.click(gestionnaireStructure)
 
     // WHEN
-    const structure = within(formulaireInvitation).getByLabelText('Structure *')
-    fireEvent.change(structure, { target: { value: 'ABC' } })
-    await select(structure, 'ABC FORMATION')
-    const envoyerInvitation = await within(formulaireInvitation).findByRole('button', { name: 'Envoyer l’invitation' })
-    fireEvent.click(envoyerInvitation)
+    jOuvreLeFormulairePourInviterUnUtilisateur()
+    jeTapeSonNom('Tartempion')
+    jeTapeSonPrenom('Martin')
+    jeTapeSonAdresseElectronique('martin.tartempion@example.com')
+    jeSelectionneUnGestionnaireStructure()
+    const structure = jeTapeSaStructure('ABC')
+    await jeSelectionneSaStructure(structure, 'ABC FORMATION')
+    jEnvoieLInvitation()
 
     // THEN
     await waitFor(() => {
@@ -275,36 +176,12 @@ describe('inviter un utilisateur', () => {
       nom: string
       uid: string
     }>> => Promise.resolve([]) })))
-    const mesUtilisateursViewModel = mesUtilisateursPresenter([], 'fooId', totalUtilisateur, rolesAvecStructure)
-    renderComponent(<MesUtilisateurs mesUtilisateursViewModel={mesUtilisateursViewModel} />, {
-      sessionUtilisateurViewModel: sessionUtilisateurViewModelFactory({
-        role: {
-          doesItBelongToGroupeAdmin: true,
-          libelle: 'Rhône',
-          nom: 'Administrateur dispositif',
-          pictogramme: 'maille',
-          rolesGerables: [
-            'Administrateur dispositif',
-            'Gestionnaire département',
-            'Gestionnaire groupement',
-            'Gestionnaire région',
-            'Gestionnaire structure',
-            'Instructeur',
-            'Pilote politique publique',
-            'Support animation',
-          ],
-        },
-      }),
-    })
+    afficherMesUtilisateurs()
 
     // WHEN
-    const inviter = screen.getByRole('button', { name: 'Inviter une personne' })
-    fireEvent.click(inviter)
-    const formulaireInvitation = screen.getByRole('dialog', { name: 'Invitez un utilisateur à rejoindre l’espace de gestion' })
-    const gestionnaireStructure = within(formulaireInvitation).getByLabelText('Gestionnaire structure')
-    fireEvent.click(gestionnaireStructure)
-    const structure = screen.getByLabelText('Structure *')
-    fireEvent.change(structure, { target: { value: 'AB' } })
+    jOuvreLeFormulairePourInviterUnUtilisateur()
+    jeSelectionneUnGestionnaireStructure()
+    jeTapeSaStructure('AB')
 
     // THEN
     await waitFor(() => {
@@ -312,10 +189,9 @@ describe('inviter un utilisateur', () => {
     })
   })
 
-  it('en tant que gestionnaire département, quand je clique sur le bouton inviter, alors le drawer s’ouvre avec tous le rôle gestionnaire département sélectionné', async () => {
+  it('en tant que gestionnaire département, quand je clique sur le bouton inviter, alors le drawer s’ouvre avec le rôle gestionnaire département sélectionné', async () => {
     // GIVEN
-    const mesUtilisateursViewModel = mesUtilisateursPresenter([], 'fooId', totalUtilisateur, rolesAvecStructure)
-    renderComponent(<MesUtilisateurs mesUtilisateursViewModel={mesUtilisateursViewModel} />, {
+    afficherMesUtilisateurs({
       sessionUtilisateurViewModel: sessionUtilisateurViewModelFactory({
         role: {
           doesItBelongToGroupeAdmin: false,
@@ -326,10 +202,9 @@ describe('inviter un utilisateur', () => {
         },
       }),
     })
-    const inviter = screen.getByRole('button', { name: 'Inviter une personne' })
 
     // WHEN
-    fireEvent.click(inviter)
+    jOuvreLeFormulairePourInviterUnUtilisateur()
 
     // THEN
     const formulaireInvitation = screen.getByRole('dialog', { name: 'Invitez un utilisateur à rejoindre l’espace de gestion' })
@@ -376,56 +251,27 @@ describe('inviter un utilisateur', () => {
     expect(envoyerInvitation).toBeEnabled()
   })
 
-  it('quand je remplis correctement le formulaire et avec un nouveau mail, alors un message de validation s’affiche et le drawer est réinitialisé', async () => {
+  it('quand je remplis correctement le formulaire et avec une nouvelle adresse électronique, alors un message de validation s’affiche et le drawer est réinitialisé', async () => {
     // GIVEN
     const inviterUnUtilisateurAction = vi.fn(async () => Promise.resolve(['OK']))
     vi.stubGlobal('dsfr', stubbedConceal())
-    const mesUtilisateursViewModel = mesUtilisateursPresenter([], 'fooId', totalUtilisateur, rolesAvecStructure)
-    renderComponent(
-      <MesUtilisateurs mesUtilisateursViewModel={mesUtilisateursViewModel} />, {
-        inviterUnUtilisateurAction,
-        sessionUtilisateurViewModel: sessionUtilisateurViewModelFactory({
-          role: {
-            doesItBelongToGroupeAdmin: true,
-            libelle: 'Rhône',
-            nom: 'Administrateur dispositif',
-            pictogramme: 'maille',
-            rolesGerables: [
-              'Administrateur dispositif',
-              'Gestionnaire département',
-              'Gestionnaire groupement',
-              'Gestionnaire région',
-              'Gestionnaire structure',
-              'Instructeur',
-              'Pilote politique publique',
-              'Support animation',
-            ],
-          },
-        }),
-      }
-    )
-    const inviter = screen.getByRole('button', { name: 'Inviter une personne' })
-    fireEvent.click(inviter)
-    const formulaireInvitation = screen.getByRole('dialog', { name: 'Invitez un utilisateur à rejoindre l’espace de gestion' })
-    const roleRadios = within(formulaireInvitation).getAllByRole('radio')
+    afficherMesUtilisateurs({ inviterUnUtilisateurAction })
 
     // WHEN
-    const nom = within(formulaireInvitation).getByLabelText('Nom *')
-    fireEvent.change(nom, { target: { value: 'Tartempion' } })
-    const prenom = within(formulaireInvitation).getByLabelText('Prénom *')
-    fireEvent.change(prenom, { target: { value: 'Martin' } })
-    const email = within(formulaireInvitation).getByLabelText(/Adresse électronique/)
-    fireEvent.change(email, { target: { value: 'martin.tartempion@example.com' } })
-    const administrateurDispositif = within(formulaireInvitation).getByLabelText('Administrateur dispositif')
-    fireEvent.click(administrateurDispositif)
-    const envoyerInvitation = await within(formulaireInvitation).findByRole('button', { name: 'Envoyer l’invitation' })
-    fireEvent.click(envoyerInvitation)
+    jOuvreLeFormulairePourInviterUnUtilisateur()
+    const drawerInvitation = drawer()
+    const roleRadios = screen.getAllByRole('radio')
+    const nom = jeTapeSonNom('Tartempion')
+    const prenom = jeTapeSonPrenom('Martin')
+    const email = jeTapeSonAdresseElectronique('martin.tartempion@example.com')
+    jeSelectionneUnAdministrateur()
+    const envoyerInvitation = jEnvoieLInvitation()
 
     // THEN
     expect(envoyerInvitation).toBeDisabled()
     const notification = await screen.findByRole('alert')
     expect(notification).toHaveTextContent('Invitation envoyée à martin.tartempion@example.com')
-    expect(formulaireInvitation).not.toBeVisible()
+    expect(drawerInvitation).not.toBeVisible()
     expect(nom).toHaveValue('')
     expect(prenom).toHaveValue('')
     expect(email).toHaveValue('')
@@ -447,59 +293,28 @@ describe('inviter un utilisateur', () => {
       .mockResolvedValueOnce(['emailExistant'])
       .mockResolvedValueOnce(['OK'])
     vi.stubGlobal('dsfr', stubbedConceal())
-    const mesUtilisateursViewModel = mesUtilisateursPresenter([], 'fooId', totalUtilisateur, rolesAvecStructure)
-    renderComponent(
-      <MesUtilisateurs mesUtilisateursViewModel={mesUtilisateursViewModel} />, {
-        inviterUnUtilisateurAction,
-        sessionUtilisateurViewModel: sessionUtilisateurViewModelFactory({
-          role: {
-            doesItBelongToGroupeAdmin: true,
-            libelle: 'Rhône',
-            nom: 'Administrateur dispositif',
-            pictogramme: 'maille',
-            rolesGerables: [
-              'Administrateur dispositif',
-              'Gestionnaire département',
-              'Gestionnaire groupement',
-              'Gestionnaire région',
-              'Gestionnaire structure',
-              'Instructeur',
-              'Pilote politique publique',
-              'Support animation',
-            ],
-          },
-        }),
-      }
-    )
-    const inviter = screen.getByRole('button', { name: 'Inviter une personne' })
-    fireEvent.click(inviter)
-    const formulaireInvitation = screen.getByRole('dialog', { name: 'Invitez un utilisateur à rejoindre l’espace de gestion' })
-    const roleRadios = within(formulaireInvitation).getAllByRole('radio')
+    afficherMesUtilisateurs({ inviterUnUtilisateurAction })
 
     // WHEN
-    const nom = within(formulaireInvitation).getByLabelText('Nom *')
-    fireEvent.change(nom, { target: { value: 'Tartempion' } })
-    const prenom = within(formulaireInvitation).getByLabelText('Prénom *')
-    fireEvent.change(prenom, { target: { value: 'Martin' } })
-    const email = within(formulaireInvitation).getByLabelText(/Adresse électronique/)
-    fireEvent.change(email, { target: { value: 'martin.tartempion@example.com' } })
-    const gestionnaireRole = within(formulaireInvitation).getByLabelText('Gestionnaire département')
-    fireEvent.click(gestionnaireRole)
-    const departementSelect = within(formulaireInvitation).getByLabelText('Département *')
-    expect(departementSelect).toBeInTheDocument()
-    await select(departementSelect, 'Ain')
-    const envoyerInvitation = await within(formulaireInvitation).findByRole('button', { name: 'Envoyer l’invitation' })
-    fireEvent.click(envoyerInvitation)
-    const messageDErreur = await within(formulaireInvitation).findByText('Cet utilisateur dispose déjà d’un compte', { selector: 'p' })
-    fireEvent.click(envoyerInvitation)
+    jOuvreLeFormulairePourInviterUnUtilisateur()
+    const drawerInvitation = drawer()
+    const roleRadios = screen.getAllByRole('radio')
+    const nom = jeTapeSonNom('Tartempion')
+    const prenom = jeTapeSonPrenom('Martin')
+    const email = jeTapeSonAdresseElectronique('martin.tartempion@example.com')
+    jeSelectionneUnGestionnaireDepartement()
+    await jeSelectionneSonDepartement('Ain')
+    jEnvoieLInvitation()
+    const messageDErreur = await screen.findByText('Cet utilisateur dispose déjà d’un compte', { selector: 'p' })
+    jEnvoieLInvitation()
 
     // THEN
     expect(messageDErreur).toBeInTheDocument()
-    const absenceMessageDErreur = await within(formulaireInvitation).findByText('Cet utilisateur dispose déjà d’un compte', { selector: 'p' })
+    const absenceMessageDErreur = await screen.findByText('Cet utilisateur dispose déjà d’un compte', { selector: 'p' })
     expect(absenceMessageDErreur).not.toBeInTheDocument()
     const notification = await screen.findByRole('alert')
     expect(notification).toHaveTextContent('Invitation envoyée à martin.tartempion@example.com')
-    expect(formulaireInvitation).not.toBeVisible()
+    expect(drawerInvitation).not.toBeVisible()
     expect(nom).toHaveValue('')
     expect(prenom).toHaveValue('')
     expect(email).toHaveValue('')
@@ -507,7 +322,7 @@ describe('inviter un utilisateur', () => {
       expect(roleRadio).not.toBeChecked()
     })
     Object.values(roleGestionnaireLabelSelectionMapping).forEach((labelChampSelection) => {
-      const champSelection = within(formulaireInvitation).queryByLabelText(`${labelChampSelection} *`)
+      const champSelection = within(drawerInvitation).queryByLabelText(`${labelChampSelection} *`)
       expect(champSelection).not.toBeInTheDocument()
     })
   })
@@ -515,107 +330,45 @@ describe('inviter un utilisateur', () => {
   it('dans le drawer d’invitation, quand je remplis correctement le formulaire et avec un mail existant, alors il y a un message d’erreur', async () => {
     // GIVEN
     const inviterUnUtilisateurAction = vi.fn(async () => Promise.resolve(['emailExistant']))
-    const mesUtilisateursViewModel = mesUtilisateursPresenter([], 'fooId', totalUtilisateur, rolesAvecStructure)
-    renderComponent(
-      <MesUtilisateurs mesUtilisateursViewModel={mesUtilisateursViewModel} />,
-      {
-        inviterUnUtilisateurAction,
-        sessionUtilisateurViewModel: sessionUtilisateurViewModelFactory({
-          role: {
-            doesItBelongToGroupeAdmin: true,
-            libelle: 'Rhône',
-            nom: 'Administrateur dispositif',
-            pictogramme: 'maille',
-            rolesGerables: [
-              'Administrateur dispositif',
-              'Gestionnaire département',
-              'Gestionnaire groupement',
-              'Gestionnaire région',
-              'Gestionnaire structure',
-              'Instructeur',
-              'Pilote politique publique',
-              'Support animation',
-            ],
-          },
-        }),
-      }
-    )
-    const inviter = screen.getByRole('button', { name: 'Inviter une personne' })
-    fireEvent.click(inviter)
-    const formulaireInvitation = screen.getByRole('dialog', { name: 'Invitez un utilisateur à rejoindre l’espace de gestion' })
+    afficherMesUtilisateurs({ inviterUnUtilisateurAction })
 
     // WHEN
-    const nom = within(formulaireInvitation).getByLabelText('Nom *')
-    fireEvent.change(nom, { target: { value: 'Tartempion' } })
-    const prenom = within(formulaireInvitation).getByLabelText('Prénom *')
-    fireEvent.change(prenom, { target: { value: 'Martin' } })
-    const email = within(formulaireInvitation).getByLabelText(/Adresse électronique/)
-    fireEvent.change(email, { target: { value: 'martin.tartempion@example.com' } })
-    const administrateurDispositif = within(formulaireInvitation).getByLabelText('Administrateur dispositif')
-    fireEvent.click(administrateurDispositif)
-    const envoyerInvitation = await within(formulaireInvitation).findByRole('button', { name: 'Envoyer l’invitation' })
-    fireEvent.click(envoyerInvitation)
+    jOuvreLeFormulairePourInviterUnUtilisateur()
+    const drawerInvitation = drawer()
+    jeTapeSonNom('Tartempion')
+    jeTapeSonPrenom('Martin')
+    jeTapeSonAdresseElectronique('martin.tartempion@example.com')
+    jeSelectionneUnAdministrateur()
+    jEnvoieLInvitation()
 
     // THEN
-    const erreurEmailDejaExistant = await within(formulaireInvitation).findByText('Cet utilisateur dispose déjà d’un compte', { selector: 'p' })
+    const erreurEmailDejaExistant = await within(drawerInvitation).findByText('Cet utilisateur dispose déjà d’un compte', { selector: 'p' })
     expect(erreurEmailDejaExistant).toBeInTheDocument()
-    expect(formulaireInvitation).toBeVisible()
+    expect(drawerInvitation).toBeVisible()
   })
 
   it('dans le drawer d’invitation, quand je remplis correctement le formulaire mais que l’invitation ne peut pas se faire, alors le drawer se ferme', async () => {
     // GIVEN
     const inviterUnUtilisateurAction = vi.fn(async () => Promise.resolve(['utilisateurNePeutPasGererUtilisateurACreer']))
     vi.stubGlobal('dsfr', stubbedConceal())
-    const mesUtilisateursViewModel = mesUtilisateursPresenter([], 'fooId', totalUtilisateur, rolesAvecStructure)
-    renderComponent(
-      <MesUtilisateurs mesUtilisateursViewModel={mesUtilisateursViewModel} />,
-      {
-        inviterUnUtilisateurAction,
-        sessionUtilisateurViewModel: sessionUtilisateurViewModelFactory({
-          role: {
-            doesItBelongToGroupeAdmin: true,
-            libelle: 'Rhône',
-            nom: 'Administrateur dispositif',
-            pictogramme: 'maille',
-            rolesGerables: [
-              'Administrateur dispositif',
-              'Gestionnaire département',
-              'Gestionnaire groupement',
-              'Gestionnaire région',
-              'Gestionnaire structure',
-              'Instructeur',
-              'Pilote politique publique',
-              'Support animation',
-            ],
-          },
-        }),
-      }
-    )
-    const inviter = screen.getByRole('button', { name: 'Inviter une personne' })
-    fireEvent.click(inviter)
-    const formulaireInvitation = screen.getByRole('dialog', { name: 'Invitez un utilisateur à rejoindre l’espace de gestion' })
-    const roleRadios = within(formulaireInvitation).getAllByRole('radio')
+    afficherMesUtilisateurs({ inviterUnUtilisateurAction })
 
     // WHEN
-    const nom = within(formulaireInvitation).getByLabelText('Nom *')
-    fireEvent.change(nom, { target: { value: 'Tartempion' } })
-    const prenom = within(formulaireInvitation).getByLabelText('Prénom *')
-    fireEvent.change(prenom, { target: { value: 'Martin' } })
-    const email = within(formulaireInvitation).getByLabelText(/Adresse électronique/)
-    fireEvent.change(email, { target: { value: 'martin.tartempion@example.com' } })
-    const administrateurDispositif = within(formulaireInvitation).getByLabelText('Administrateur dispositif')
-    fireEvent.click(administrateurDispositif)
-    const envoyerInvitation = await within(formulaireInvitation).findByRole('button', { name: 'Envoyer l’invitation' })
-    fireEvent.click(envoyerInvitation)
+    jOuvreLeFormulairePourInviterUnUtilisateur()
+    const drawerInvitation = drawer()
+    const roleRadios = within(drawerInvitation).getAllByRole('radio')
+    const nom = jeTapeSonNom('Tartempion')
+    const prenom = jeTapeSonPrenom('Martin')
+    const email = jeTapeSonAdresseElectronique('martin.tartempion@example.com')
+    jeSelectionneUnAdministrateur()
+    jEnvoieLInvitation()
 
     // THEN
-    const absenceDeMessageDErreur = within(formulaireInvitation).queryByText('Cet utilisateur dispose déjà d’un compte', { selector: 'p' })
+    const absenceDeMessageDErreur = within(drawerInvitation).queryByText('Cet utilisateur dispose déjà d’un compte', { selector: 'p' })
     expect(absenceDeMessageDErreur).not.toBeInTheDocument()
-    const formulaireInvitationApresInvitationEnEchec = await screen.findByRole(
-      'dialog',
-      { name: 'Invitez un utilisateur à rejoindre l’espace de gestion' }
-    )
-    expect(formulaireInvitationApresInvitationEnEchec).not.toBeVisible()
+    await waitFor(() => {
+      expect(drawerInvitation).not.toBeVisible()
+    })
     expect(nom).toHaveValue('')
     expect(prenom).toHaveValue('')
     expect(email).toHaveValue('')
@@ -625,10 +378,83 @@ describe('inviter un utilisateur', () => {
   })
 
   function jOuvreLeFormulairePourInviterUnUtilisateur(): void {
-    fireEvent.click(screen.getByRole('button', { name: 'Inviter une personne' }))
+    presserLeBouton('Inviter une personne')
   }
 
   function jeFermeLeFormulairePourInviterUnUtilisateur(): void {
-    fireEvent.click(screen.getByRole('button', { name: 'Fermer l’invitation' }))
+    presserLeBouton('Fermer l’invitation')
+  }
+
+  function jeTapeSonNom(value: string): HTMLElement {
+    return saisirLeTexte('Nom *', value)
+  }
+
+  function jeTapeSonPrenom(value: string): HTMLElement {
+    return saisirLeTexte('Prénom *', value)
+  }
+
+  function jeTapeSonAdresseElectronique(value: string): HTMLElement {
+    return saisirLeTexte(/Adresse électronique/, value)
+  }
+
+  function jeSelectionneUnAdministrateur(): void {
+    fireEvent.click(within(drawer()).getByLabelText('Administrateur dispositif'))
+  }
+
+  function jeSelectionneUnGestionnaireDepartement(): void {
+    fireEvent.click(within(drawer()).getByLabelText('Gestionnaire département'))
+  }
+
+  function jeSelectionneUnGestionnaireStructure(): void {
+    fireEvent.click(within(drawer()).getByLabelText('Gestionnaire structure'))
+  }
+
+  function jeTapeSaStructure(value: string): HTMLElement {
+    return saisirLeTexte('Structure *', value)
+  }
+
+  async function jeSelectionneSaStructure(input: HTMLElement, nomStructure: string): Promise<void> {
+    await selectionnerLElement(input, nomStructure)
+  }
+
+  async function jeSelectionneSonDepartement(departement: string): Promise<void> {
+    await selectionnerLElement(screen.getByLabelText('Département *'), departement)
+  }
+
+  function jeSelectionneUnDepartementInexistant(): void {
+    saisirLeTexte('Département *', 'departementInexistant')
+  }
+
+  function jEnvoieLInvitation(): HTMLElement {
+    return presserLeBouton('Envoyer l’invitation')
+  }
+
+  function drawer(): HTMLElement {
+    return screen.getByRole('dialog', { name: 'Invitez un utilisateur à rejoindre l’espace de gestion' })
+  }
+
+  function afficherMesUtilisateurs(options?: Partial<Parameters<typeof renderComponent>[1]>): void {
+    const mesUtilisateursViewModel = mesUtilisateursPresenter([], 'fooId', 11, rolesAvecStructure)
+    renderComponent(<MesUtilisateurs mesUtilisateursViewModel={mesUtilisateursViewModel} />, {
+      sessionUtilisateurViewModel: sessionUtilisateurViewModelFactory({
+        role: {
+          doesItBelongToGroupeAdmin: true,
+          libelle: 'Rhône',
+          nom: 'Administrateur dispositif',
+          pictogramme: 'maille',
+          rolesGerables: [
+            'Administrateur dispositif',
+            'Gestionnaire département',
+            'Gestionnaire groupement',
+            'Gestionnaire région',
+            'Gestionnaire structure',
+            'Instructeur',
+            'Pilote politique publique',
+            'Support animation',
+          ],
+        },
+      }),
+      ...options,
+    })
   }
 })

--- a/src/components/MesUtilisateurs/MesUtilisateurs.tsx
+++ b/src/components/MesUtilisateurs/MesUtilisateurs.tsx
@@ -249,7 +249,7 @@ export default function MesUtilisateurs(
           ) : null
       }
       <SupprimerUnUtilisateur
-        closeDrawer={() => {
+        closeModal={() => {
           setIsModaleSuppressionOpen(false)
         }}
         id={modalId}

--- a/src/components/MesUtilisateurs/SupprimerUnUtilisateur.tsx
+++ b/src/components/MesUtilisateurs/SupprimerUnUtilisateur.tsx
@@ -8,14 +8,14 @@ export default function SupprimerUnUtilisateur({
   id,
   isOpen,
   utilisateurASupprimer,
-  closeDrawer,
+  closeModal,
 }: Props): ReactElement {
   const { pathname, supprimerUnUtilisateurAction } = useContext(clientContext)
   const modaleTitreId = useId()
 
   return (
     <Modal
-      close={close}
+      close={closeModal}
       id={id}
       isOpen={isOpen}
       labelId={modaleTitreId}
@@ -38,7 +38,7 @@ export default function SupprimerUnUtilisateur({
           <button
             aria-controls={id}
             className="fr-btn fr-btn--secondary"
-            onClick={close}
+            onClick={closeModal}
             type="button"
           >
             Annuler
@@ -56,13 +56,9 @@ export default function SupprimerUnUtilisateur({
     </Modal>
   )
 
-  function close(): void {
-    closeDrawer()
-  }
-
   async function supprimer(uidUtilisateurASupprimer: string): Promise<void> {
     await supprimerUnUtilisateurAction({ path: pathname, uidUtilisateurASupprimer })
-    close()
+    closeModal()
   }
 }
 
@@ -70,7 +66,7 @@ type Props = Readonly<{
   id: string
   isOpen: boolean
   utilisateurASupprimer: UtilisateurASupprimer
-  closeDrawer(): void
+  closeModal(): void
 }>
 
 type UtilisateurASupprimer = Readonly<{

--- a/src/components/shared/Drawer/Drawer.module.css
+++ b/src/components/shared/Drawer/Drawer.module.css
@@ -38,7 +38,6 @@
 .fr-modal__body {
   height: 100vh;
   max-height: 100vh !important;
-  overflow-y: hidden;
   padding-bottom: 2rem;
   padding-top: 2rem;
 }

--- a/src/components/shared/Pagination/DernierePage.tsx
+++ b/src/components/shared/Pagination/DernierePage.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import Link from 'next/link'
 import { ReactElement } from 'react'
 

--- a/src/components/testHelper.tsx
+++ b/src/components/testHelper.tsx
@@ -1,5 +1,6 @@
-import { render, RenderResult } from '@testing-library/react'
+import { fireEvent, render, RenderResult, screen } from '@testing-library/react'
 import { ReactElement } from 'react'
+import { select } from 'react-select-event'
 import { ToastContainer } from 'react-toastify'
 import { Mock } from 'vitest'
 
@@ -102,4 +103,28 @@ export function stubbedConceal() {
       conceal: vi.fn(),
     },
   })
+}
+
+export function presserLeBouton(name: string): HTMLElement {
+  const button = screen.getByRole('button', { name })
+  fireEvent.click(button)
+  return button
+}
+
+export function cocherLaCase(name: string): void {
+  fireEvent.click(screen.getByRole('checkbox', { name }))
+}
+
+export function presserLeBoutonRadio(name: string): void {
+  fireEvent.click(screen.getByRole('radio', { name }))
+}
+
+export function saisirLeTexte(name: string | RegExp, value: string): HTMLElement {
+  const input = screen.getByLabelText(name)
+  fireEvent.change(input, { target: { value } })
+  return input
+}
+
+export async function selectionnerLElement(input: HTMLElement, nomStructure: string): Promise<void> {
+  await select(input, nomStructure)
 }


### PR DESCRIPTION
Ce qui a été fait et devient la norme :
- les tests deviennent des scénarii donc utilisation de petites fonctions faisant office d'action utilisateur commençant par `je + verbe` placé en bas du fichier
- ces fonctions d'actions utilisateur sont mise dans le `WHEN` pour mieux d'écrire les étapes
- ces même petits fonctions utilisent des petites fonctions techniques partagés dans testHelper
- la notion de render est aussi mise dans une petite fonction commençant par `afficherXXX`
- l'affichage du drawer est explicité par `toBeVisible` dorénavant avec une subtilité dans le `WHEN`
- on gagne 100 lignes !!!!

# Contrat du dev

## Qualité

- [x] Relire le code
- [x] Relire le ticket
- [x] [Relire les critères d'acceptation](https://github.com/anct-cnum/suite-gestionnaire-numerique/discussions/252)
- [x] Vérifier le coverage
- [x] Recetter l'application
- [x] Ajouter des variables d'environnement sur la production au besoin

## Accessibilité

- [x] Vérifier l'accessibilité avec a11y.css, WAVE, Axe, headingMap
- [x] Naviguer au clavier
- [x] Vérifier le constraste en mode sombre

## Facultatif mais fortement conseillé

- [x] Lancer les tests de mutation

> **Et n'oublie pas de vérifier ce que tu as fait en production !**
