### PR TITLE
Suppression de conceal quand ce n'est pas nécessaire

### DIFF
--- a/src/components/Gouvernance/NoteDeContexte/NoteDeContexte.test.tsx
+++ b/src/components/Gouvernance/NoteDeContexte/NoteDeContexte.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, screen, within } from '@testing-library/react'
 import { vi } from 'vitest'
 
 import Gouvernance from '../Gouvernance'
-import { presserLeBouton, renderComponent, stubbedConceal } from '@/components/testHelper'
+import { presserLeBouton, renderComponent } from '@/components/testHelper'
 import { gouvernancePresenter } from '@/presenters/gouvernancePresenter'
 import { gouvernanceReadModelFactory } from '@/use-cases/testHelper'
 
@@ -62,7 +62,6 @@ describe('note de contexte', () => {
 
   it('quand je clique sur le bouton enregistrer le drawer se ferme et une notification s‘affiche', async () => {
     // GIVEN
-    vi.stubGlobal('dsfr', stubbedConceal())
     const ajouterUneNoteDeContexteAction = vi.fn(async () => Promise.resolve(['OK']))
     afficherUneGouvernance({ ajouterUneNoteDeContexteAction, pathname: '/gouvernance/11' })
 
@@ -86,7 +85,6 @@ describe('note de contexte', () => {
   it('quand je clique sur le bouton enregistrer mais qu‘une erreur intervient, alors une notification apparaît', async () => {
     // GIVEN
     const ajouterUneNoteDeContexteAction = vi.fn(async () => Promise.resolve(['Le format est incorrect', 'autre erreur']))
-    vi.stubGlobal('dsfr', stubbedConceal())
     afficherUneGouvernance({ ajouterUneNoteDeContexteAction, pathname: '/gouvernance/11' })
 
     // WHEN

--- a/src/components/MesInformationsPersonnelles/MesInformationsPersonnelles.test.tsx
+++ b/src/components/MesInformationsPersonnelles/MesInformationsPersonnelles.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, screen, within } from '@testing-library/react'
 import * as nextAuth from 'next-auth/react'
 
 import MesInformationsPersonnelles from './MesInformationsPersonnelles'
-import { presserLeBouton, saisirLeTexte, matchWithoutMarkup, renderComponent, stubbedConceal } from '@/components/testHelper'
+import { presserLeBouton, saisirLeTexte, matchWithoutMarkup, renderComponent } from '@/components/testHelper'
 import { mesInformationsPersonnellesPresenter } from '@/presenters/mesInformationsPersonnellesPresenter'
 import { mesInformationsPersonnellesReadModelFactory } from '@/use-cases/testHelper'
 
@@ -365,6 +365,7 @@ describe('mes informations personnelles : en tant qu’utilisateur authentifié'
       const enregistrer = within(formulaire).getByRole('button', { name: 'Enregistrer' })
       expect(enregistrer).toBeEnabled()
       expect(enregistrer).toHaveAttribute('type', 'submit')
+      expect(enregistrer).toHaveAttribute('aria-controls', 'drawer-modifier-mon-compte')
     })
 
     it('alors le téléphone n’est pas rempli s’il est non renseigné', () => {
@@ -408,7 +409,6 @@ describe('mes informations personnelles : en tant qu’utilisateur authentifié'
     it('quand je modifie mes informations personnelles alors elles sont modifiées et le drawer est fermé', async () => {
       // GIVEN
       const modifierMesInformationsPersonnellesAction = vi.fn(async () => Promise.resolve(['OK']))
-      vi.stubGlobal('dsfr', stubbedConceal())
       afficherMesInformationsPersonnelles({ modifierMesInformationsPersonnellesAction, pathname: '/mes-informations-personnelles' })
 
       // WHEN

--- a/src/components/MesInformationsPersonnelles/MesInformationsPersonnelles.tsx
+++ b/src/components/MesInformationsPersonnelles/MesInformationsPersonnelles.tsx
@@ -221,7 +221,6 @@ export default function MesInformationsPersonnelles(
           closeDrawer={() => {
             setIsDrawerOpen(false)
           }}
-          dialogRef={drawerModifierMonCompteRef}
           email={mesInformationsPersonnellesViewModel.emailDeContact}
           id={drawerId}
           labelId={labelId}

--- a/src/components/MesInformationsPersonnelles/ModifierMonCompte.tsx
+++ b/src/components/MesInformationsPersonnelles/ModifierMonCompte.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { FormEvent, ReactElement, RefObject, useContext, useId, useState } from 'react'
+import { FormEvent, ReactElement, useContext, useId, useState } from 'react'
 
 import { clientContext } from '../shared/ClientContext'
 import DrawerTitle from '../shared/DrawerTitle/DrawerTitle'
@@ -10,7 +10,6 @@ import { emailPattern, telephonePattern } from '@/shared/patterns'
 
 export default function ModifierMonCompte({
   email,
-  dialogRef,
   id,
   labelId,
   nom,
@@ -113,7 +112,10 @@ export default function ModifierMonCompte({
             </button>
           </div>
           <div className="fr-col-5">
-            <SubmitButton isDisabled={isDisabled}>
+            <SubmitButton
+              ariaControls={id}
+              isDisabled={isDisabled}
+            >
               {isDisabled ? 'Modification en cours...' : 'Enregistrer'}
             </SubmitButton>
           </div>
@@ -136,12 +138,10 @@ export default function ModifierMonCompte({
       })
 
     closeDrawer()
-    window.dsfr(dialogRef.current).modal.conceal()
   }
 }
 
 type Props = Readonly<{
-  dialogRef: RefObject<HTMLDialogElement | null>
   email: string
   id: string
   labelId: string

--- a/src/components/MesUtilisateurs/MesUtilisateurs.test.tsx
+++ b/src/components/MesUtilisateurs/MesUtilisateurs.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, screen, waitFor, within } from '@testing-library/react'
 import { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime'
 
 import MesUtilisateurs from './MesUtilisateurs'
-import { presserLeBouton, saisirLeTexte, renderComponent, rolesAvecStructure, stubbedConceal } from '@/components/testHelper'
+import { presserLeBouton, saisirLeTexte, renderComponent, rolesAvecStructure } from '@/components/testHelper'
 import { mesUtilisateursPresenter } from '@/presenters/mesUtilisateursPresenter'
 import { sessionUtilisateurViewModelFactory } from '@/presenters/testHelper'
 import { utilisateurReadModelFactory } from '@/use-cases/testHelper'
@@ -285,7 +285,6 @@ describe('mes utilisateurs', () => {
     it('quand je clique sur le bouton "Renvoyer cette invitation" alors le drawer se ferme et il en est notifié', async () => {
       // GIVEN
       const reinviterUnUtilisateurAction = vi.fn(async () => Promise.resolve(['OK']))
-      vi.stubGlobal('dsfr', stubbedConceal())
       afficherMesUtilisateurs([utilisateurEnAttenteReadModel], { pathname: '/mes-utilisateurs', reinviterUnUtilisateurAction })
 
       // WHEN

--- a/src/components/MesUtilisateurs/MesUtilisateurs.tsx
+++ b/src/components/MesUtilisateurs/MesUtilisateurs.tsx
@@ -288,7 +288,6 @@ export default function MesUtilisateurs(
           closeDrawer={() => {
             setIsDrawerRenvoyerInvitationOpen(false)
           }}
-          dialogRef={drawerRenvoyerInvitationRef}
           drawerId={drawerRenvoyerInvitationId}
           labelId={labelRenvoyerInvitationId}
           utilisateur={utilisateurEnAttenteSelectionne}

--- a/src/components/MesUtilisateurs/ReinviterUnUtilisateur.tsx
+++ b/src/components/MesUtilisateurs/ReinviterUnUtilisateur.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, RefObject, useContext } from 'react'
+import { ReactElement, useContext } from 'react'
 
 import { clientContext } from '../shared/ClientContext'
 import DrawerTitle from '../shared/DrawerTitle/DrawerTitle'
@@ -9,7 +9,6 @@ export default function ReinviterUnUtilisateur({
   labelId,
   drawerId,
   closeDrawer,
-  dialogRef,
 }: Props): ReactElement {
   const { pathname, reinviterUnUtilisateurAction } = useContext(clientContext)
 
@@ -45,18 +44,12 @@ export default function ReinviterUnUtilisateur({
       path: pathname,
       uidUtilisateurAReinviter: utilisateur.uid,
     })
-    close()
-    Notification('success', { description: utilisateur.email, title: 'Invitation envoyée à ' })
-  }
-
-  function close(): void {
     closeDrawer()
-    window.dsfr(dialogRef.current).modal.conceal()
+    Notification('success', { description: utilisateur.email, title: 'Invitation envoyée à ' })
   }
 }
 
 type Props = Readonly<{
-  dialogRef: RefObject<HTMLDialogElement | null>
   utilisateur: Readonly<{
     email: string
     inviteLe: string


### PR DESCRIPTION
Pour rappel, conceal n'est utile que dans le cas où il y a un message d'erreur qui doit s'afficher dans le formulaire sinon l'attribut aria-controls fait très bien l'affaire et ça évite de le doubler.

# Contrat du dev

## Qualité

- [x] Relire le code
- [x] Relire le ticket
- [x] [Relire les critères d'acceptation](https://github.com/anct-cnum/suite-gestionnaire-numerique/discussions/252)
- [x] Vérifier le coverage
- [x] Recetter l'application

> **Et n'oublie pas de vérifier ce que tu as fait en production !**
