### PR TITLE
new Date() ne peut s'écrire que dans les controllers pour éviter des bugs

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -224,13 +224,33 @@
   },
   "overrides": [
     {
+      "files": ["**/*"],
+      "excludedFiles": ["src/app/**/*", "seeds/**/*"],
+      "rules": {
+        "no-restricted-syntax": [
+          "error",
+          {
+            "message": "La date doit être injectée dans un controller",
+            "selector": "NewExpression[callee.name='Date'][arguments.length=0]"
+          }
+        ]
+      }
+    },
+    {
       "files": ["**/*.test.ts?(x)"],
       "extends": ["plugin:vitest/all"],
       "rules": {
+        "func-style": "off",
+        "no-restricted-syntax": [
+          "error",
+          {
+            "message": "Utiliser plutôt epochTime",
+            "selector": "NewExpression[callee.name='Date']"
+          }
+        ],
+        "no-undef": "off",
         "@typescript-eslint/class-methods-use-this": "off",
         "@typescript-eslint/unbound-method": "off",
-        "func-style": "off",
-        "no-undef": "off",
         "vitest/max-expects": "off",
         "vitest/no-conditional-expect": "off",
         "vitest/no-hooks": "off",

--- a/src/app/(connecte)/(avec-menu)/gouvernance/[codeDepartement]/page.tsx
+++ b/src/app/(connecte)/(avec-menu)/gouvernance/[codeDepartement]/page.tsx
@@ -10,11 +10,10 @@ import { RecupererUneGouvernance } from '@/use-cases/queries/RecupererUneGouvern
 export default async function GouvernanceController({ params }: Props): Promise<ReactElement> {
   try {
     const codeDepartement = (await params).codeDepartement
-    const now = new Date()
     const gouvernanceReadModel =
        await new RecupererUneGouvernance(new PrismaGouvernanceLoader(prisma.gouvernanceRecord)).get({ codeDepartement })
 
-    const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModel, now)
+    const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModel, new Date())
     return (
       <Gouvernance gouvernanceViewModel={gouvernanceViewModel} />
     )

--- a/src/app/(connecte)/(sans-menu)/mes-utilisateurs/page.tsx
+++ b/src/app/(connecte)/(sans-menu)/mes-utilisateurs/page.tsx
@@ -76,7 +76,8 @@ export default async function MesUtilisateursController({ searchParams }: Props)
     utilisateursCourants,
     sub,
     total,
-    rolesAvecStructure
+    rolesAvecStructure,
+    new Date()
   )
 
   return (

--- a/src/components/Gouvernance/Comitologie/AjouterUnComite.tsx
+++ b/src/components/Gouvernance/Comitologie/AjouterUnComite.tsx
@@ -8,6 +8,7 @@ import { ComiteViewModel } from '@/presenters/gouvernancePresenter'
 
 export default function AjouterUnComite({
   comite,
+  dateAujourdhui,
   id,
   labelId,
   uidGouvernance,
@@ -19,6 +20,7 @@ export default function AjouterUnComite({
   return (
     <FormulaireComite
       comite={comite}
+      dateAujourdhui={dateAujourdhui}
       label="Ajouter un comité"
       labelId={labelId}
       validerFormulaire={creerUnComite}
@@ -59,6 +61,7 @@ export default function AjouterUnComite({
 
 type Props = Readonly<{
   comite: ComiteViewModel
+  dateAujourdhui: string
   id: string
   labelId: string
   uidGouvernance: string

--- a/src/components/Gouvernance/Comitologie/Comitologie.test.tsx
+++ b/src/components/Gouvernance/Comitologie/Comitologie.test.tsx
@@ -1,15 +1,15 @@
 import { within, screen, fireEvent, waitFor } from '@testing-library/react'
 
 import Gouvernance from '../Gouvernance'
-import { FrozenDate, presserLeBouton, presserLeBoutonRadio, matchWithoutMarkup, renderComponent } from '@/components/testHelper'
+import { presserLeBouton, presserLeBoutonRadio, matchWithoutMarkup, renderComponent } from '@/components/testHelper'
 import { gouvernancePresenter } from '@/presenters/gouvernancePresenter'
+import { epochTimePlusOneDay } from '@/shared/testHelper'
 import { gouvernanceReadModelFactory } from '@/use-cases/testHelper'
 
 describe('comitologie', () => {
   describe('quand je clique sur ajouter une comitologie,', () => {
     it('alors le drawer pour ajouter un comité s’affiche', () => {
       // GIVEN
-      vi.stubGlobal('Date', FrozenDate)
       afficherUneGouvernance()
 
       // WHEN
@@ -50,7 +50,7 @@ describe('comitologie', () => {
       const date = within(formulaire).getByLabelText('Date du prochain comité')
       expect(date).not.toBeRequired()
       expect(date).toHaveAttribute('type', 'date')
-      expect(date).toHaveAttribute('min', '1996-04-15')
+      expect(date).toHaveAttribute('min', '1970-01-02')
 
       const commentaire = within(formulaire).getByLabelText('Laissez ici un commentaire général sur le comité', { selector: 'textarea' })
       expect(commentaire).not.toBeRequired()
@@ -76,7 +76,6 @@ describe('comitologie', () => {
 
     it('puis que je remplis correctement le formulaire, alors le drawer se ferme, une notification s’affiche, la gouvernance est mise à jour et le formulaire est réinitialisé', async () => {
       // GIVEN
-      vi.stubGlobal('Date', FrozenDate)
       const ajouterUnComiteAction = vi.fn(async () => Promise.resolve(['OK']))
       afficherUneGouvernance({ ajouterUnComiteAction, pathname: '/gouvernance/11' })
 
@@ -85,7 +84,7 @@ describe('comitologie', () => {
       const ajouterUnComiteDrawer = screen.getByRole('dialog', { name: 'Ajouter un comité' })
       jeSelectionneUnType('Technique')
       jeSelectionneUneFrequence('Annuelle')
-      const date = jeChoisisUneDate(ajouterUnComiteDrawer, '1996-04-15')
+      const date = jeChoisisUneDate(ajouterUnComiteDrawer, '1970-01-02')
       const commentaire = jeTapeUnCommentaire(ajouterUnComiteDrawer, 'commentaire')
       const enregistrer = jEnregistreLeComite()
 
@@ -101,7 +100,7 @@ describe('comitologie', () => {
       expect(ajouterUnComiteDrawer).not.toBeVisible()
       expect(ajouterUnComiteAction).toHaveBeenCalledWith({
         commentaire: 'commentaire',
-        date: '1996-04-15',
+        date: '1970-01-02',
         frequence: 'annuelle',
         path: '/gouvernance/11',
         type: 'technique',
@@ -115,7 +114,6 @@ describe('comitologie', () => {
 
     it('puis que je ne remplis pas la date et le commentaire qui sont facultatifs, alors la gouvernance est mise à jour', async () => {
       // GIVEN
-      vi.stubGlobal('Date', FrozenDate)
       const ajouterUnComiteAction = vi.fn(async () => Promise.resolve(['OK']))
       afficherUneGouvernance({ ajouterUnComiteAction, pathname: '/gouvernance/11' })
 
@@ -160,7 +158,6 @@ describe('comitologie', () => {
   describe('quand je clique sur un comité,', () => {
     it('alors le drawer des détails du comité s’affiche', () => {
       // GIVEN
-      vi.stubGlobal('Date', FrozenDate)
       afficherUneGouvernance()
 
       // WHEN
@@ -200,8 +197,8 @@ describe('comitologie', () => {
       const date = within(formulaire).getByLabelText('Date du prochain comité')
       expect(date).not.toBeRequired()
       expect(date).toHaveAttribute('type', 'date')
-      expect(date).toHaveAttribute('min', '1996-04-15')
-      expect(date).toHaveValue('2024-03-01')
+      expect(date).toHaveAttribute('min', '1970-01-02')
+      expect(date).toHaveValue('1970-01-01')
 
       const commentaire = within(formulaire).getByLabelText('Laissez ici un commentaire général sur le comité', { selector: 'textarea' })
       expect(commentaire).not.toBeRequired()
@@ -217,7 +214,7 @@ describe('comitologie', () => {
       expect(enregistrer).toHaveAttribute('type', 'submit')
       expect(enregistrer).not.toBeDisabled()
 
-      const modifierPar = screen.getByText('Modifié le 01/02/2024 par Martin Tartempion')
+      const modifierPar = screen.getByText('Modifié le 31/12/1969 par Martin Tartempion')
       expect(modifierPar).toBeInTheDocument()
     })
 
@@ -236,7 +233,6 @@ describe('comitologie', () => {
 
     it('puis que je le modifie et que je l’enregistre, alors le drawer se ferme, une notification s’affiche et la gouvernance est mise à jour', async () => {
       // GIVEN
-      vi.stubGlobal('Date', FrozenDate)
       const modifierUnComiteAction = vi.fn(async () => Promise.resolve(['OK']))
       afficherUneGouvernance({ modifierUnComiteAction, pathname: '/gouvernance/11' })
 
@@ -270,7 +266,6 @@ describe('comitologie', () => {
 
     it('puis que je modifie sans remplir la date et le commentaire qui sont facultatifs, alors la gouvernance est mise à jour', async () => {
       // GIVEN
-      vi.stubGlobal('Date', FrozenDate)
       const modifierUnComiteAction = vi.fn(async () => Promise.resolve(['OK']))
       afficherUneGouvernance({ modifierUnComiteAction, pathname: '/gouvernance/11' })
 
@@ -297,12 +292,13 @@ describe('comitologie', () => {
 
     it('puis que je le modifie mais qu’une erreur intervient, alors une notification s’affiche', async () => {
       // GIVEN
-      vi.stubGlobal('Date', FrozenDate)
       const modifierUnComiteAction = vi.fn(async () => Promise.resolve(['Le format est incorrect', 'autre erreur']))
       afficherUneGouvernance({ modifierUnComiteAction, pathname: '/gouvernance/11' })
 
       // WHEN
       jOuvreLeFormulairePourModifierUnComite()
+      const modifierUnComiteDrawer = screen.getByRole('dialog', { name: 'Détail du Comité technique' })
+      jeChoisisUneDate(modifierUnComiteDrawer, epochTimePlusOneDay.toISOString())
       jEnregistreLeComite()
 
       // THEN
@@ -312,7 +308,6 @@ describe('comitologie', () => {
 
     it('puis que je le supprime, alors le drawer se ferme, une notification s’affiche et la gouvernance est mise à jour', async () => {
       // GIVEN
-      vi.stubGlobal('Date', FrozenDate)
       const supprimerUnComiteAction = vi.fn(async () => Promise.resolve(['OK']))
       afficherUneGouvernance({ pathname: '/gouvernance/11', supprimerUnComiteAction })
 
@@ -338,7 +333,6 @@ describe('comitologie', () => {
 
     it('puis que je le supprime mais qu’une erreur intervient, alors une notification s’affiche', async () => {
       // GIVEN
-      vi.stubGlobal('Date', FrozenDate)
       const supprimerUnComiteAction = vi.fn(async () => Promise.resolve(['Le format est incorrect', 'autre erreur']))
       afficherUneGouvernance({ pathname: '/gouvernance/11', supprimerUnComiteAction })
 
@@ -400,9 +394,7 @@ describe('comitologie', () => {
   }
 
   function afficherUneGouvernance(options?: Partial<Parameters<typeof renderComponent>[1]>): void {
-    const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModelFactory(), now)
+    const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModelFactory(), epochTimePlusOneDay)
     renderComponent(<Gouvernance gouvernanceViewModel={gouvernanceViewModel} />, options)
   }
-
-  const now = new Date('2024-09-06')
 })

--- a/src/components/Gouvernance/Comitologie/ComitologieRemplie.tsx
+++ b/src/components/Gouvernance/Comitologie/ComitologieRemplie.tsx
@@ -5,7 +5,7 @@ import Drawer from '@/components/shared/Drawer/Drawer'
 import Table from '@/components/shared/Table/Table'
 import { GouvernanceViewModel } from '@/presenters/gouvernancePresenter'
 
-export default function ComitologieRemplie({ comites, uidGouvernance }: Props): ReactElement {
+export default function ComitologieRemplie({ comites, dateAujourdhui, uidGouvernance }: Props): ReactElement {
   // Stryker disable next-line BooleanLiteral
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
   const [comite, setComite] = useState(comites[0])
@@ -70,6 +70,7 @@ export default function ComitologieRemplie({ comites, uidGouvernance }: Props): 
             setIsDrawerOpen(false)
           }}
           comite={comite}
+          dateAujourdhui={dateAujourdhui}
           id={drawerModifierComiteId}
           label={`Détail du ${comite.intitule}`}
           labelId={labelModifierComiteId}
@@ -82,5 +83,6 @@ export default function ComitologieRemplie({ comites, uidGouvernance }: Props): 
 
 type Props = Readonly<{
   comites: NonNullable<GouvernanceViewModel['comites']>
+  dateAujourdhui: string
   uidGouvernance: string
 }>

--- a/src/components/Gouvernance/Comitologie/FormulaireComite.tsx
+++ b/src/components/Gouvernance/Comitologie/FormulaireComite.tsx
@@ -6,11 +6,11 @@ import Icon from '@/components/shared/Icon/Icon'
 import SegmentedControl from '@/components/shared/SegmentedControl/SegmentedControl'
 import TextArea from '@/components/shared/TextArea/TextArea'
 import { ComiteViewModel } from '@/presenters/gouvernancePresenter'
-import { formatForInputDate } from '@/presenters/shared/date'
 
 export default function FormulaireComite({
   children,
   comite,
+  dateAujourdhui,
   label,
   labelId,
   validerFormulaire,
@@ -56,7 +56,7 @@ export default function FormulaireComite({
       <div className="fr-col-6 fr-mb-3w">
         <Datepicker
           defaultValue={comite.date}
-          min={formatForInputDate(new Date())}
+          min={dateAujourdhui}
           name="date"
         >
           Date du prochain comité
@@ -82,6 +82,7 @@ export default function FormulaireComite({
 
 type Props = PropsWithChildren<Readonly<{
   comite: ComiteViewModel
+  dateAujourdhui: string
   label: string
   labelId: string
   validerFormulaire(event: FormEvent<HTMLFormElement>): void

--- a/src/components/Gouvernance/Comitologie/ModifierUnComite.tsx
+++ b/src/components/Gouvernance/Comitologie/ModifierUnComite.tsx
@@ -9,6 +9,7 @@ import { ComiteViewModel } from '@/presenters/gouvernancePresenter'
 
 export default function ModifierUnComite({
   comite,
+  dateAujourdhui,
   id,
   label,
   labelId,
@@ -22,6 +23,7 @@ export default function ModifierUnComite({
     <>
       <FormulaireComite
         comite={comite}
+        dateAujourdhui={dateAujourdhui}
         label={label}
         labelId={labelId}
         validerFormulaire={modifierUnComite}
@@ -99,6 +101,7 @@ export default function ModifierUnComite({
 
 type Props = Readonly<{
   comite: ComiteViewModel
+  dateAujourdhui: string
   id: string
   label: string
   labelId: string

--- a/src/components/Gouvernance/FeuilleDeRoute/FeuilleDeRoute.test.tsx
+++ b/src/components/Gouvernance/FeuilleDeRoute/FeuilleDeRoute.test.tsx
@@ -3,9 +3,8 @@ import { within, screen, render } from '@testing-library/react'
 import Gouvernance from '../Gouvernance'
 import { presserLeBouton } from '@/components/testHelper'
 import { gouvernancePresenter } from '@/presenters/gouvernancePresenter'
+import { epochTime } from '@/shared/testHelper'
 import { gouvernanceReadModelFactory } from '@/use-cases/testHelper'
-
-const now = new Date('2024-09-06')
 
 describe('feuille de route', () => {
   it('quand je clique sur une feuille de route, alors un drawer s’ouvre avec les détails de la feuille de route', () => {
@@ -130,7 +129,7 @@ describe('feuille de route', () => {
   }
 
   function afficherUneGouvernance(override?: Partial<Parameters<typeof gouvernanceReadModelFactory>[0]>): void {
-    const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModelFactory(override), now)
+    const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModelFactory(override), epochTime)
     render(<Gouvernance gouvernanceViewModel={gouvernanceViewModel} />)
   }
 })

--- a/src/components/Gouvernance/Gouvernance.test.tsx
+++ b/src/components/Gouvernance/Gouvernance.test.tsx
@@ -3,13 +3,13 @@ import { render, screen, within } from '@testing-library/react'
 import Gouvernance from './Gouvernance'
 import { matchWithoutMarkup, presserLeBouton } from '../testHelper'
 import { gouvernancePresenter } from '@/presenters/gouvernancePresenter'
-import { epochTime } from '@/shared/testHelper'
+import { epochTime, epochTimePlusOneDay } from '@/shared/testHelper'
 import { gouvernanceReadModelFactory } from '@/use-cases/testHelper'
 
 describe('gouvernance', () => {
   it('quand j’affiche une gouvernance, alors elle s’affiche avec son titre et son sous titre', () => {
     // GIVEN
-    const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModelFactory({ departement: 'Rhône' }), now)
+    const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModelFactory({ departement: 'Rhône' }), epochTimePlusOneDay)
 
     // WHEN
     render(<Gouvernance gouvernanceViewModel={gouvernanceViewModel} />)
@@ -28,7 +28,7 @@ describe('gouvernance', () => {
       feuillesDeRoute: undefined,
       membres: undefined,
       noteDeContexte: undefined,
-    }), now)
+    }), epochTimePlusOneDay)
 
     // WHEN
     render(<Gouvernance gouvernanceViewModel={gouvernanceViewModel} />)
@@ -52,7 +52,7 @@ describe('gouvernance', () => {
 
   it('quand j’affiche une gouvernance sans comité, alors elle s’affiche avec sa section lui demandant d’en ajouter un', () => {
     // GIVEN
-    const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModelFactory({ comites: undefined, departement: 'Rhône' }), now)
+    const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModelFactory({ comites: undefined, departement: 'Rhône' }), epochTimePlusOneDay)
 
     // WHEN
     render(<Gouvernance gouvernanceViewModel={gouvernanceViewModel} />)
@@ -73,7 +73,7 @@ describe('gouvernance', () => {
 
   it('quand j’affiche une gouvernance sans comité et que je clique sur ajouter un comité, alors s’affiche le formulaire de création', () => {
     // GIVEN
-    const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModelFactory({ comites: undefined, departement: 'Rhône' }), now)
+    const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModelFactory({ comites: undefined, departement: 'Rhône' }), epochTimePlusOneDay)
 
     render(<Gouvernance gouvernanceViewModel={gouvernanceViewModel} />)
 
@@ -87,7 +87,7 @@ describe('gouvernance', () => {
 
   it('quand j’affiche une gouvernance sans comité et que je clique sur ajouter un comité puis que je clique sur fermer, alors le drawer se ferme', () => {
     // GIVEN
-    const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModelFactory({ comites: undefined, departement: 'Rhône' }), now)
+    const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModelFactory({ comites: undefined, departement: 'Rhône' }), epochTimePlusOneDay)
     render(<Gouvernance gouvernanceViewModel={gouvernanceViewModel} />)
 
     // WHEN
@@ -105,7 +105,7 @@ describe('gouvernance', () => {
       comites: [
         {
           commentaire: 'commentaire',
-          date: new Date('2024-09-06'),
+          date: epochTime,
           derniereEdition: epochTime,
           frequence: 'semestrielle',
           id: 1,
@@ -115,8 +115,8 @@ describe('gouvernance', () => {
         },
         {
           commentaire: 'commentaire',
-          date: new Date('2024-03-01'),
-          derniereEdition: epochTime,
+          date: epochTimePlusOneDay,
+          derniereEdition: epochTimePlusOneDay,
           frequence: 'trimestrielle',
           id: 1,
           nomEditeur: 'Tartempion',
@@ -153,17 +153,17 @@ describe('gouvernance', () => {
     const rowsBody = within(body).getAllByRole('row')
     const columns1Body = within(rowsBody[0]).getAllByRole('cell')
     expect(columns1Body).toHaveLength(3)
-    expect(columns1Body[1].textContent).toBe('Comité stratégique : 06/09/2024')
+    expect(columns1Body[1].textContent).toBe('Comité stratégique : 01/01/1970')
     expect(columns1Body[2].textContent).toBe('Semestriel')
     const columns2Body = within(rowsBody[1]).getAllByRole('cell')
     expect(columns2Body).toHaveLength(3)
-    expect(columns2Body[1].textContent).toBe('Comité technique : 01/03/2024')
+    expect(columns2Body[1].textContent).toBe('Comité technique : 02/01/1970')
     expect(columns2Body[2].textContent).toBe('Trimestriel')
   })
 
   it('quand j’affiche une gouvernance sans membre, alors elle s’affiche avec son résumé et sa section lui demandant d’en ajouter un', () => {
     // GIVEN
-    const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModelFactory({ departement: 'Rhône', membres: undefined }), now)
+    const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModelFactory({ departement: 'Rhône', membres: undefined }), epochTimePlusOneDay)
 
     // WHEN
     render(<Gouvernance gouvernanceViewModel={gouvernanceViewModel} />)
@@ -230,7 +230,7 @@ describe('gouvernance', () => {
           typologieMembre: 'Collectivité, EPCI',
         },
       ],
-    }), now)
+    }), epochTimePlusOneDay)
 
     // WHEN
     render(<Gouvernance gouvernanceViewModel={gouvernanceViewModel} />)
@@ -308,7 +308,7 @@ describe('gouvernance', () => {
           typologieMembre: 'Préfecture départementale',
         },
       ],
-    }), now)
+    }), epochTimePlusOneDay)
 
     // WHEN
     render(<Gouvernance gouvernanceViewModel={gouvernanceViewModel} />)
@@ -327,7 +327,7 @@ describe('gouvernance', () => {
 
   it('quand j’affiche une gouvernance sans feuille de route, alors elle s’affiche avec son résumé à 0 et sa section lui demandant d’en ajouter une', () => {
     // GIVEN
-    const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModelFactory({ departement: 'Rhône', feuillesDeRoute: undefined }), now)
+    const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModelFactory({ departement: 'Rhône', feuillesDeRoute: undefined }), epochTimePlusOneDay)
 
     // WHEN
     render(<Gouvernance gouvernanceViewModel={gouvernanceViewModel} />)
@@ -376,7 +376,7 @@ describe('gouvernance', () => {
           totalActions: 1,
         },
       ],
-    }), now)
+    }), epochTimePlusOneDay)
 
     // WHEN
     render(<Gouvernance gouvernanceViewModel={gouvernanceViewModel} />)
@@ -440,7 +440,7 @@ describe('gouvernance', () => {
           totalActions: 3,
         },
       ],
-    }), now)
+    }), epochTimePlusOneDay)
 
     // WHEN
     render(<Gouvernance gouvernanceViewModel={gouvernanceViewModel} />)
@@ -461,7 +461,7 @@ describe('gouvernance', () => {
 
   it('quand j’affiche une gouvernance sans note de contexte, alors elle s’affiche avec sa section lui demandant d’en ajouter une', () => {
     // GIVEN
-    const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModelFactory({ departement: 'Rhône', noteDeContexte: undefined }), now)
+    const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModelFactory({ departement: 'Rhône', noteDeContexte: undefined }), epochTimePlusOneDay)
 
     // WHEN
     render(<Gouvernance gouvernanceViewModel={gouvernanceViewModel} />)
@@ -484,12 +484,12 @@ describe('gouvernance', () => {
     // GIVEN
     const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModelFactory({
       noteDeContexte: {
-        dateDeModification: new Date('2024-09-06'),
+        dateDeModification: epochTime,
         nomAuteur: 'Deschamps',
         prenomAuteur: 'Jean',
         texte: '<strong>titre note de contexte</strong><p>un paragraphe avec du <b>bold</b>.</p><p>un paragraphe avec du <b>bold</b>.</p><p>un paragraphe avec du <b>bold</b>.</p><p>un paragraphe avec du <b>bold</b>.</p><p>un paragraphe avec du <b>bold</b>.</p><p>un paragraphe avec du <b>bold</b>.</p><p>un paragraphe avec du <b>bold</b>.</p><p>un paragraphe avec du <b>bold</b>.</p><p>un paragraphe avec du <b>bold</b>.</p><p>un paragraphe avec du <b>bold</b>.</p><p>un paragraphe avec du <b>bold</b>.</p><p>un paragraphe avec du <b>bold</b>.</p><p>un paragraphe avec du <b>bold</b>.</p><p>un paragraphe avec du <b>bold</b>.</p><p>un paragraphe avec du <b>bold</b>.</p><p>un paragraphe avec du <b>bold</b>.</p><p>un paragraphe avec du <b>bold</b>.</p>',
       },
-    }), now)
+    }), epochTimePlusOneDay)
 
     // WHEN
     render(<Gouvernance gouvernanceViewModel={gouvernanceViewModel} />)
@@ -501,7 +501,7 @@ describe('gouvernance', () => {
     expect(titreNoteDeContexte).toBeInTheDocument()
     const modifier = within(sectionNoteDeContexte).getByRole('button', { name: 'Modifier' })
     expect(modifier).toHaveAttribute('type', 'button')
-    const auteurDeLaNote = screen.getAllByText('Modifié le 06/09/2024 par Jean Deschamps', { selector: 'p' })[0]
+    const auteurDeLaNote = screen.getAllByText('Modifié le 01/01/1970 par Jean Deschamps', { selector: 'p' })[0]
     expect(auteurDeLaNote).toBeInTheDocument()
     const contenuNoteDeContexte = within(sectionNoteDeContexte).getByRole('article')
     const noteDeContexteElement1 = within(contenuNoteDeContexte).getByText('titre note de contexte', { selector: 'strong' })
@@ -517,7 +517,10 @@ describe('gouvernance', () => {
 
   it('quand j’affiche une gouvernance sans note de contexte et que je clique sur ajouter une note de contexte puis que je clique sur fermer, alors le drawer se ferme', () => {
     // GIVEN
-    const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModelFactory({ noteDeContexte: undefined }), now)
+    const gouvernanceViewModel = gouvernancePresenter(
+      gouvernanceReadModelFactory({ noteDeContexte: undefined }),
+      epochTimePlusOneDay
+    )
     render(<Gouvernance gouvernanceViewModel={gouvernanceViewModel} />)
 
     // WHEN
@@ -533,12 +536,12 @@ describe('gouvernance', () => {
     // GIVEN
     const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModelFactory({
       noteDeContexte: {
-        dateDeModification: new Date('0'),
+        dateDeModification: epochTime,
         nomAuteur: 'Deschamps',
         prenomAuteur: 'Jean',
         texte: '<strong>titre note de contexte</strong><p>un paragraphe avec du <b>bold</b>.</p>',
       },
-    }), now)
+    }), epochTimePlusOneDay)
     render(<Gouvernance gouvernanceViewModel={gouvernanceViewModel} />)
 
     // WHEN
@@ -565,7 +568,7 @@ describe('gouvernance', () => {
           type: 'stratégique',
         },
       ],
-    }), now)
+    }), epochTimePlusOneDay)
 
     // WHEN
     render(<Gouvernance gouvernanceViewModel={gouvernanceViewModel} />)
@@ -582,7 +585,7 @@ describe('gouvernance', () => {
       comites: [
         {
           commentaire: 'commentaire',
-          date: new Date('2020-09-05'),
+          date: epochTime,
           derniereEdition: epochTime,
           frequence: 'semestrielle',
           id: 1,
@@ -591,7 +594,7 @@ describe('gouvernance', () => {
           type: 'stratégique',
         },
       ],
-    }), now)
+    }), epochTimePlusOneDay)
 
     // WHEN
     render(<Gouvernance gouvernanceViewModel={gouvernanceViewModel} />)
@@ -608,7 +611,7 @@ describe('gouvernance', () => {
       comites: [
         {
           commentaire: 'commentaire',
-          date: new Date('1996-04-15'),
+          date: epochTime,
           derniereEdition: epochTime,
           frequence: 'semestrielle',
           id: 1,
@@ -617,7 +620,7 @@ describe('gouvernance', () => {
           type: 'stratégique',
         },
       ],
-    }), new Date('1996-04-15'))
+    }), epochTime)
 
     // WHEN
     render(<Gouvernance gouvernanceViewModel={gouvernanceViewModel} />)
@@ -625,7 +628,7 @@ describe('gouvernance', () => {
     // THEN
     const comites = screen.getByRole('table', { name: 'Comités' })
     const columns1Body = within(comites).getAllByRole('cell')
-    expect(columns1Body[1].textContent).toBe('Comité stratégique : 15/04/1996')
+    expect(columns1Body[1].textContent).toBe('Comité stratégique : 01/01/1970')
   })
 
   function jOuvreLeFormulairePourAjouterUnComite(): void {
@@ -647,6 +650,4 @@ describe('gouvernance', () => {
   function jeDeplieLaNoteDeContexte(): HTMLElement {
     return presserLeBouton('Lire plus')
   }
-
-  const now = new Date('2024-09-06')
 })

--- a/src/components/Gouvernance/Gouvernance.tsx
+++ b/src/components/Gouvernance/Gouvernance.tsx
@@ -179,6 +179,7 @@ export default function Gouvernance({ gouvernanceViewModel }: Props): ReactEleme
               setIsDrawerOpen(false)
             }}
             comite={gouvernanceViewModel.comiteARemplir}
+            dateAujourdhui={gouvernanceViewModel.dateAujourdhui}
             id={drawerComiteId}
             labelId={labelComiteId}
             uidGouvernance={gouvernanceViewModel.uid}
@@ -205,6 +206,7 @@ export default function Gouvernance({ gouvernanceViewModel }: Props): ReactEleme
             >
               <ComitologieRemplie
                 comites={gouvernanceViewModel.comites}
+                dateAujourdhui={gouvernanceViewModel.dateAujourdhui}
                 uidGouvernance={gouvernanceViewModel.uid}
               />
             </SectionRemplie>

--- a/src/components/Gouvernance/Membre/Membre.test.tsx
+++ b/src/components/Gouvernance/Membre/Membre.test.tsx
@@ -4,6 +4,7 @@ import { fireEvent, within, screen, render, cleanup } from '@testing-library/rea
 import Gouvernance from '../Gouvernance'
 import { matchWithoutMarkup } from '@/components/testHelper'
 import { gouvernancePresenter } from '@/presenters/gouvernancePresenter'
+import { epochTime } from '@/shared/testHelper'
 import { gouvernanceReadModelFactory } from '@/use-cases/testHelper'
 
 describe('membres', () => {
@@ -534,7 +535,7 @@ describe('membres', () => {
 })
 
 function afficherGouvernance(gouvernance?: object): void {
-  const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModelFactory(gouvernance), new Date())
+  const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModelFactory(gouvernance), epochTime)
   render(<Gouvernance gouvernanceViewModel={gouvernanceViewModel} />)
 }
 

--- a/src/components/Gouvernance/NoteDeContexte/NoteDeContexte.test.tsx
+++ b/src/components/Gouvernance/NoteDeContexte/NoteDeContexte.test.tsx
@@ -5,9 +5,8 @@ import { vi } from 'vitest'
 import Gouvernance from '../Gouvernance'
 import { presserLeBouton, renderComponent } from '@/components/testHelper'
 import { gouvernancePresenter } from '@/presenters/gouvernancePresenter'
+import { epochTime } from '@/shared/testHelper'
 import { gouvernanceReadModelFactory } from '@/use-cases/testHelper'
-
-const now = new Date('2024-09-06')
 
 const mockRichTextEditor = {
   contenu: '',
@@ -126,7 +125,7 @@ describe('note de contexte', () => {
     expect(editeurDeTextEnrichi.innerHTML).toBe('<p><strong>titre note de contexte</strong></p><p>un paragraphe avec du bold <strong>bold</strong></p>')
     const boutonEnregistrer = within(drawer).getByRole('button', { name: 'Enregistrer' })
     expect(boutonEnregistrer).toBeDisabled()
-    const modifierPar = within(drawer).getByText('Modifié le 06/09/2024 par Jean Deschamps')
+    const modifierPar = within(drawer).getByText('Modifié le 01/01/1970 par Jean Deschamps')
     expect(modifierPar).toBeInTheDocument()
   })
 
@@ -196,19 +195,22 @@ describe('note de contexte', () => {
   })
 
   function afficherUneGouvernance(options?: Partial<Parameters<typeof renderComponent>[1]>): void {
-    const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModelFactory({ noteDeContexte: undefined }), now)
+    const gouvernanceViewModel = gouvernancePresenter(
+      gouvernanceReadModelFactory({ noteDeContexte: undefined }),
+      epochTime
+    )
     renderComponent(<Gouvernance gouvernanceViewModel={gouvernanceViewModel} />, options)
   }
 
   function afficherUneGouvernanceAvecNoteDeContexte(options?: Partial<Parameters<typeof renderComponent>[1]>): void {
     const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModelFactory({
       noteDeContexte: {
-        dateDeModification: new Date('2024-09-06'),
+        dateDeModification: epochTime,
         nomAuteur: 'Deschamps',
         prenomAuteur: 'Jean',
         texte: '<p><strong>titre note de contexte</strong></p><p>un paragraphe avec du bold <b>bold</b></p>',
       },
-    }), now)
+    }), epochTime)
     renderComponent(<Gouvernance gouvernanceViewModel={gouvernanceViewModel} />, options)
   }
 

--- a/src/components/Gouvernance/NotePrivee/NotePrivee.test.tsx
+++ b/src/components/Gouvernance/NotePrivee/NotePrivee.test.tsx
@@ -224,6 +224,21 @@ describe('note privée', () => {
       expect(enregistrer).toBeEnabled()
     })
 
+    it('puis que je veux supprimer la note privée mais qu’une erreur intervient, alors une notification s’affiche', async () => {
+      // GIVEN
+      const supprimerUneNotePriveeAction = vi.fn(async () => Promise.resolve(['Le format est incorrect', 'autre erreur']))
+      afficherUneGouvernanceAvecNotePrivee({ pathname: '/gouvernance/11', supprimerUneNotePriveeAction })
+
+      // WHEN
+      jouvreLeFormulairePourModifierUneNotePrivee()
+      jEffaceLaNotePrivee()
+      jEnregistreLaNotePrivee()
+
+      // THEN
+      const notification = await screen.findByRole('alert')
+      expect(notification.textContent).toBe('Erreur : Le format est incorrect, autre erreur')
+    })
+
     function jouvreLeFormulairePourModifierUneNotePrivee(): void {
       presserLeBouton('Modifier la note')
     }

--- a/src/components/MesUtilisateurs/FiltrerMesUtilisateurs.test.tsx
+++ b/src/components/MesUtilisateurs/FiltrerMesUtilisateurs.test.tsx
@@ -4,6 +4,7 @@ import { clearFirst } from 'react-select-event'
 import MesUtilisateurs from './MesUtilisateurs'
 import { cocherLaCase, presserLeBouton, saisirLeTexte, renderComponent, rolesAvecStructure, structuresFetch, selectionnerLElement } from '@/components/testHelper'
 import { mesUtilisateursPresenter } from '@/presenters/mesUtilisateursPresenter'
+import { epochTime } from '@/shared/testHelper'
 
 describe('filtrer mes utilisateurs', () => {
   it('quand je clique sur le bouton pour filtrer alors les filtres apparaissent', () => {
@@ -399,7 +400,7 @@ describe('filtrer mes utilisateurs', () => {
     options?: Partial<Parameters<typeof renderComponent>[1]>,
     totalUtilisateur = 11
   ): void {
-    const mesUtilisateursViewModel = mesUtilisateursPresenter([], 'fooId', totalUtilisateur, rolesAvecStructure)
+    const mesUtilisateursViewModel = mesUtilisateursPresenter([], 'fooId', totalUtilisateur, rolesAvecStructure, epochTime)
     renderComponent(<MesUtilisateurs mesUtilisateursViewModel={mesUtilisateursViewModel} />, options)
   }
 })

--- a/src/components/MesUtilisateurs/InviterUnUtilisateur.test.tsx
+++ b/src/components/MesUtilisateurs/InviterUnUtilisateur.test.tsx
@@ -4,6 +4,7 @@ import MesUtilisateurs from './MesUtilisateurs'
 import { renderComponent, matchWithoutMarkup, structuresFetch, rolesAvecStructure, stubbedConceal, presserLeBouton, saisirLeTexte, selectionnerLElement } from '@/components/testHelper'
 import { mesUtilisateursPresenter } from '@/presenters/mesUtilisateursPresenter'
 import { sessionUtilisateurViewModelFactory } from '@/presenters/testHelper'
+import { epochTime } from '@/shared/testHelper'
 
 describe('inviter un utilisateur', () => {
   it('en tant qu’administrateur, quand je clique sur le bouton inviter, alors le drawer s’ouvre avec tous les rôles sélectionnables', async () => {
@@ -434,7 +435,7 @@ describe('inviter un utilisateur', () => {
   }
 
   function afficherMesUtilisateurs(options?: Partial<Parameters<typeof renderComponent>[1]>): void {
-    const mesUtilisateursViewModel = mesUtilisateursPresenter([], 'fooId', 11, rolesAvecStructure)
+    const mesUtilisateursViewModel = mesUtilisateursPresenter([], 'fooId', 11, rolesAvecStructure, epochTime)
     renderComponent(<MesUtilisateurs mesUtilisateursViewModel={mesUtilisateursViewModel} />, {
       sessionUtilisateurViewModel: sessionUtilisateurViewModelFactory({
         role: {

--- a/src/components/testHelper.tsx
+++ b/src/components/testHelper.tsx
@@ -97,11 +97,6 @@ export const rolesAvecStructure: RolesAvecStructure = {
     placeholder: 'Nom de la structure',
   },
 }
-export class FrozenDate extends Date {
-  constructor(date: number | string | Date | undefined) {
-    super(date ?? '1996-04-15T03:24:00')
-  }
-}
 
 export function stubbedConceal() {
   return (): { modal: { conceal: Mock } } => ({

--- a/src/domain/UtilisateurFactory.test.ts
+++ b/src/domain/UtilisateurFactory.test.ts
@@ -5,7 +5,7 @@ import { GestionnaireRegion } from './GestionnaireRegion'
 import { GestionnaireStructure } from './GestionnaireStructure'
 import { Utilisateur } from './Utilisateur'
 import { UtilisateurFactory } from './UtilisateurFactory'
-import { epochTime } from '@/shared/testHelper'
+import { epochTime, epochTimePlusOneDay, invalidDate } from '@/shared/testHelper'
 
 describe('utilisateur factory', () => {
   it.each([
@@ -105,7 +105,7 @@ describe('utilisateur factory', () => {
       expectedIsActive: false,
     },
     {
-      derniereConnexion: new Date(1),
+      derniereConnexion: epochTimePlusOneDay,
       desc: 'un utilisateur s’étant déjà connecté est créé comme actif',
       expectedIsActive: true,
     },
@@ -162,7 +162,7 @@ describe('utilisateur factory', () => {
   it('la date de dernière connexion doit être une date valide', () => {
     // GIVEN
     const utilisateurParams = {
-      derniereConnexion: new Date('foo'),
+      derniereConnexion: invalidDate,
       emailDeContact: 'martin.tartempion@example.net',
       inviteLe: epochTime,
       isSuperAdmin: false,
@@ -183,7 +183,7 @@ describe('utilisateur factory', () => {
     const utilisateurParams = {
       derniereConnexion: epochTime,
       emailDeContact: 'martin.tartempion@example.net',
-      inviteLe: new Date('foo'),
+      inviteLe: invalidDate,
       isSuperAdmin: false,
       nom: 'Tartempion',
       prenom: 'Martin',

--- a/src/domain/testHelper.ts
+++ b/src/domain/testHelper.ts
@@ -40,7 +40,7 @@ export function gouvernanceFactory(override?: Partial<Parameters<typeof Gouverna
     },
     notePrivee: {
       contenu: 'un contenu quelconque',
-      dateDeModification: new Date('2000-01-01'),
+      dateDeModification: epochTime,
       uidEditeur: new UtilisateurUid(utilisateurFactory().state.uid),
     },
     uid: 'gouvernanceFooId',

--- a/src/gateways/NextAuthAuthentificationGateway.ts
+++ b/src/gateways/NextAuthAuthentificationGateway.ts
@@ -34,6 +34,7 @@ const nextAuthOptions = {
       if (profile) {
         const utilisateurRepository = new PrismaUtilisateurRepository(prisma.utilisateurRecord)
         if (profile.sub !== undefined) {
+          // eslint-disable-next-line no-restricted-syntax
           await new MettreAJourDateDeDerniereConnexion(utilisateurRepository, new Date()).execute({
             uidUtilisateurCourant: profile.sub,
           })

--- a/src/gateways/PrismaComiteRepository.test.ts
+++ b/src/gateways/PrismaComiteRepository.test.ts
@@ -2,7 +2,7 @@ import { PrismaComiteRepository } from './PrismaComiteRepository'
 import { comiteRecordFactory, departementRecordFactory, gouvernanceRecordFactory, regionRecordFactory, utilisateurRecordFactory } from './testHelper'
 import prisma from '../../prisma/prismaClient'
 import { comiteFactory } from '@/domain/testHelper'
-import { epochTime } from '@/shared/testHelper'
+import { epochTime, epochTimePlusOneDay } from '@/shared/testHelper'
 
 describe('comité repository', () => {
   beforeEach(async () => prisma.$queryRaw`START TRANSACTION`)
@@ -163,7 +163,7 @@ describe('comité repository', () => {
       data: gouvernanceRecordFactory({ departementCode: '75' }),
     })
     await prisma.comiteRecord.create({
-      data: comiteRecordFactory({ date: epochTime, derniereEdition: new Date('1970-01-02'), editeurUtilisateurId: 'userFooId', gouvernanceDepartementCode: '75', id: 2 }),
+      data: comiteRecordFactory({ date: epochTime, derniereEdition: epochTimePlusOneDay, editeurUtilisateurId: 'userFooId', gouvernanceDepartementCode: '75', id: 2 }),
     })
     const repository = new PrismaComiteRepository(prisma.comiteRecord)
 
@@ -210,9 +210,9 @@ describe('comité repository', () => {
     // WHEN
     await repository.update(comiteFactory({
       commentaire: 'deuxième commentaire',
-      date: new Date('2025-01-01'),
+      date: epochTimePlusOneDay,
       dateDeCreation: epochTime,
-      dateDeModification: new Date('2025-01-01'),
+      dateDeModification: epochTimePlusOneDay,
       frequence: 'mensuelle',
       type: 'autre',
       uid: {
@@ -236,8 +236,8 @@ describe('comité repository', () => {
     expect(comiteRecord).toMatchObject(comiteRecordFactory({
       commentaire: 'deuxième commentaire',
       creation: epochTime,
-      date: new Date('2025-01-01'),
-      derniereEdition: new Date('2025-01-01'),
+      date: epochTimePlusOneDay,
+      derniereEdition: epochTimePlusOneDay,
       editeurUtilisateurId: 'userFooId',
       frequence: 'mensuelle',
       gouvernanceDepartementCode: '75',

--- a/src/gateways/PrismaGouvernanceLoader.test.ts
+++ b/src/gateways/PrismaGouvernanceLoader.test.ts
@@ -1,7 +1,7 @@
 import { PrismaGouvernanceLoader } from './PrismaGouvernanceLoader'
 import { departementRecordFactory, regionRecordFactory, utilisateurRecordFactory } from './testHelper'
 import prisma from '../../prisma/prismaClient'
-import { epochTime } from '@/shared/testHelper'
+import { epochTime, epochTimeMinusOneDay } from '@/shared/testHelper'
 import { UneGouvernanceReadModel } from '@/use-cases/queries/RecupererUneGouvernance'
 
 describe('gouvernance loader', () => {
@@ -42,8 +42,8 @@ describe('gouvernance loader', () => {
         // @ts-expect-error
         {
           commentaire: 'commentaire',
-          date: new Date('2024-11-23'),
-          derniereEdition: new Date('2024-11-23'),
+          date: epochTime,
+          derniereEdition: epochTime,
           frequence: 'trimestrielle',
           nomEditeur: 'Deschamps',
           prenomEditeur: 'Jean',
@@ -52,8 +52,8 @@ describe('gouvernance loader', () => {
         // @ts-expect-error
         {
           commentaire: 'commentaire',
-          date: new Date('2024-08-01'),
-          derniereEdition: new Date('2024-11-23'),
+          date: epochTimeMinusOneDay,
+          derniereEdition: epochTime,
           frequence: 'trimestrielle',
           nomEditeur: 'Deschamps',
           prenomEditeur: 'Jean',
@@ -156,8 +156,8 @@ describe('gouvernance loader', () => {
     await prisma.comiteRecord.create({
       data: {
         commentaire: 'commentaire',
-        creation: new Date('2024-11-23'),
-        derniereEdition: new Date('2024-11-23'),
+        creation: epochTime,
+        derniereEdition: epochTime,
         editeurUtilisateurId: 'userFooId',
         frequence: 'trimestrielle',
         gouvernanceDepartementCode: gouvernance.departementCode,
@@ -177,7 +177,7 @@ describe('gouvernance loader', () => {
         {
           commentaire: 'commentaire',
           date: undefined,
-          derniereEdition: new Date('2024-11-23'),
+          derniereEdition: epochTime,
           frequence: 'trimestrielle',
           nomEditeur: 'Deschamps',
           periodicite: 'trimestrielle',
@@ -211,9 +211,9 @@ describe('gouvernance loader', () => {
     })
     await prisma.comiteRecord.create({
       data: {
-        creation: new Date('2024-11-23'),
-        date: new Date('2024-11-23'),
-        derniereEdition: new Date('2024-11-23'),
+        creation: epochTime,
+        date: epochTime,
+        derniereEdition: epochTime,
         editeurUtilisateurId: 'userFooId',
         frequence: 'trimestrielle',
         gouvernanceDepartementCode: gouvernance.departementCode,
@@ -233,8 +233,8 @@ describe('gouvernance loader', () => {
       [
         {
           commentaire: '',
-          date: new Date('2024-11-23'),
-          derniereEdition: new Date('2024-11-23'),
+          date: epochTime,
+          derniereEdition: epochTime,
           frequence: 'trimestrielle',
           nomEditeur: 'Deschamps',
           prenomEditeur: 'Jean',
@@ -266,9 +266,9 @@ describe('gouvernance loader', () => {
     await prisma.comiteRecord.create({
       data: {
         commentaire: 'commentaire',
-        creation: new Date('2024-11-23'),
-        date: new Date('2024-11-23'),
-        derniereEdition: new Date('2024-11-23'),
+        creation: epochTime,
+        date: epochTime,
+        derniereEdition: epochTime,
         editeurUtilisateurId: 'userFooId',
         frequence: 'trimestrielle',
         gouvernanceDepartementCode: gouvernance.departementCode,
@@ -287,8 +287,8 @@ describe('gouvernance loader', () => {
       [
         {
           commentaire: 'commentaire',
-          date: new Date('2024-11-23'),
-          derniereEdition: new Date('2024-11-23'),
+          date: epochTime,
+          derniereEdition: epochTime,
           frequence: 'trimestrielle',
           nomEditeur: 'Tartempion',
           periodicite: 'trimestrielle',
@@ -462,9 +462,9 @@ async function creerComites(): Promise<void> {
   await prisma.comiteRecord.create({
     data: {
       commentaire: 'commentaire',
-      creation: new Date('2024-11-23'),
-      date: new Date('2024-11-23'),
-      derniereEdition: new Date('2024-11-23'),
+      creation: epochTime,
+      date: epochTime,
+      derniereEdition: epochTime,
       editeurUtilisateurId: 'userFooId',
       frequence: 'trimestrielle',
       gouvernanceDepartementCode: '93',
@@ -474,9 +474,9 @@ async function creerComites(): Promise<void> {
   await prisma.comiteRecord.create({
     data: {
       commentaire: 'commentaire',
-      creation: new Date('2024-11-23'),
-      date: new Date('2024-08-01'),
-      derniereEdition: new Date('2024-11-23'),
+      creation: epochTime,
+      date: epochTimeMinusOneDay,
+      derniereEdition: epochTime,
       editeurUtilisateurId: 'userFooId',
       frequence: 'trimestrielle',
       gouvernanceDepartementCode: '93',

--- a/src/gateways/PrismaGouvernanceRepository.test.ts
+++ b/src/gateways/PrismaGouvernanceRepository.test.ts
@@ -96,7 +96,7 @@ describe('gouvernance repository', () => {
     const gouvernanceMiseAJourAvecNoteDeContexte = gouvernanceFactory({
       noteDeContexte: {
         contenu: '<p>lorem ipsum dolor sit amet</p>',
-        dateDeModification: new Date('2000-01-01'),
+        dateDeModification: epochTime,
         uidEditeur: new UtilisateurUid({
           email: 'martin.tartempion@example.net',
           value: 'userFooId',
@@ -124,7 +124,7 @@ describe('gouvernance repository', () => {
       editeurNotePriveeId: null,
       noteDeContexte: {
         contenu: '<p>lorem ipsum dolor sit amet</p>',
-        derniereEdition: new Date('2000-01-01'),
+        derniereEdition: epochTime,
         editeurId: 'userFooId',
         gouvernanceDepartementCode: '75',
       },
@@ -243,7 +243,7 @@ describe('gouvernance repository', () => {
     await repository.update(gouvernanceFactory({
       notePrivee: {
         contenu: 'un autre contenu quelconque',
-        dateDeModification: new Date('2000-01-01'),
+        dateDeModification: epochTime,
         uidEditeur: new UtilisateurUid(utilisateurFactory({
           uid: {
             email: 'userFooId2@example.com',
@@ -261,7 +261,7 @@ describe('gouvernance repository', () => {
       editeurNotePriveeId: 'userFooId2',
       notePrivee: {
         contenu: 'un autre contenu quelconque',
-        derniereEdition: new Date('2000-01-01').toISOString(),
+        derniereEdition: epochTime.toISOString(),
       },
     }))
     expect(modifiedRecords[1]).toStrictEqual(gouvernanceRecordFactory({

--- a/src/gateways/PrismaUtilisateurLoader.test.ts
+++ b/src/gateways/PrismaUtilisateurLoader.test.ts
@@ -534,7 +534,7 @@ describe('prisma utilisateur query', () => {
     it('quand je cherche mes utilisateurs alors je distingue ceux inactifs', async () => {
       // GIVEN
       await prisma.utilisateurRecord.create({
-        data: utilisateurRecordFactory({ derniereConnexion: new Date('2024-01-01'), nom: 'a', ssoId }),
+        data: utilisateurRecordFactory({ derniereConnexion: epochTime, nom: 'a', ssoId }),
       })
       await prisma.utilisateurRecord.create({
         data: utilisateurRecordFactory({ derniereConnexion: null, nom: 'b', ssoEmail: 'anthony.parquet@example.com', ssoId: '123456' }),
@@ -558,9 +558,8 @@ describe('prisma utilisateur query', () => {
 
     it('quand je cherche mes utilisateurs actifs alors je trouve tous ceux qui sont actifs', async () => {
       // GIVEN
-      const derniereConnexion = new Date('2024-01-01')
       await prisma.utilisateurRecord.create({
-        data: utilisateurRecordFactory({ derniereConnexion, nom: 'a', ssoId }),
+        data: utilisateurRecordFactory({ derniereConnexion: epochTime, nom: 'a', ssoId }),
       })
       await prisma.utilisateurRecord.create({
         data: utilisateurRecordFactory({ derniereConnexion: null, nom: 'b', ssoEmail: 'anthony.parquet@example.com', ssoId: '123456' }),

--- a/src/gateways/PrismaUtilisateurRepository.test.ts
+++ b/src/gateways/PrismaUtilisateurRepository.test.ts
@@ -11,7 +11,7 @@ import {
 import prisma from '../../prisma/prismaClient'
 import { departementFactory, utilisateurFactory } from '@/domain/testHelper'
 import { UtilisateurUid } from '@/domain/Utilisateur'
-import { epochTime } from '@/shared/testHelper'
+import { epochTime, epochTimePlusOneDay } from '@/shared/testHelper'
 
 const uidUtilisateurValue = 'userFooId'
 const uidUtilisateur = new UtilisateurUid({ email: 'martin.tartempion@example.net', value: uidUtilisateurValue })
@@ -188,7 +188,7 @@ describe('utilisateur repository', () => {
           expectedIsActive: false,
         },
         {
-          derniereConnexion: new Date(1),
+          derniereConnexion: epochTimePlusOneDay,
           desc: 'un utilisateur s’étant déjà connecté est marqué actif',
           expectedIsActive: true,
         },

--- a/src/gateways/testHelper.ts
+++ b/src/gateways/testHelper.ts
@@ -88,7 +88,7 @@ export function gouvernanceRecordFactory(
     editeurNotePriveeId: 'userFooId',
     notePrivee: {
       contenu: 'un contenu quelconque',
-      derniereEdition: '2000-01-01T00:00:00.000Z',
+      derniereEdition: '1970-01-01T00:00:00.000Z',
     },
     ...override,
   }

--- a/src/presenters/gouvernancePresenter.ts
+++ b/src/presenters/gouvernancePresenter.ts
@@ -10,6 +10,7 @@ export function gouvernancePresenter(
   return {
     ...{ comites: gouvernanceReadModel.comites?.map((comite) => toComitesViewModel(comite, now)) },
     comiteARemplir,
+    dateAujourdhui: formatForInputDate(now),
     departement: gouvernanceReadModel.departement,
     isVide: isGouvernanceVide(gouvernanceReadModel),
     notePrivee: toNotePriveeViewModel(gouvernanceReadModel.notePrivee),
@@ -32,6 +33,7 @@ export function gouvernancePresenter(
 export type GouvernanceViewModel = Readonly<{
   comites?: ReadonlyArray<ComiteResumeViewModel>
   comiteARemplir: ComiteViewModel
+  dateAujourdhui: string
   departement: string
   isVide: boolean
   notePrivee?: Readonly<{

--- a/src/presenters/mesUtilisateursPresenter.ts
+++ b/src/presenters/mesUtilisateursPresenter.ts
@@ -7,7 +7,7 @@ export function mesUtilisateursPresenter(
   uid: string,
   totalUtilisateur: number,
   rolesAvecStructure: RolesAvecStructure,
-  now = (): Date => new Date()
+  now: Date
 ): MesUtilisateursViewModel {
   return {
     displayPagination: totalUtilisateur > config.utilisateursParPage,
@@ -28,7 +28,7 @@ export function mesUtilisateursPresenter(
         },
         derniereConnexion: buildDate(monUtilisateur),
         emailDeContact: monUtilisateur.email,
-        inviteLe: buildDateFrancaiseEnAttente(monUtilisateur.inviteLe, now()),
+        inviteLe: buildDateFrancaiseEnAttente(monUtilisateur.inviteLe, now),
         isActif: monUtilisateur.isActive,
         picto,
         prenomEtNom: `${monUtilisateur.prenom} ${monUtilisateur.nom}`,
@@ -97,15 +97,16 @@ function buildDate(utilisateurReadModel: UnUtilisateurReadModel): string {
 
 function buildDateFrancaiseEnAttente(dateDInvitation: Date, now: Date): string {
   const today = formaterEnDateFrancaise(now)
-  const yesterday = formaterEnDateFrancaise(new Date(now.setDate(now.getDate() - 1)))
+  const invitationDate = formaterEnDateFrancaise(dateDInvitation)
+  const yesterday = formaterEnDateFrancaise(new Date(new Date(now).setDate(new Date(now).getDate() - 1)))
 
-  if (formaterEnDateFrancaise(dateDInvitation) === today) {
+  if (invitationDate === today) {
     return 'Invitation envoyée aujourd’hui'
   }
 
-  if (formaterEnDateFrancaise(dateDInvitation) === yesterday) {
+  if (invitationDate === yesterday) {
     return 'Invitation envoyée hier'
   }
 
-  return `Invitation envoyée le ${formaterEnDateFrancaise(dateDInvitation)}`
+  return `Invitation envoyée le ${invitationDate}`
 }

--- a/src/shared/testHelper.ts
+++ b/src/shared/testHelper.ts
@@ -1,1 +1,11 @@
-export const epochTime: Readonly<Date> = new Date(0)
+const millisPerDay = 86_400_000
+
+export const epochTimeMinusTwoDays: Date = new Date(-millisPerDay * 2)
+
+export const epochTimeMinusOneDay: Date = new Date(-millisPerDay)
+
+export const epochTime: Date = new Date(0)
+
+export const epochTimePlusOneDay: Date = new Date(millisPerDay)
+
+export const invalidDate: Date = new Date(NaN)

--- a/src/use-cases/commands/AjouterUnComite.test.ts
+++ b/src/use-cases/commands/AjouterUnComite.test.ts
@@ -6,7 +6,7 @@ import { Comite } from '@/domain/Comite'
 import { Gouvernance, GouvernanceUid } from '@/domain/Gouvernance'
 import { comiteFactory, gouvernanceFactory, utilisateurFactory } from '@/domain/testHelper'
 import { Utilisateur, UtilisateurUidState } from '@/domain/Utilisateur'
-import { epochTime } from '@/shared/testHelper'
+import { epochTime, epochTimePlusOneDay, invalidDate } from '@/shared/testHelper'
 
 describe('ajouter un comité à une gouvernance', () => {
   beforeEach(() => {
@@ -19,7 +19,7 @@ describe('ajouter un comité à une gouvernance', () => {
     {
       commentaire,
       date,
-      expectedDate: new Date(date),
+      expectedDate: epochTime,
       frequence: frequenceValide,
       intention: 'complètement',
       type: typeValide,
@@ -40,7 +40,7 @@ describe('ajouter un comité à une gouvernance', () => {
     type,
   }) => {
     // GIVEN
-    const dateDeCreation = new Date('2024-01-01')
+    const dateDeCreation = epochTime
     const ajouterUnComite = new AjouterUnComite(
       new GouvernanceRepositorySpy(),
       new GestionnaireRepositorySpy(),
@@ -87,7 +87,7 @@ describe('ajouter un comité à une gouvernance', () => {
   it.each([
     {
       date,
-      dateDeCreation: date,
+      dateDeCreation: epochTime,
       expectedFailure: 'frequenceInvalide',
       frequence: 'frequenceInvalide',
       intention: 'd’une fréquence invalide',
@@ -95,7 +95,7 @@ describe('ajouter un comité à une gouvernance', () => {
     },
     {
       date,
-      dateDeCreation: date,
+      dateDeCreation: epochTime,
       expectedFailure: 'typeInvalide',
       frequence: frequenceValide,
       intention: 'd’un type invalide',
@@ -103,7 +103,7 @@ describe('ajouter un comité à une gouvernance', () => {
     },
     {
       date: 'dateDuComiteInvalide',
-      dateDeCreation: date,
+      dateDeCreation: epochTime,
       expectedFailure: 'dateDuComiteInvalide',
       frequence: frequenceValide,
       intention: 'de la date invalide',
@@ -111,15 +111,15 @@ describe('ajouter un comité à une gouvernance', () => {
     },
     {
       date,
-      dateDeCreation: 'dateDeCreationInvalide',
+      dateDeCreation: invalidDate,
       expectedFailure: 'dateDeCreationInvalide',
       frequence: frequenceValide,
       intention: 'de la date de création invalide',
       type: typeValide,
     },
     {
-      date: '2024-01-01',
-      dateDeCreation: '2024-01-02',
+      date,
+      dateDeCreation: epochTimePlusOneDay,
       expectedFailure: 'dateDuComiteDoitEtreDansLeFutur',
       frequence: frequenceValide,
       intention: 'de la date de comité qui est dans le passé',
@@ -131,7 +131,7 @@ describe('ajouter un comité à une gouvernance', () => {
       new GouvernanceRepositorySpy(),
       new GestionnaireRepositorySpy(),
       new ComiteRepositorySpy(),
-      new Date(dateDeCreation)
+      dateDeCreation
     )
 
     // WHEN
@@ -230,7 +230,7 @@ describe('ajouter un comité à une gouvernance', () => {
 })
 
 const commentaire = 'un commentaire'
-const date = '2024-01-01'
+const date = epochTime.toISOString()
 const frequenceValide = 'mensuelle'
 const typeValide = 'strategique'
 const uidGouvernance = 'gouvernanceFooId'

--- a/src/use-cases/commands/InviterUnUtilisateur.test.ts
+++ b/src/use-cases/commands/InviterUnUtilisateur.test.ts
@@ -108,7 +108,7 @@ describe('inviter un utilisateur', () => {
       '$desc puis un e-mail lui est envoyé',
       async ({ utilisateurCourant, utilisateurAInviter }) => {
         // GIVEN
-        const date = new Date('2024-01-01')
+        const date = epochTime
         const repository = new RepositorySpy(
           utilisateurFactory({
             codeOrganisation: utilisateurCourant.codeOrganisation,
@@ -207,7 +207,7 @@ describe('inviter un utilisateur', () => {
 
   it('étant donné que l’utilisateur à inviter existe déjà, quand l’utilisateur courant l’invite, alors il y a une erreur', async () => {
     // GIVEN
-    const date = new Date('2024-01-01')
+    const date = epochTime
     const utilisateurACreer = utilisateurFactory({
       derniereConnexion: undefined,
       inviteLe: date,

--- a/src/use-cases/commands/MettreAJourDateDeDerniereConnexion.test.ts
+++ b/src/use-cases/commands/MettreAJourDateDeDerniereConnexion.test.ts
@@ -2,6 +2,7 @@ import { MettreAJourDateDeDerniereConnexion } from './MettreAJourDateDeDerniereC
 import { FindUtilisateurRepository, UpdateUtilisateurRepository } from './shared/UtilisateurRepository'
 import { utilisateurFactory } from '@/domain/testHelper'
 import { Utilisateur, UtilisateurUidState } from '@/domain/Utilisateur'
+import { epochTime, invalidDate } from '@/shared/testHelper'
 
 describe('mettre à jour la date de dernière connexion à chaque connexion', () => {
   beforeEach(() => {
@@ -12,9 +13,8 @@ describe('mettre à jour la date de dernière connexion à chaque connexion', ()
   it('étant donné que le compte de l’utilisateur courant n’existe plus, quand sa date de dernière connexion doit être mise à jour, alors il y a une erreur', async () => {
     // GIVEN
     const uidUtilisateurCourant = 'fooId'
-    const date = new Date('2023-02-03')
     const repository = new UtilisateurInexistantRepositorySpy()
-    const mettreAJourDateDerniereConnexion = new MettreAJourDateDeDerniereConnexion(repository, date)
+    const mettreAJourDateDerniereConnexion = new MettreAJourDateDeDerniereConnexion(repository, epochTime)
     // WHEN
     const result = await mettreAJourDateDerniereConnexion.execute({ uidUtilisateurCourant })
     // THEN
@@ -25,7 +25,7 @@ describe('mettre à jour la date de dernière connexion à chaque connexion', ()
   it('étant donné une nouvelle date de connexion d’un utilisateur, quand une mise à jour est demandée, alors elle est mise à jour', async () => {
     // GIVEN
     const uidUtilisateurCourant = 'fooId'
-    const date = new Date('2023-02-03')
+    const date = epochTime
     const repository = new UtilisateurRepositorySpy()
     const mettreAJourDateDerniereConnexion = new MettreAJourDateDeDerniereConnexion(repository, date)
 
@@ -47,9 +47,8 @@ describe('mettre à jour la date de dernière connexion à chaque connexion', ()
   it('étant donné une date invalide de connexion d’un utilisateur, quand une mise à jour est demandée, alors elle n’est pas mise à jour', async () => {
     // GIVEN
     const uidUtilisateurCourant = 'fooId'
-    const date = new Date('foo')
     const repository = new UtilisateurRepositorySpy()
-    const mettreAJourDateDerniereConnexion = new MettreAJourDateDeDerniereConnexion(repository, date)
+    const mettreAJourDateDerniereConnexion = new MettreAJourDateDeDerniereConnexion(repository, invalidDate)
 
     // WHEN
     const asyncResult = mettreAJourDateDerniereConnexion.execute({ uidUtilisateurCourant })

--- a/src/use-cases/commands/ModifierUnComite.test.ts
+++ b/src/use-cases/commands/ModifierUnComite.test.ts
@@ -6,7 +6,7 @@ import { Comite } from '@/domain/Comite'
 import { Gouvernance, GouvernanceUid } from '@/domain/Gouvernance'
 import { comiteFactory, gouvernanceFactory, utilisateurFactory } from '@/domain/testHelper'
 import { Utilisateur, UtilisateurUidState } from '@/domain/Utilisateur'
-import { epochTime } from '@/shared/testHelper'
+import { epochTime, epochTimePlusOneDay, invalidDate } from '@/shared/testHelper'
 
 describe('modifier un comité', () => {
   beforeEach(() => {
@@ -20,7 +20,7 @@ describe('modifier un comité', () => {
     {
       commentaire,
       date,
-      expectedDate: new Date(date),
+      expectedDate: epochTime,
       frequence: frequenceValide,
       intention: 'complètement',
       type: typeValide,
@@ -41,7 +41,7 @@ describe('modifier un comité', () => {
     type,
   }) => {
     // GIVEN
-    const dateDeModification = new Date('2024-01-01')
+    const dateDeModification = epochTime
     const modifierUnComite = new ModifierUnComite(
       new GouvernanceRepositorySpy(),
       new GestionnaireRepositorySpy(),
@@ -68,7 +68,7 @@ describe('modifier un comité', () => {
       comiteFactory({
         commentaire,
         date: expectedDate,
-        dateDeCreation: new Date(epochTime),
+        dateDeCreation: epochTime,
         dateDeModification,
         frequence,
         type,
@@ -87,7 +87,7 @@ describe('modifier un comité', () => {
   it.each([
     {
       date,
-      dateDeModification: date,
+      dateDeModification: epochTime,
       expectedFailure: 'frequenceInvalide',
       frequence: 'frequenceInvalide',
       intention: 'd’une fréquence invalide',
@@ -95,7 +95,7 @@ describe('modifier un comité', () => {
     },
     {
       date,
-      dateDeModification: date,
+      dateDeModification: epochTime,
       expectedFailure: 'typeInvalide',
       frequence: frequenceValide,
       intention: 'd’un type invalide',
@@ -103,7 +103,7 @@ describe('modifier un comité', () => {
     },
     {
       date: 'dateDuComiteInvalide',
-      dateDeModification: date,
+      dateDeModification: epochTime,
       expectedFailure: 'dateDuComiteInvalide',
       frequence: frequenceValide,
       intention: 'de la date invalide',
@@ -111,15 +111,15 @@ describe('modifier un comité', () => {
     },
     {
       date,
-      dateDeModification: 'dateDeModificationInvalide',
+      dateDeModification: invalidDate,
       expectedFailure: 'dateDeModificationInvalide',
       frequence: frequenceValide,
       intention: 'de la date de modification invalide',
       type: typeValide,
     },
     {
-      date: '2024-01-01',
-      dateDeModification: '2024-01-02',
+      date,
+      dateDeModification: epochTimePlusOneDay,
       expectedFailure: 'dateDuComiteDoitEtreDansLeFutur',
       frequence: frequenceValide,
       intention: 'de la date de comité qui est dans le passé',
@@ -131,7 +131,7 @@ describe('modifier un comité', () => {
       new GouvernanceRepositorySpy(),
       new GestionnaireRepositorySpy(),
       new ComiteRepositorySpy(),
-      new Date(dateDeModification)
+      dateDeModification
     )
 
     // WHEN
@@ -262,7 +262,7 @@ describe('modifier un comité', () => {
 })
 
 const commentaire = 'un commentaire'
-const date = '2024-01-01'
+const date = epochTime.toISOString()
 const frequenceValide = 'mensuelle'
 const typeValide = 'strategique'
 const uidComite = 'comiteFooId'

--- a/src/use-cases/commands/ModifierUneNoteDeContexte.test.ts
+++ b/src/use-cases/commands/ModifierUneNoteDeContexte.test.ts
@@ -15,7 +15,7 @@ describe('modifier une note de contexte à une gouvernance', () => {
 
   it('étant donné une gouvernance existante, quand une note de contexte est modifiée par son gestionnaire, alors elle est modifiée', async () => {
     // GIVEN
-    const dateDeModification = new Date('3000-01-01')
+    const dateDeModification = epochTime
     const uidEditeur = 'userFooId2'
     const modifierNoteDeContexte = new ModifierUneNoteDeContexte(
       new GouvernanceRepositorySpy(),

--- a/src/use-cases/commands/ModifierUneNotePrivee.test.ts
+++ b/src/use-cases/commands/ModifierUneNotePrivee.test.ts
@@ -15,7 +15,7 @@ describe('modifier une note privée à une gouvernance', () => {
 
   it('étant donné une gouvernance existante, quand une note privée est modifiée par son gestionnaire, alors elle est modifiée', async () => {
     // GIVEN
-    const dateDeModification = new Date('3000-01-01')
+    const dateDeModification = epochTime
     const uidEditeur = 'userFooId2'
     const modifierNotePrivee = new ModifierUneNotePrivee(
       new GouvernanceRepositorySpy(),

--- a/src/use-cases/commands/ReinviterUnUtilisateur.test.ts
+++ b/src/use-cases/commands/ReinviterUnUtilisateur.test.ts
@@ -3,7 +3,7 @@ import { EmailGateway } from './shared/EmailGateway'
 import { FindUtilisateurRepository, UpdateUtilisateurRepository } from './shared/UtilisateurRepository'
 import { utilisateurFactory } from '@/domain/testHelper'
 import { Utilisateur, UtilisateurUidState } from '@/domain/Utilisateur'
-import { epochTime } from '@/shared/testHelper'
+import { epochTime, epochTimeMinusOneDay, invalidDate } from '@/shared/testHelper'
 
 describe('réinviter un utilisateur', () => {
   beforeEach(() => {
@@ -13,7 +13,7 @@ describe('réinviter un utilisateur', () => {
 
   it('étant donné que l’utilisateur courant peut gérer l’utilisateur à réinviter, quand il le réinvite, la date d’invitation est mise à jour puis un e-mail lui est envoyé', async () => {
     // GIVEN
-    const date = new Date('2023-02-03')
+    const date = epochTimeMinusOneDay
     const repository = new RepositorySpy()
     const reinviterUnUtilisateur = new ReinviterUnUtilisateur(repository, emailGatewayFactorySpy, date)
     const command = {
@@ -109,12 +109,11 @@ describe('réinviter un utilisateur', () => {
 
   it('étant donné une date invalide d’invitation d’un utilisateur, quand il est réinvité, alors il y a une erreur', async () => {
     // GIVEN
-    const dateDInvitationInvalide = new Date('foo')
     const repository = new RepositorySpy()
     const reinviterUnUtilisateur = new ReinviterUnUtilisateur(
       repository,
       emailGatewayFactorySpy,
-      dateDInvitationInvalide
+      invalidDate
     )
     const command = {
       uidUtilisateurAReinviter: 'uidUtilisateurAReinviterInactif',
@@ -131,14 +130,14 @@ describe('réinviter un utilisateur', () => {
 
 const utilisateursByUid: Record<string, Utilisateur> = {
   uidUtilisateurAReinviterActif: utilisateurFactory({
-    derniereConnexion: new Date('2024-01-01'),
-    inviteLe: new Date('2024-01-01'),
+    derniereConnexion: epochTime,
+    inviteLe: epochTime,
     role: 'Gestionnaire structure',
     uid: { email: 'uidUtilisateurAReinviterActif', value: 'uidUtilisateurAReinviterActif' },
   }),
   uidUtilisateurAReinviterInactif: utilisateurFactory({
     derniereConnexion: undefined,
-    inviteLe: new Date('2024-01-01'),
+    inviteLe: epochTime,
     role: 'Gestionnaire structure',
     uid: { email: 'uidUtilisateurAReinviterInactif', value: 'uidUtilisateurAReinviterInactif' },
   }),

--- a/src/use-cases/testHelper.ts
+++ b/src/use-cases/testHelper.ts
@@ -4,7 +4,7 @@ import { MesMembresReadModel } from './queries/RecupererMesMembres'
 import { UneGouvernanceReadModel } from './queries/RecupererUneGouvernance'
 import { UnUtilisateurReadModel } from './queries/shared/UnUtilisateurReadModel'
 import { Roles } from '@/domain/Role'
-import { epochTime } from '@/shared/testHelper'
+import { epochTime, epochTimeMinusOneDay } from '@/shared/testHelper'
 
 export function utilisateurReadModelFactory(
   override?: Partial<UnUtilisateurReadModel>
@@ -65,8 +65,8 @@ export function gouvernanceReadModelFactory(
       },
       {
         commentaire: 'commentaire',
-        date: new Date('2024-03-01'),
-        derniereEdition: new Date('2024-02-01'),
+        date: epochTime,
+        derniereEdition: epochTimeMinusOneDay,
         frequence: 'trimestrielle',
         id: 2,
         nomEditeur: 'Tartempion',


### PR DESCRIPTION
Vu les potentiels bugs que peut apporter la Date, j'ai ajouté une règle eslint pour interdire `new Date()` partout dans le code sauf aux extrêmité pour nous imposer de l'injecter et en faciliter les tests et j'ai aussi interdis le fait d'utiliser `new Date(xxx)` dans les tests mais on a à disposition 3 constantes `epochTime`.

# Contrat du dev

## Qualité

- [x] Relire le code
- [x] Relire le ticket
- [x] [Relire les critères d'acceptation](https://github.com/anct-cnum/suite-gestionnaire-numerique/discussions/252)
- [x] Vérifier le coverage

## Facultatif mais fortement conseillé

- [ ] Lancer les tests de mutation

> **Et n'oublie pas de vérifier ce que tu as fait en production !**
