### PR TITLE
refactor: gestion des cas d'entités non trouvées par les repositories…

### DIFF
--- a/src/app/(connecte)/(avec-menu)/gouvernance/[codeDepartement]/page.tsx
+++ b/src/app/(connecte)/(avec-menu)/gouvernance/[codeDepartement]/page.tsx
@@ -11,7 +11,8 @@ export default async function GouvernanceController({ params }: Props): Promise<
   try {
     const codeDepartement = (await params).codeDepartement
     const gouvernanceReadModel =
-       await new RecupererUneGouvernance(new PrismaGouvernanceLoader(prisma.gouvernanceRecord)).get({ codeDepartement })
+      await new RecupererUneGouvernance(new PrismaGouvernanceLoader(prisma.gouvernanceRecord))
+        .handle({ codeDepartement })
 
     const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModel, new Date())
     return (

--- a/src/app/(connecte)/(sans-menu)/mes-informations-personnelles/page.tsx
+++ b/src/app/(connecte)/(sans-menu)/mes-informations-personnelles/page.tsx
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
 
 export default async function MesInformationsPersonnellesController(): Promise<ReactElement> {
   const mesInformationsPersonnellesQuery = new PrismaMesInformationsPersonnellesLoader(prisma.utilisateurRecord)
-  const mesInformationsPersonnellesReadModel = await mesInformationsPersonnellesQuery.findByUid(await getSessionSub())
+  const mesInformationsPersonnellesReadModel = await mesInformationsPersonnellesQuery.byUid(await getSessionSub())
   const mesInformationsPersonnellesViewModel =
     mesInformationsPersonnellesPresenter(mesInformationsPersonnellesReadModel)
 

--- a/src/app/(connecte)/(sans-menu)/mes-utilisateurs/page.tsx
+++ b/src/app/(connecte)/(sans-menu)/mes-utilisateurs/page.tsx
@@ -38,7 +38,7 @@ export default async function MesUtilisateursController({ searchParams }: Props)
   const utilisateurLoader = new PrismaUtilisateurLoader(prisma.utilisateurRecord)
   const rechercherMesUtilisateurs = new RechercherMesUtilisateurs(utilisateurLoader)
   const { utilisateursCourants, total } =
-    await rechercherMesUtilisateurs.get({
+    await rechercherMesUtilisateurs.handle({
       uid: sub,
       utilisateursActives,
       ...codeDepartement,

--- a/src/app/(connecte)/layout.tsx
+++ b/src/app/(connecte)/layout.tsx
@@ -34,7 +34,7 @@ export default async function Layout({ children }: Readonly<PropsWithChildren>):
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
       await new MettreAJourUidALaPremiereConnexion(utilisateurRepository)
-        .execute({
+        .handle({
           emailAsUid: session.user.email,
           uid: session.user.sub,
         })
@@ -43,7 +43,7 @@ export default async function Layout({ children }: Readonly<PropsWithChildren>):
   }
 
   const correctionNomPrenom = await new CorrigerNomPrenomSiAbsents(utilisateurRepository)
-    .execute({
+    .handle({
       actuels: {
         nom: utilisateurReadModel.nom,
         prenom: utilisateurReadModel.prenom,

--- a/src/app/api/actions/ajouterUnComiteAction.test.ts
+++ b/src/app/api/actions/ajouterUnComiteAction.test.ts
@@ -9,7 +9,7 @@ describe('ajouter un comité action', () => {
     // GIVEN
     vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce('userFooId')
     vi.spyOn(nextCache, 'revalidatePath').mockImplementationOnce(vi.fn())
-    vi.spyOn(AjouterUnComite.prototype, 'execute').mockResolvedValueOnce('OK')
+    vi.spyOn(AjouterUnComite.prototype, 'handle').mockResolvedValueOnce('OK')
 
     // WHEN
     const messages = await ajouterUnComiteAction({
@@ -22,7 +22,7 @@ describe('ajouter un comité action', () => {
     })
 
     // THEN
-    expect(AjouterUnComite.prototype.execute).toHaveBeenCalledWith({
+    expect(AjouterUnComite.prototype.handle).toHaveBeenCalledWith({
       commentaire: 'commentaire',
       date: '2024-01-01',
       frequence: 'Mensuelle',

--- a/src/app/api/actions/ajouterUnComiteAction.ts
+++ b/src/app/api/actions/ajouterUnComiteAction.ts
@@ -25,7 +25,7 @@ export async function ajouterUnComiteAction(
     new PrismaUtilisateurRepository(prisma.utilisateurRecord),
     new PrismaComiteRepository(prisma.comiteRecord),
     new Date()
-  ).execute({
+  ).handle({
     commentaire: actionParams.commentaire,
     date: actionParams.date,
     frequence: actionParams.frequence,

--- a/src/app/api/actions/ajouterUneNoteDeContexteAction.test.ts
+++ b/src/app/api/actions/ajouterUneNoteDeContexteAction.test.ts
@@ -11,7 +11,7 @@ describe('ajouter une note de contexte', () => {
     // GIVEN
     vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce('userFooId')
     vi.spyOn(nextCache, 'revalidatePath').mockImplementationOnce(vi.fn())
-    vi.spyOn(AjouterNoteDeContexteAGouvernance.prototype, 'execute').mockResolvedValueOnce('OK')
+    vi.spyOn(AjouterNoteDeContexteAGouvernance.prototype, 'handle').mockResolvedValueOnce('OK')
 
     // WHEN
     const messages = await ajouterUneNoteDeContexteAction({
@@ -23,7 +23,7 @@ describe('ajouter une note de contexte', () => {
     // THEN
     expect(messages).toStrictEqual(['OK'])
     expect(nextCache.revalidatePath).toHaveBeenCalledWith('/gouvernance/11')
-    expect(AjouterNoteDeContexteAGouvernance.prototype.execute).toHaveBeenCalledWith({
+    expect(AjouterNoteDeContexteAGouvernance.prototype.handle).toHaveBeenCalledWith({
       contenu: '<p>ma note de contexte</p>',
       uidEditeur: 'userFooId',
       uidGouvernance: 'uidGouvernance',
@@ -46,7 +46,7 @@ describe('ajouter une note de contexte', () => {
     // GIVEN
     vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce('userFooId')
     vi.spyOn(nextCache, 'revalidatePath').mockImplementationOnce(vi.fn())
-    vi.spyOn(AjouterNoteDeContexteAGouvernance.prototype, 'execute').mockResolvedValueOnce('OK')
+    vi.spyOn(AjouterNoteDeContexteAGouvernance.prototype, 'handle').mockResolvedValueOnce('OK')
 
     const contenuMalveillant = '<p>Contenu légitime</p><script>alert("xss")</script><img src="x" onerror="alert(1)">'
 
@@ -58,11 +58,10 @@ describe('ajouter une note de contexte', () => {
     })
 
     // THEN
-    expect(AjouterNoteDeContexteAGouvernance.prototype.execute).toHaveBeenCalledWith({
+    expect(AjouterNoteDeContexteAGouvernance.prototype.handle).toHaveBeenCalledWith({
       contenu: '<p>Contenu légitime</p>',
       uidEditeur: 'userFooId',
       uidGouvernance: 'uidGouvernance',
     })
   })
 })
-

--- a/src/app/api/actions/ajouterUneNoteDeContexteAction.ts
+++ b/src/app/api/actions/ajouterUneNoteDeContexteAction.ts
@@ -25,7 +25,7 @@ export async function ajouterUneNoteDeContexteAction(
     new PrismaUtilisateurRepository(prisma.utilisateurRecord),
     new Date()
   )
-  const result = await ajouterNoteDeContexteAGouvernance.execute({
+  const result = await ajouterNoteDeContexteAGouvernance.handle({
     contenu: sanitize(actionParam.contenu, sanitizeDefaultOptions),
     uidEditeur: await getSessionSub(),
     uidGouvernance: actionParam.uidGouvernance,
@@ -43,4 +43,3 @@ type ActionParams = Readonly<{
 const validator = z.object({
   path: z.string().min(1, { message: 'Le chemin doit être renseigné' }),
 })
-

--- a/src/app/api/actions/ajouterUneNotePriveeAction.test.ts
+++ b/src/app/api/actions/ajouterUneNotePriveeAction.test.ts
@@ -9,7 +9,7 @@ describe('ajouter une note privée action', () => {
     // GIVEN
     vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce('userFooId')
     vi.spyOn(nextCache, 'revalidatePath').mockImplementationOnce(vi.fn())
-    vi.spyOn(AjouterUneNotePrivee.prototype, 'execute').mockResolvedValueOnce('OK')
+    vi.spyOn(AjouterUneNotePrivee.prototype, 'handle').mockResolvedValueOnce('OK')
 
     // WHEN
     const messages = await ajouterUneNotePriveeAction({
@@ -19,7 +19,7 @@ describe('ajouter une note privée action', () => {
     })
 
     // THEN
-    expect(AjouterUneNotePrivee.prototype.execute).toHaveBeenCalledWith({
+    expect(AjouterUneNotePrivee.prototype.handle).toHaveBeenCalledWith({
       contenu: 'un contenu quelconque',
       uidEditeur: 'userFooId',
       uidGouvernance: 'gouvernanceFooId',

--- a/src/app/api/actions/ajouterUneNotePriveeAction.ts
+++ b/src/app/api/actions/ajouterUneNotePriveeAction.ts
@@ -21,7 +21,7 @@ export async function ajouterUneNotePriveeAction(actionParams: ActionParams): Re
     new PrismaGouvernanceRepository(prisma.gouvernanceRecord, prisma.noteDeContexteRecord),
     new PrismaUtilisateurRepository(prisma.utilisateurRecord),
     new Date()
-  ).execute({
+  ).handle({
     contenu: actionParams.contenu,
     uidEditeur: await getSessionSub(),
     uidGouvernance: actionParams.uidGouvernance,

--- a/src/app/api/actions/changerMonRoleAction.test.ts
+++ b/src/app/api/actions/changerMonRoleAction.test.ts
@@ -12,13 +12,13 @@ describe('changer mon rôle action', () => {
     const nouveauRole = 'Instructeur'
     vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce(sub)
     vi.spyOn(nextCache, 'revalidatePath').mockReturnValueOnce()
-    vi.spyOn(ChangerMonRole.prototype, 'execute').mockResolvedValueOnce('OK')
+    vi.spyOn(ChangerMonRole.prototype, 'handle').mockResolvedValueOnce('OK')
 
     // WHEN
     const messages = await changerMonRoleAction({ nouveauRole, path })
 
     // THEN
-    expect(ChangerMonRole.prototype.execute).toHaveBeenCalledWith({
+    expect(ChangerMonRole.prototype.handle).toHaveBeenCalledWith({
       nouveauRole,
       uidUtilisateurCourant: sub,
     })

--- a/src/app/api/actions/changerMonRoleAction.ts
+++ b/src/app/api/actions/changerMonRoleAction.ts
@@ -20,7 +20,7 @@ export async function changerMonRoleAction(
   }
 
   const message = await new ChangerMonRole(new PrismaUtilisateurRepository(prisma.utilisateurRecord))
-    .execute({
+    .handle({
       nouveauRole: validationResult.data.nouveauRole,
       uidUtilisateurCourant: await getSessionSub(),
     })

--- a/src/app/api/actions/inviterUnUtilisateurAction.test.ts
+++ b/src/app/api/actions/inviterUnUtilisateurAction.test.ts
@@ -86,7 +86,7 @@ describe('inviter un utilisateur action', () => {
       },
     ])('$desc', async ({ actionParams, expectedCommand }) => {
       // GIVEN
-      vi.spyOn(InviterUnUtilisateur.prototype, 'execute').mockResolvedValueOnce('OK')
+      vi.spyOn(InviterUnUtilisateur.prototype, 'handle').mockResolvedValueOnce('OK')
       vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce(sub)
       vi.spyOn(nextCache, 'revalidatePath').mockImplementationOnce(vi.fn())
 
@@ -94,7 +94,7 @@ describe('inviter un utilisateur action', () => {
       const messages = await inviterUnUtilisateurAction(actionParams)
 
       // THEN
-      expect(InviterUnUtilisateur.prototype.execute).toHaveBeenCalledWith(expectedCommand)
+      expect(InviterUnUtilisateur.prototype.handle).toHaveBeenCalledWith(expectedCommand)
       expect(nextCache.revalidatePath).toHaveBeenCalledWith(actionParams.path)
       expect(messages).toStrictEqual(['OK'])
     })
@@ -104,7 +104,7 @@ describe('inviter un utilisateur action', () => {
     // GIVEN
     const sub = 'd96a66b5-8980-4e5c-88a9-aa0ff334a828'
     vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce(sub)
-    vi.spyOn(InviterUnUtilisateur.prototype, 'execute').mockResolvedValueOnce('emailExistant')
+    vi.spyOn(InviterUnUtilisateur.prototype, 'handle').mockResolvedValueOnce('emailExistant')
     vi.spyOn(nextCache, 'revalidatePath').mockImplementationOnce(vi.fn())
 
     const inviterUnUtilisateurParams = {
@@ -225,7 +225,7 @@ describe('inviter un utilisateur action', () => {
           // GIVEN
           vi.spyOn(nextCache, 'revalidatePath').mockImplementationOnce(vi.fn())
           vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce('sub')
-          vi.spyOn(PrismaUtilisateurRepository.prototype, 'find').mockResolvedValueOnce(
+          vi.spyOn(PrismaUtilisateurRepository.prototype, 'get').mockResolvedValueOnce(
             utilisateurFactory({ isSuperAdmin })
           )
           vi.spyOn(PrismaUtilisateurRepository.prototype, 'add').mockResolvedValueOnce(true)

--- a/src/app/api/actions/inviterUnUtilisateurAction.ts
+++ b/src/app/api/actions/inviterUnUtilisateurAction.ts
@@ -24,7 +24,7 @@ export async function inviterUnUtilisateurAction(
     new PrismaUtilisateurRepository(prisma.utilisateurRecord),
     emailInvitationGatewayFactory,
     new Date()
-  ).execute({
+  ).handle({
     email: validationResult.data.email,
     nom: validationResult.data.nom,
     prenom: validationResult.data.prenom,

--- a/src/app/api/actions/modifierMesInformationsPersonnellesAction.test.ts
+++ b/src/app/api/actions/modifierMesInformationsPersonnellesAction.test.ts
@@ -11,7 +11,7 @@ describe('modifier mes informations personnelles action', () => {
     const sub = 'fooId'
     vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce(sub)
     vi.spyOn(nextCache, 'revalidatePath').mockReturnValueOnce()
-    vi.spyOn(ModifierMesInformationsPersonnelles.prototype, 'execute').mockResolvedValueOnce('OK')
+    vi.spyOn(ModifierMesInformationsPersonnelles.prototype, 'handle').mockResolvedValueOnce('OK')
 
     // WHEN
     const messages = await modifierMesInformationsPersonnellesAction({
@@ -23,7 +23,7 @@ describe('modifier mes informations personnelles action', () => {
     })
 
     // THEN
-    expect(ModifierMesInformationsPersonnelles.prototype.execute).toHaveBeenCalledWith({
+    expect(ModifierMesInformationsPersonnelles.prototype.handle).toHaveBeenCalledWith({
       modification: {
         emailDeContact: 'martin.tartempion@example.com',
         nom: 'Tartempion',
@@ -78,7 +78,7 @@ describe('modifier mes informations personnelles action', () => {
     const telephoneVide = ''
     vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce(sub)
     vi.spyOn(nextCache, 'revalidatePath').mockReturnValueOnce()
-    vi.spyOn(ModifierMesInformationsPersonnelles.prototype, 'execute').mockResolvedValueOnce('OK')
+    vi.spyOn(ModifierMesInformationsPersonnelles.prototype, 'handle').mockResolvedValueOnce('OK')
 
     // WHEN
     const messages = await modifierMesInformationsPersonnellesAction({

--- a/src/app/api/actions/modifierMesInformationsPersonnellesAction.ts
+++ b/src/app/api/actions/modifierMesInformationsPersonnellesAction.ts
@@ -21,7 +21,7 @@ export async function modifierMesInformationsPersonnellesAction(
 
   const message = await new ModifierMesInformationsPersonnelles(
     new PrismaUtilisateurRepository(prisma.utilisateurRecord)
-  ).execute({
+  ).handle({
     modification: {
       emailDeContact: actionParams.emailDeContact,
       nom: actionParams.nom,

--- a/src/app/api/actions/modifierUnComiteAction.test.ts
+++ b/src/app/api/actions/modifierUnComiteAction.test.ts
@@ -9,7 +9,7 @@ describe('modifier un comité action', () => {
     // GIVEN
     vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce('userFooId')
     vi.spyOn(nextCache, 'revalidatePath').mockImplementationOnce(vi.fn())
-    vi.spyOn(ModifierUnComite.prototype, 'execute').mockResolvedValueOnce('OK')
+    vi.spyOn(ModifierUnComite.prototype, 'handle').mockResolvedValueOnce('OK')
 
     // WHEN
     const messages = await modifierUnComiteAction({
@@ -23,7 +23,7 @@ describe('modifier un comité action', () => {
     })
 
     // THEN
-    expect(ModifierUnComite.prototype.execute).toHaveBeenCalledWith({
+    expect(ModifierUnComite.prototype.handle).toHaveBeenCalledWith({
       commentaire: 'commentaire',
       date: '2024-01-01',
       frequence: 'Mensuelle',

--- a/src/app/api/actions/modifierUnComiteAction.ts
+++ b/src/app/api/actions/modifierUnComiteAction.ts
@@ -25,7 +25,7 @@ export async function modifierUnComiteAction(
     new PrismaUtilisateurRepository(prisma.utilisateurRecord),
     new PrismaComiteRepository(prisma.comiteRecord),
     new Date()
-  ).execute({
+  ).handle({
     commentaire: actionParams.commentaire,
     date: actionParams.date,
     frequence: actionParams.frequence,

--- a/src/app/api/actions/modifierUneNoteDeContexteAction.test.ts
+++ b/src/app/api/actions/modifierUneNoteDeContexteAction.test.ts
@@ -10,7 +10,7 @@ describe('modifier une note de contexte', () => {
     // GIVEN
     vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce('userFooId')
     vi.spyOn(nextCache, 'revalidatePath').mockImplementationOnce(vi.fn())
-    vi.spyOn(ModifierUneNoteDeContexte.prototype, 'execute').mockResolvedValueOnce('OK')
+    vi.spyOn(ModifierUneNoteDeContexte.prototype, 'handle').mockResolvedValueOnce('OK')
 
     // WHEN
     const messages = await modifierUneNoteDeContexteAction({
@@ -22,7 +22,7 @@ describe('modifier une note de contexte', () => {
     // THEN
     expect(messages).toStrictEqual(['OK'])
     expect(nextCache.revalidatePath).toHaveBeenCalledWith('/gouvernance/11')
-    expect(ModifierUneNoteDeContexte.prototype.execute).toHaveBeenCalledWith({
+    expect(ModifierUneNoteDeContexte.prototype.handle).toHaveBeenCalledWith({
       contenu: '<p>ma note de contexte modifiée</p>',
       uidEditeur: 'userFooId',
       uidGouvernance: 'uidGouvernance',
@@ -45,7 +45,7 @@ describe('modifier une note de contexte', () => {
     // GIVEN
     vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce('userFooId')
     vi.spyOn(nextCache, 'revalidatePath').mockImplementationOnce(vi.fn())
-    vi.spyOn(ModifierUneNoteDeContexte.prototype, 'execute').mockResolvedValueOnce('OK')
+    vi.spyOn(ModifierUneNoteDeContexte.prototype, 'handle').mockResolvedValueOnce('OK')
 
     const contenuMalveillant = '<p>Contenu légitime</p><script>alert("xss")</script><img src="x" onerror="alert(1)">'
 
@@ -57,7 +57,7 @@ describe('modifier une note de contexte', () => {
     })
 
     // THEN
-    expect(ModifierUneNoteDeContexte.prototype.execute).toHaveBeenCalledWith({
+    expect(ModifierUneNoteDeContexte.prototype.handle).toHaveBeenCalledWith({
       contenu: '<p>Contenu légitime</p>',
       uidEditeur: 'userFooId',
       uidGouvernance: 'uidGouvernance',

--- a/src/app/api/actions/modifierUneNoteDeContexteAction.ts
+++ b/src/app/api/actions/modifierUneNoteDeContexteAction.ts
@@ -26,7 +26,7 @@ export async function modifierUneNoteDeContexteAction(
     new PrismaUtilisateurRepository(prisma.utilisateurRecord),
     new Date()
   )
-  const result = await modifierUneNoteDeContexte.execute({
+  const result = await modifierUneNoteDeContexte.handle({
     contenu: sanitize(actionParam.contenu, sanitizeDefaultOptions),
     uidEditeur: await getSessionSub(),
     uidGouvernance: actionParam.uidGouvernance,
@@ -44,4 +44,3 @@ type ActionParams = Readonly<{
 const validator = z.object({
   path: z.string().min(1, { message: 'Le chemin doit être renseigné' }),
 })
-

--- a/src/app/api/actions/modifierUneNotePriveeAction.test.ts
+++ b/src/app/api/actions/modifierUneNotePriveeAction.test.ts
@@ -9,7 +9,7 @@ describe('modifier une note privée action', () => {
     // GIVEN
     vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce('userFooId')
     vi.spyOn(nextCache, 'revalidatePath').mockImplementationOnce(vi.fn())
-    vi.spyOn(ModifierUneNotePrivee.prototype, 'execute').mockResolvedValueOnce('OK')
+    vi.spyOn(ModifierUneNotePrivee.prototype, 'handle').mockResolvedValueOnce('OK')
 
     // WHEN
     const messages = await modifierUneNotePriveeAction({
@@ -19,7 +19,7 @@ describe('modifier une note privée action', () => {
     })
 
     // THEN
-    expect(ModifierUneNotePrivee.prototype.execute).toHaveBeenCalledWith({
+    expect(ModifierUneNotePrivee.prototype.handle).toHaveBeenCalledWith({
       contenu: 'un contenu quelconque',
       uidEditeur: 'userFooId',
       uidGouvernance: 'gouvernanceFooId',

--- a/src/app/api/actions/modifierUneNotePriveeAction.ts
+++ b/src/app/api/actions/modifierUneNotePriveeAction.ts
@@ -21,7 +21,7 @@ export async function modifierUneNotePriveeAction(actionParams: ActionParams): R
     new PrismaGouvernanceRepository(prisma.gouvernanceRecord, prisma.noteDeContexteRecord),
     new PrismaUtilisateurRepository(prisma.utilisateurRecord),
     new Date()
-  ).execute({
+  ).handle({
     contenu: actionParams.contenu,
     uidEditeur: await getSessionSub(),
     uidGouvernance: actionParams.uidGouvernance,

--- a/src/app/api/actions/reinviterUnUtilisateurAction.test.ts
+++ b/src/app/api/actions/reinviterUnUtilisateurAction.test.ts
@@ -10,7 +10,7 @@ describe('reinviter un utilisateur action', () => {
     const sub = 'uidUtilisateurCourant'
     const path = '/mes-utilisateurs'
     vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce(sub)
-    vi.spyOn(ReinviterUnUtilisateur.prototype, 'execute').mockResolvedValueOnce('OK')
+    vi.spyOn(ReinviterUnUtilisateur.prototype, 'handle').mockResolvedValueOnce('OK')
     vi.spyOn(nextCache, 'revalidatePath').mockImplementationOnce(vi.fn())
 
     // WHEN
@@ -21,7 +21,7 @@ describe('reinviter un utilisateur action', () => {
 
     // THEN
     expect(nextCache.revalidatePath).toHaveBeenCalledWith(path)
-    expect(ReinviterUnUtilisateur.prototype.execute).toHaveBeenCalledWith({
+    expect(ReinviterUnUtilisateur.prototype.handle).toHaveBeenCalledWith({
       uidUtilisateurAReinviter: 'uidUtilisateurAReinviter',
       uidUtilisateurCourant: 'uidUtilisateurCourant',
     })

--- a/src/app/api/actions/reinviterUnUtilisateurAction.ts
+++ b/src/app/api/actions/reinviterUnUtilisateurAction.ts
@@ -23,7 +23,7 @@ export async function reinviterUnUtilisateurAction(
     new PrismaUtilisateurRepository(prisma.utilisateurRecord),
     emailInvitationGatewayFactory,
     new Date()
-  ).execute({
+  ).handle({
     uidUtilisateurAReinviter: actionParams.uidUtilisateurAReinviter,
     uidUtilisateurCourant: await getSessionSub(),
   })

--- a/src/app/api/actions/supprimerMonCompteAction.test.ts
+++ b/src/app/api/actions/supprimerMonCompteAction.test.ts
@@ -7,13 +7,13 @@ describe('supprimer mon compte action', () => {
     // GIVEN
     const sub = 'fooId'
     vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce(sub)
-    vi.spyOn(SupprimerUnUtilisateur.prototype, 'execute').mockResolvedValueOnce('OK')
+    vi.spyOn(SupprimerUnUtilisateur.prototype, 'handle').mockResolvedValueOnce('OK')
 
     // WHEN
     const messages = await supprimerMonCompteAction()
 
     // THEN
-    expect(SupprimerUnUtilisateur.prototype.execute).toHaveBeenCalledWith({
+    expect(SupprimerUnUtilisateur.prototype.handle).toHaveBeenCalledWith({
       uidUtilisateurASupprimer: sub,
       uidUtilisateurCourant: sub,
     })

--- a/src/app/api/actions/supprimerMonCompteAction.ts
+++ b/src/app/api/actions/supprimerMonCompteAction.ts
@@ -10,7 +10,7 @@ export async function supprimerMonCompteAction(): ResultAsync<ReadonlyArray<stri
   const sessionSub = await getSessionSub()
 
   const message = await new SupprimerUnUtilisateur(new PrismaUtilisateurRepository(prisma.utilisateurRecord))
-    .execute({
+    .handle({
       uidUtilisateurASupprimer: sessionSub,
       uidUtilisateurCourant: sessionSub,
     })

--- a/src/app/api/actions/supprimerUnComiteAction.test.ts
+++ b/src/app/api/actions/supprimerUnComiteAction.test.ts
@@ -9,7 +9,7 @@ describe('supprimer un comité action', () => {
     // GIVEN
     vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce('userFooId')
     vi.spyOn(nextCache, 'revalidatePath').mockImplementationOnce(vi.fn())
-    vi.spyOn(SupprimerUnComite.prototype, 'execute').mockResolvedValueOnce('OK')
+    vi.spyOn(SupprimerUnComite.prototype, 'handle').mockResolvedValueOnce('OK')
 
     // WHEN
     const messages = await supprimerUnComiteAction({
@@ -19,7 +19,7 @@ describe('supprimer un comité action', () => {
     })
 
     // THEN
-    expect(SupprimerUnComite.prototype.execute).toHaveBeenCalledWith({
+    expect(SupprimerUnComite.prototype.handle).toHaveBeenCalledWith({
       uid: '1',
       uidEditeur: 'userFooId',
       uidGouvernance: 'gouvernanceFooId',

--- a/src/app/api/actions/supprimerUnComiteAction.ts
+++ b/src/app/api/actions/supprimerUnComiteAction.ts
@@ -24,7 +24,7 @@ export async function supprimerUnComiteAction(
     new PrismaGouvernanceRepository(prisma.gouvernanceRecord, prisma.noteDeContexteRecord),
     new PrismaUtilisateurRepository(prisma.utilisateurRecord),
     new PrismaComiteRepository(prisma.comiteRecord)
-  ).execute({
+  ).handle({
     uid: actionParams.uid,
     uidEditeur: await getSessionSub(),
     uidGouvernance: actionParams.uidGouvernance,

--- a/src/app/api/actions/supprimerUnUtilisateurAction.test.ts
+++ b/src/app/api/actions/supprimerUnUtilisateurAction.test.ts
@@ -12,13 +12,13 @@ describe('supprimer un utilisateur action', () => {
     const uidUtilisateurASupprimer = 'barId'
     vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce(sub)
     vi.spyOn(nextCache, 'revalidatePath').mockReturnValueOnce()
-    vi.spyOn(SupprimerUnUtilisateur.prototype, 'execute').mockResolvedValueOnce('OK')
+    vi.spyOn(SupprimerUnUtilisateur.prototype, 'handle').mockResolvedValueOnce('OK')
 
     // WHEN
     const messages = await supprimerUnUtilisateurAction({ path, uidUtilisateurASupprimer })
 
     // THEN
-    expect(SupprimerUnUtilisateur.prototype.execute).toHaveBeenCalledWith({
+    expect(SupprimerUnUtilisateur.prototype.handle).toHaveBeenCalledWith({
       uidUtilisateurASupprimer,
       uidUtilisateurCourant: sub,
     })

--- a/src/app/api/actions/supprimerUnUtilisateurAction.ts
+++ b/src/app/api/actions/supprimerUnUtilisateurAction.ts
@@ -19,7 +19,7 @@ export async function supprimerUnUtilisateurAction(
   }
 
   const message = await new SupprimerUnUtilisateur(new PrismaUtilisateurRepository(prisma.utilisateurRecord))
-    .execute({
+    .handle({
       uidUtilisateurASupprimer: actionParams.uidUtilisateurASupprimer,
       uidUtilisateurCourant: await getSessionSub(),
     })

--- a/src/app/api/actions/supprimerUneNotePriveeAction.test.ts
+++ b/src/app/api/actions/supprimerUneNotePriveeAction.test.ts
@@ -9,7 +9,7 @@ describe('supprimer une note privée action', () => {
     // GIVEN
     vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce('userFooId')
     vi.spyOn(nextCache, 'revalidatePath').mockImplementationOnce(vi.fn())
-    vi.spyOn(SupprimerUneNotePrivee.prototype, 'execute').mockResolvedValueOnce('OK')
+    vi.spyOn(SupprimerUneNotePrivee.prototype, 'handle').mockResolvedValueOnce('OK')
 
     // WHEN
     const messages = await supprimerUneNotePriveeAction({
@@ -18,7 +18,7 @@ describe('supprimer une note privée action', () => {
     })
 
     // THEN
-    expect(SupprimerUneNotePrivee.prototype.execute).toHaveBeenCalledWith({
+    expect(SupprimerUneNotePrivee.prototype.handle).toHaveBeenCalledWith({
       uidEditeur: 'userFooId',
       uidGouvernance: 'gouvernanceFooId',
     })

--- a/src/app/api/actions/supprimerUneNotePriveeAction.ts
+++ b/src/app/api/actions/supprimerUneNotePriveeAction.ts
@@ -20,7 +20,7 @@ export async function supprimerUneNotePriveeAction(actionParams: ActionParams): 
   const result = await new SupprimerUneNotePrivee(
     new PrismaGouvernanceRepository(prisma.gouvernanceRecord, prisma.noteDeContexteRecord),
     new PrismaUtilisateurRepository(prisma.utilisateurRecord)
-  ).execute({
+  ).handle({
     uidEditeur: await getSessionSub(),
     uidGouvernance: actionParams.uidGouvernance,
   })

--- a/src/app/api/structures/route.test.ts
+++ b/src/app/api/structures/route.test.ts
@@ -65,7 +65,7 @@ describe('route /structures', () => {
     ])('$desc', async ({ searchParams, expectedFindParams }) => {
       // GIVEN
       vi.spyOn(ssoGateway, 'getSession').mockResolvedValueOnce({ user: {} as ssoGateway.Profile })
-      const spiedFind = vi.spyOn(RechercherLesStructures.prototype, 'get')
+      const spiedFind = vi.spyOn(RechercherLesStructures.prototype, 'handle')
         .mockResolvedValueOnce([{ commune: 'TARBES', nom: 'La Poste', uid: '802' }])
 
       const req = {

--- a/src/app/api/structures/route.ts
+++ b/src/app/api/structures/route.ts
@@ -16,7 +16,7 @@ export async function GET(request: NextRequest): Promise<NextResponse<Structures
     return NextResponse.json(null, { status: 400 })
   }
   const rechercherLesStructures = new RechercherLesStructures(new PrismaStructureLoader(prisma.structureRecord))
-  const structuresReadModel = await rechercherLesStructures.get({
+  const structuresReadModel = await rechercherLesStructures.handle({
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     match: search!,
     zone: makeZone(request.nextUrl.searchParams),
@@ -24,7 +24,7 @@ export async function GET(request: NextRequest): Promise<NextResponse<Structures
   return NextResponse.json(structuresReadModel)
 }
 
-function makeZone(searchParams: URLSearchParams): Parameters<typeof RechercherLesStructures.prototype.get>[0]['zone'] {
+function makeZone(searchParams: URLSearchParams): Parameters<typeof RechercherLesStructures.prototype.handle>[0]['zone'] {
   const [departement, region] = [searchParams.get('departement'), searchParams.get('region')]
   let zone: ReturnType<typeof makeZone>
   if (!isNullishOrEmpty(departement)) {

--- a/src/gateways/NextAuthAuthentificationGateway.ts
+++ b/src/gateways/NextAuthAuthentificationGateway.ts
@@ -35,7 +35,7 @@ const nextAuthOptions = {
         const utilisateurRepository = new PrismaUtilisateurRepository(prisma.utilisateurRecord)
         if (profile.sub !== undefined) {
           // eslint-disable-next-line no-restricted-syntax
-          await new MettreAJourDateDeDerniereConnexion(utilisateurRepository, new Date()).execute({
+          await new MettreAJourDateDeDerniereConnexion(utilisateurRepository, new Date()).handle({
             uidUtilisateurCourant: profile.sub,
           })
         }

--- a/src/gateways/PrismaComiteRepository.test.ts
+++ b/src/gateways/PrismaComiteRepository.test.ts
@@ -91,7 +91,7 @@ describe('comité repository', () => {
     const repository = new PrismaComiteRepository(prisma.comiteRecord)
 
     // WHEN
-    const comiteRecord = await repository.find('1')
+    const comiteRecord = await repository.get('1')
 
     // THEN
     expect(comiteRecord.state).toStrictEqual(comiteFactory({
@@ -123,7 +123,7 @@ describe('comité repository', () => {
     const repository = new PrismaComiteRepository(prisma.comiteRecord)
 
     // WHEN
-    const comiteRecord = repository.find('666')
+    const comiteRecord = repository.get('666')
 
     // THEN
     await expect(comiteRecord).rejects.toThrow(Prisma.PrismaClientKnownRequestError)
@@ -148,7 +148,7 @@ describe('comité repository', () => {
     const repository = new PrismaComiteRepository(prisma.comiteRecord)
 
     // WHEN
-    const comiteRecord = repository.find('2')
+    const comiteRecord = repository.get('2')
 
     // THEN
     await expect(async () => comiteRecord).rejects.toThrow('dateDuComiteDoitEtreDansLeFutur')

--- a/src/gateways/PrismaComiteRepository.test.ts
+++ b/src/gateways/PrismaComiteRepository.test.ts
@@ -1,3 +1,5 @@
+import { Prisma } from '@prisma/client'
+
 import { PrismaComiteRepository } from './PrismaComiteRepository'
 import { creerUnComite, creerUnDepartement, creerUneGouvernance, creerUneRegion, creerUnUtilisateur, comiteRecordFactory } from './testHelper'
 import prisma from '../../prisma/prismaClient'
@@ -92,7 +94,7 @@ describe('comité repository', () => {
     const comiteRecord = await repository.find('1')
 
     // THEN
-    expect(comiteRecord?.state).toStrictEqual(comiteFactory({
+    expect(comiteRecord.state).toStrictEqual(comiteFactory({
       commentaire,
       date,
       dateDeCreation: epochTime,
@@ -121,10 +123,11 @@ describe('comité repository', () => {
     const repository = new PrismaComiteRepository(prisma.comiteRecord)
 
     // WHEN
-    const comiteRecord = await repository.find('666')
+    const comiteRecord = repository.find('666')
 
     // THEN
-    expect(comiteRecord).toBeNull()
+    await expect(comiteRecord).rejects.toThrow(Prisma.PrismaClientKnownRequestError)
+    await expect(comiteRecord).rejects.toMatchObject({ code: 'P2025' })
   })
 
   it('ne trouve pas un comité quand une de ses données n’est pas valide', async () => {
@@ -148,8 +151,7 @@ describe('comité repository', () => {
     const comiteRecord = repository.find('2')
 
     // THEN
-    // eslint-disable-next-line vitest/require-to-throw-message
-    await expect(async () => comiteRecord).rejects.toThrow()
+    await expect(async () => comiteRecord).rejects.toThrow('dateDuComiteDoitEtreDansLeFutur')
   })
 
   it('modifier un comité', async () => {

--- a/src/gateways/PrismaComiteRepository.ts
+++ b/src/gateways/PrismaComiteRepository.ts
@@ -27,8 +27,8 @@ export class PrismaComiteRepository implements ComiteRepository {
     return true
   }
 
-  async find(uid: Comite['uid']['state']['value']): Promise<Comite | null> {
-    const record = await this.#dataResource.findUnique({
+  async find(uid: Comite['uid']['state']['value']): Promise<Comite> {
+    const record = await this.#dataResource.findUniqueOrThrow({
       include: {
         relationUtilisateur: true,
       },
@@ -36,10 +36,6 @@ export class PrismaComiteRepository implements ComiteRepository {
         id: Number(uid),
       },
     })
-
-    if (!record) {
-      return null
-    }
 
     const comite = Comite.create({
       commentaire: record.commentaire ?? undefined,

--- a/src/gateways/PrismaComiteRepository.ts
+++ b/src/gateways/PrismaComiteRepository.ts
@@ -27,7 +27,7 @@ export class PrismaComiteRepository implements ComiteRepository {
     return true
   }
 
-  async find(uid: Comite['uid']['state']['value']): Promise<Comite> {
+  async get(uid: Comite['uid']['state']['value']): Promise<Comite> {
     const record = await this.#dataResource.findUniqueOrThrow({
       include: {
         relationUtilisateur: true,

--- a/src/gateways/PrismaGouvernanceLoader.ts
+++ b/src/gateways/PrismaGouvernanceLoader.ts
@@ -42,7 +42,7 @@ export class PrismaGouvernanceLoader extends UneGouvernanceReadModelLoader {
     this.#dataResource = dataResource
   }
 
-  protected override async find(codeDepartement: string): Promise<UneGouvernanceReadModel> {
+  protected override async gouvernance(codeDepartement: string): Promise<UneGouvernanceReadModel> {
     const gouvernanceRecord = await this.#dataResource.findFirst({
       include: {
         comites: {

--- a/src/gateways/PrismaGouvernanceRepository.test.ts
+++ b/src/gateways/PrismaGouvernanceRepository.test.ts
@@ -23,7 +23,7 @@ describe('gouvernance repository', () => {
     const repository = new PrismaGouvernanceRepository(prisma.gouvernanceRecord, prisma.noteDeContexteRecord)
 
     // WHEN
-    const gouvernanceTrouvee = repository.find(new GouvernanceUid('3'))
+    const gouvernanceTrouvee = repository.get(new GouvernanceUid('3'))
 
     // THEN
     await expect(gouvernanceTrouvee).rejects.toThrow(Prisma.PrismaClientKnownRequestError)
@@ -42,7 +42,7 @@ describe('gouvernance repository', () => {
     const repository = new PrismaGouvernanceRepository(prisma.gouvernanceRecord, prisma.noteDeContexteRecord)
 
     // WHEN
-    const gouvernanceTrouvee = await repository.find(new GouvernanceUid(departementCode))
+    const gouvernanceTrouvee = await repository.get(new GouvernanceUid(departementCode))
 
     // THEN
     expect(gouvernanceTrouvee.state).toStrictEqual(
@@ -61,7 +61,7 @@ describe('gouvernance repository', () => {
     const repository = new PrismaGouvernanceRepository(prisma.gouvernanceRecord, prisma.noteDeContexteRecord)
 
     // WHEN
-    const gouvernanceTrouvee = await repository.find(new GouvernanceUid(departementCode))
+    const gouvernanceTrouvee = await repository.get(new GouvernanceUid(departementCode))
 
     // THEN
     expect(gouvernanceTrouvee.state).toStrictEqual(gouvernanceFactory({ uid: departementCode }).state)
@@ -79,7 +79,7 @@ describe('gouvernance repository', () => {
     const repository = new PrismaGouvernanceRepository(prisma.gouvernanceRecord, prisma.noteDeContexteRecord)
 
     // WHEN
-    const gouvernanceTrouvee = await repository.find(new GouvernanceUid(departementCode))
+    const gouvernanceTrouvee = await repository.get(new GouvernanceUid(departementCode))
 
     // THEN
     expect(gouvernanceTrouvee.state).toStrictEqual(

--- a/src/gateways/PrismaGouvernanceRepository.test.ts
+++ b/src/gateways/PrismaGouvernanceRepository.test.ts
@@ -1,3 +1,5 @@
+import { Prisma } from '@prisma/client'
+
 import { PrismaGouvernanceRepository } from './PrismaGouvernanceRepository'
 import { creerUnDepartement, creerUneGouvernance, creerUneNoteDeContexte, creerUneRegion, creerUnUtilisateur, gouvernanceRecordFactory } from './testHelper'
 import prisma from '../../prisma/prismaClient'
@@ -21,10 +23,11 @@ describe('gouvernance repository', () => {
     const repository = new PrismaGouvernanceRepository(prisma.gouvernanceRecord, prisma.noteDeContexteRecord)
 
     // WHEN
-    const gouvernanceTrouvee = await repository.find(new GouvernanceUid('3'))
+    const gouvernanceTrouvee = repository.find(new GouvernanceUid('3'))
 
     // THEN
-    expect(gouvernanceTrouvee).toBeNull()
+    await expect(gouvernanceTrouvee).rejects.toThrow(Prisma.PrismaClientKnownRequestError)
+    await expect(gouvernanceTrouvee).rejects.toMatchObject({ code: 'P2025' })
   })
 
   it('rechercher une gouvernance qui existe sans note de contexte', async () => {
@@ -42,7 +45,7 @@ describe('gouvernance repository', () => {
     const gouvernanceTrouvee = await repository.find(new GouvernanceUid(departementCode))
 
     // THEN
-    expect(gouvernanceTrouvee?.state).toStrictEqual(
+    expect(gouvernanceTrouvee.state).toStrictEqual(
       gouvernanceFactory({ noteDeContexte: undefined, uid: departementCode }).state
     )
   })
@@ -61,7 +64,7 @@ describe('gouvernance repository', () => {
     const gouvernanceTrouvee = await repository.find(new GouvernanceUid(departementCode))
 
     // THEN
-    expect(gouvernanceTrouvee?.state).toStrictEqual(gouvernanceFactory({ uid: departementCode }).state)
+    expect(gouvernanceTrouvee.state).toStrictEqual(gouvernanceFactory({ uid: departementCode }).state)
   })
 
   it('rechercher une gouvernance qui existe sans note privée', async () => {
@@ -79,7 +82,7 @@ describe('gouvernance repository', () => {
     const gouvernanceTrouvee = await repository.find(new GouvernanceUid(departementCode))
 
     // THEN
-    expect(gouvernanceTrouvee?.state).toStrictEqual(
+    expect(gouvernanceTrouvee.state).toStrictEqual(
       gouvernanceFactory({ noteDeContexte: undefined, notePrivee: undefined, uid: departementCode }).state
     )
   })

--- a/src/gateways/PrismaGouvernanceRepository.ts
+++ b/src/gateways/PrismaGouvernanceRepository.ts
@@ -16,8 +16,8 @@ export class PrismaGouvernanceRepository implements GouvernanceRepository {
     this.#gouvernanceDataResource = gouvernanceDataResource
   }
 
-  async find(uid: GouvernanceUid): Promise<Gouvernance | null> {
-    const record = await this.#gouvernanceDataResource.findUnique({
+  async find(uid: GouvernanceUid): Promise<Gouvernance> {
+    const record = await this.#gouvernanceDataResource.findUniqueOrThrow({
       include: {
         noteDeContexte: {
           include: {
@@ -31,9 +31,6 @@ export class PrismaGouvernanceRepository implements GouvernanceRepository {
         departementCode: uid.state.value,
       },
     })
-    if (!record) {
-      return null
-    }
 
     const noteDeContexte = record.noteDeContexte ? {
       contenu: record.noteDeContexte.contenu,

--- a/src/gateways/PrismaGouvernanceRepository.ts
+++ b/src/gateways/PrismaGouvernanceRepository.ts
@@ -16,7 +16,7 @@ export class PrismaGouvernanceRepository implements GouvernanceRepository {
     this.#gouvernanceDataResource = gouvernanceDataResource
   }
 
-  async find(uid: GouvernanceUid): Promise<Gouvernance> {
+  async get(uid: GouvernanceUid): Promise<Gouvernance> {
     const record = await this.#gouvernanceDataResource.findUniqueOrThrow({
       include: {
         noteDeContexte: {

--- a/src/gateways/PrismaMesInformationsPersonnellesLoader.test.ts
+++ b/src/gateways/PrismaMesInformationsPersonnellesLoader.test.ts
@@ -46,7 +46,7 @@ describe('mes informations personnelles loader', () => {
     const mesInformationsPersonnellesLoader = new PrismaMesInformationsPersonnellesLoader(prisma.utilisateurRecord)
 
     // WHEN
-    const mesInformationsPersonnellesReadModel = await mesInformationsPersonnellesLoader.findByUid(ssoIdExistant)
+    const mesInformationsPersonnellesReadModel = await mesInformationsPersonnellesLoader.byUid(ssoIdExistant)
 
     // THEN
     expect(mesInformationsPersonnellesReadModel).toStrictEqual<MesInformationsPersonnellesReadModel>({
@@ -73,7 +73,7 @@ describe('mes informations personnelles loader', () => {
     const mesInformationsPersonnellesLoader = new PrismaMesInformationsPersonnellesLoader(prisma.utilisateurRecord)
 
     // WHEN
-    const mesInformationsPersonnellesReadModel = await mesInformationsPersonnellesLoader.findByUid(ssoIdExistant)
+    const mesInformationsPersonnellesReadModel = await mesInformationsPersonnellesLoader.byUid(ssoIdExistant)
 
     // THEN
     expect(mesInformationsPersonnellesReadModel).toStrictEqual<MesInformationsPersonnellesReadModel>({
@@ -105,7 +105,7 @@ describe('mes informations personnelles loader', () => {
 
     // WHEN
     const utilisateurReadModel = async (): Promise<MesInformationsPersonnellesReadModel> => {
-      return mesInformationsPersonnellesGateway.findByUid(ssoIdInexistant)
+      return mesInformationsPersonnellesGateway.byUid(ssoIdInexistant)
     }
 
     // THEN

--- a/src/gateways/PrismaMesInformationsPersonnellesLoader.test.ts
+++ b/src/gateways/PrismaMesInformationsPersonnellesLoader.test.ts
@@ -1,4 +1,4 @@
-import { Role } from '@prisma/client'
+import { Prisma, Role } from '@prisma/client'
 
 import { PrismaMesInformationsPersonnellesLoader } from './PrismaMesInformationsPersonnellesLoader'
 import { creerUnDepartement, creerUneRegion, creerUneStructure, creerUnUtilisateur } from './testHelper'
@@ -109,6 +109,7 @@ describe('mes informations personnelles loader', () => {
     }
 
     // THEN
-    await expect(utilisateurReadModel).rejects.toThrow('L’utilisateur n’existe pas.')
+    await expect(utilisateurReadModel).rejects.toThrow(Prisma.PrismaClientKnownRequestError)
+    await expect(utilisateurReadModel).rejects.toMatchObject({ code: 'P2025' })
   })
 })

--- a/src/gateways/PrismaMesInformationsPersonnellesLoader.ts
+++ b/src/gateways/PrismaMesInformationsPersonnellesLoader.ts
@@ -1,7 +1,6 @@
 import { Prisma } from '@prisma/client'
 
 import { UtilisateurEtSesRelationsRecord, toTypologieRole } from './shared/RoleMapper'
-import { UtilisateurNonTrouveError } from '@/use-cases/queries/RechercherUnUtilisateur'
 import { MesInformationsPersonnellesReadModel, MesInformationsPersonnellesLoader } from '@/use-cases/queries/RecupererMesInformationsPersonnelles'
 
 export class PrismaMesInformationsPersonnellesLoader implements MesInformationsPersonnellesLoader {
@@ -11,8 +10,8 @@ export class PrismaMesInformationsPersonnellesLoader implements MesInformationsP
     this.dataResource = dataResource
   }
 
-  async findByUid(uid: string): Promise<MesInformationsPersonnellesReadModel> {
-    const utilisateurRecord = await this.dataResource.findUnique({
+  async byUid(uid: string): Promise<MesInformationsPersonnellesReadModel> {
+    const utilisateurRecord = await this.dataResource.findUniqueOrThrow({
       include: {
         relationDepartement: true,
         relationGroupement: true,
@@ -23,10 +22,6 @@ export class PrismaMesInformationsPersonnellesLoader implements MesInformationsP
         ssoId: uid,
       },
     })
-
-    if (utilisateurRecord === null) {
-      throw new UtilisateurNonTrouveError()
-    }
 
     return transform(utilisateurRecord)
   }

--- a/src/gateways/PrismaMesMembresLoader.test.ts
+++ b/src/gateways/PrismaMesMembresLoader.test.ts
@@ -7,7 +7,7 @@ describe('mes membres loader', () => {
 
   afterEach(async () => prisma.$queryRaw`ROLLBACK TRANSACTION`)
 
-  it('quand les membres rattachés à une gouvernance existante sont demandés, alors elle sont renvoyée dans l’ordre alphabétique', async () => {
+  it('quand les membres rattachés à une gouvernance sont demandés, alors elle sont renvoyée dans l’ordre alphabétique', async () => {
     // GIVEN
     await creerUneRegion({ code: '84', nom: 'Auvergne-Rhône-Alpes' })
     await creerUnDepartement({ code: '69', nom: 'Rhône', regionCode: '84' })

--- a/src/gateways/PrismaMesMembresLoader.ts
+++ b/src/gateways/PrismaMesMembresLoader.ts
@@ -10,7 +10,7 @@ export class PrismaMesMembresLoader extends MesMembresLoader {
     this.#dataResource = dataResource
   }
 
-  protected override async find(codeDepartementGouvernance: string): Promise<MesMembresReadModel> {
+  protected override async membres(codeDepartementGouvernance: string): Promise<MesMembresReadModel> {
     const result: ReadonlyArray<Membres> = await this.#dataResource.$queryRaw`
       SELECT commune AS "nomMembre", ARRAY_AGG(role) AS role FROM membre_gouvernance_commune WHERE "gouvernanceDepartementCode" = ${codeDepartementGouvernance} GROUP BY commune
       UNION ALL

--- a/src/gateways/PrismaStructureLoader.test.ts
+++ b/src/gateways/PrismaStructureLoader.test.ts
@@ -58,7 +58,7 @@ describe('structures loader', () => {
       const structureLoader = new PrismaStructureLoader(prisma.structureRecord)
 
       // WHEN
-      const structureReadModel = await structureLoader.findStructures(match)
+      const structureReadModel = await structureLoader.structures(match)
 
       // THEN
       expect(structureReadModel).toStrictEqual(expected)
@@ -70,7 +70,7 @@ describe('structures loader', () => {
       const structureLoader = new PrismaStructureLoader(prisma.structureRecord)
 
       // WHEN
-      const structureReadModel = await structureLoader.findStructuresByDepartement('ris', '06')
+      const structureReadModel = await structureLoader.structuresByDepartement('ris', '06')
 
       // THEN
       expect(structureReadModel).toStrictEqual([
@@ -88,7 +88,7 @@ describe('structures loader', () => {
       const structureLoader = new PrismaStructureLoader(prisma.structureRecord)
 
       // WHEN
-      const structureReadModel = await structureLoader.findStructuresByRegion('ris', '93')
+      const structureReadModel = await structureLoader.structuresByRegion('ris', '93')
 
       // THEN
       expect(structureReadModel).toStrictEqual([

--- a/src/gateways/PrismaStructureLoader.ts
+++ b/src/gateways/PrismaStructureLoader.ts
@@ -9,11 +9,11 @@ export class PrismaStructureLoader implements StructureLoader {
     this.#dataResource = dataResource
   }
 
-  async findStructures(match: string): Promise<StructuresReadModel> {
+  async structures(match: string): Promise<StructuresReadModel> {
     return this.#structuresRecord(match).then(transform)
   }
 
-  async findStructuresByDepartement(match: string, codeDepartement: string): Promise<StructuresReadModel> {
+  async structuresByDepartement(match: string, codeDepartement: string): Promise<StructuresReadModel> {
     return this.#structuresRecord(match, {
       departementCode: {
         equals: codeDepartement,
@@ -21,7 +21,7 @@ export class PrismaStructureLoader implements StructureLoader {
     }).then(transform)
   }
 
-  async findStructuresByRegion(match: string, codeRegion: string): Promise<StructuresReadModel> {
+  async structuresByRegion(match: string, codeRegion: string): Promise<StructuresReadModel> {
     return this.#structuresRecord(match, {
       relationDepartement: {
         regionCode: {

--- a/src/gateways/PrismaUtilisateurLoader.test.ts
+++ b/src/gateways/PrismaUtilisateurLoader.test.ts
@@ -192,7 +192,7 @@ describe('prisma utilisateur query', () => {
       })
 
       // WHEN
-      const mesUtilisateursReadModel = await utilisateurLoader.findMesUtilisateursEtLeTotal(
+      const mesUtilisateursReadModel = await utilisateurLoader.mesUtilisateursEtLeTotal(
         utilisateurAuthentifie,
         pageCourante,
         utilisateursParPage,
@@ -278,7 +278,7 @@ describe('prisma utilisateur query', () => {
       await creerUnUtilisateur({ nom: 'Durant', role: 'administrateur_dispositif', ssoEmail: 'martin.tartempion@example.fr', ssoId: 'fakeSsoId' })
 
       // WHEN
-      const mesUtilisateursReadModel = await utilisateurLoader.findMesUtilisateursEtLeTotal(
+      const mesUtilisateursReadModel = await utilisateurLoader.mesUtilisateursEtLeTotal(
         utilisateurAuthentifie,
         pageCourante,
         utilisateursParPage,
@@ -317,7 +317,7 @@ describe('prisma utilisateur query', () => {
       await creerUnUtilisateur({ nom: 'Durant', role: 'administrateur_dispositif', ssoEmail: 'martin.tartempion@example.fr', ssoId: 'fakeSsoId' })
 
       // WHEN
-      const mesUtilisateursReadModel = await utilisateurLoader.findMesUtilisateursEtLeTotal(
+      const mesUtilisateursReadModel = await utilisateurLoader.mesUtilisateursEtLeTotal(
         utilisateurAuthentifie,
         pageCourante,
         utilisateursParPage,
@@ -356,7 +356,7 @@ describe('prisma utilisateur query', () => {
       await creerUnUtilisateur({ nom: 'Durant', role: 'administrateur_dispositif', ssoEmail: 'fakeSsoEmail@example.com', ssoId: 'fakeSsoId' })
 
       // WHEN
-      const mesUtilisateursReadModel = await utilisateurLoader.findMesUtilisateursEtLeTotal(
+      const mesUtilisateursReadModel = await utilisateurLoader.mesUtilisateursEtLeTotal(
         utilisateurAuthentifie,
         pageCourante,
         utilisateursParPage,
@@ -397,7 +397,7 @@ describe('prisma utilisateur query', () => {
       await creerUnUtilisateur({ nom: 'Durant', role: 'administrateur_dispositif', ssoEmail: 'fakeSsoEmail@example.com', ssoId: 'fakeSsoId' })
 
       // WHEN
-      const mesUtilisateursReadModel = await utilisateurLoader.findMesUtilisateursEtLeTotal(
+      const mesUtilisateursReadModel = await utilisateurLoader.mesUtilisateursEtLeTotal(
         utilisateurAuthentifie,
         pageCourante,
         utilisateursParPage,
@@ -424,7 +424,7 @@ describe('prisma utilisateur query', () => {
       const utilisateursParPage = 1
 
       // WHEN
-      const mesUtilisateursReadModel = await utilisateurLoader.findMesUtilisateursEtLeTotal(
+      const mesUtilisateursReadModel = await utilisateurLoader.mesUtilisateursEtLeTotal(
         utilisateurAuthentifie,
         pageCourante,
         utilisateursParPage,
@@ -446,7 +446,7 @@ describe('prisma utilisateur query', () => {
       await creerUnUtilisateur({ isSupprime: true, ssoEmail: 'anthony.parquet@example.com', ssoId: '123456' })
 
       // WHEN
-      const mesUtilisateursReadModel = await utilisateurLoader.findMesUtilisateursEtLeTotal(
+      const mesUtilisateursReadModel = await utilisateurLoader.mesUtilisateursEtLeTotal(
         utilisateurAuthentifie,
         pageCourante,
         utilisateursParPage,
@@ -469,7 +469,7 @@ describe('prisma utilisateur query', () => {
       await creerUnUtilisateur({ derniereConnexion: null, nom: 'b', ssoEmail: 'anthony.parquet@example.com', ssoId: '123456' })
 
       // WHEN
-      const mesUtilisateursReadModel = await utilisateurLoader.findMesUtilisateursEtLeTotal(
+      const mesUtilisateursReadModel = await utilisateurLoader.mesUtilisateursEtLeTotal(
         utilisateurAuthentifie,
         pageCourante,
         utilisateursParPage,
@@ -491,7 +491,7 @@ describe('prisma utilisateur query', () => {
       const isActive = true
 
       // WHEN
-      const mesUtilisateursReadModel = await utilisateurLoader.findMesUtilisateursEtLeTotal(
+      const mesUtilisateursReadModel = await utilisateurLoader.mesUtilisateursEtLeTotal(
         utilisateurAuthentifie,
         pageCourante,
         utilisateursParPage,
@@ -516,7 +516,7 @@ describe('prisma utilisateur query', () => {
       const roles = ['administrateur_dispositif', 'gestionnaire_structure']
 
       // WHEN
-      const mesUtilisateursReadModel = await utilisateurLoader.findMesUtilisateursEtLeTotal(
+      const mesUtilisateursReadModel = await utilisateurLoader.mesUtilisateursEtLeTotal(
         utilisateurAuthentifie,
         pageCourante,
         utilisateursParPage,
@@ -551,7 +551,7 @@ describe('prisma utilisateur query', () => {
       await creerUnUtilisateur({ ssoEmail: 'nicolas.james@example.org', ssoId: '1234568', structureId: 11 })
 
       // WHEN
-      const mesUtilisateursReadModel = await utilisateurLoader.findMesUtilisateursEtLeTotal(
+      const mesUtilisateursReadModel = await utilisateurLoader.mesUtilisateursEtLeTotal(
         utilisateurAuthentifie,
         pageCourante,
         utilisateursParPage,
@@ -590,7 +590,7 @@ describe('prisma utilisateur query', () => {
       await creerUnUtilisateur({ ssoEmail: 'anthony.parquet@example.org', ssoId: 'sdfghj', structureId: 11 })
 
       // WHEN
-      const mesUtilisateursReadModel = await utilisateurLoader.findMesUtilisateursEtLeTotal(
+      const mesUtilisateursReadModel = await utilisateurLoader.mesUtilisateursEtLeTotal(
         utilisateurAuthentifie,
         pageCourante,
         utilisateursParPage,
@@ -645,7 +645,7 @@ describe('prisma utilisateur query', () => {
       })
 
       // WHEN
-      const mesUtilisateursReadModel = await utilisateurLoader.findMesUtilisateursEtLeTotal(
+      const mesUtilisateursReadModel = await utilisateurLoader.mesUtilisateursEtLeTotal(
         utilisateurAuthentifie,
         pageCourante,
         utilisateursParPage,
@@ -698,7 +698,7 @@ describe('prisma utilisateur query', () => {
       const prenomOuNomOuEmail = 'gregory.logeais@example.net'
 
       // WHEN
-      const result = await utilisateurLoader.findMesUtilisateursEtLeTotal(
+      const result = await utilisateurLoader.mesUtilisateursEtLeTotal(
         utilisateurAuthentifie,
         pageCourante,
         utilisateursParPage,
@@ -720,7 +720,7 @@ describe('prisma utilisateur query', () => {
       const prenomOuNomOuEmail = 'structure@example.net'
 
       // WHEN
-      const result = await utilisateurLoader.findMesUtilisateursEtLeTotal(
+      const result = await utilisateurLoader.mesUtilisateursEtLeTotal(
         utilisateurAuthentifie,
         pageCourante,
         utilisateursParPage,
@@ -742,7 +742,7 @@ describe('prisma utilisateur query', () => {
       const prenomOuNomOuEmail = 'Baptiste'
 
       // WHEN
-      const result = await utilisateurLoader.findMesUtilisateursEtLeTotal(
+      const result = await utilisateurLoader.mesUtilisateursEtLeTotal(
         utilisateurAuthentifie,
         pageCourante,
         utilisateursParPage,
@@ -765,7 +765,7 @@ describe('prisma utilisateur query', () => {
       const prenomOuNomOuEmail = 'Nogent'
 
       // WHEN
-      const result = await utilisateurLoader.findMesUtilisateursEtLeTotal(
+      const result = await utilisateurLoader.mesUtilisateursEtLeTotal(
         utilisateurAuthentifie,
         pageCourante,
         utilisateursParPage,
@@ -788,7 +788,7 @@ describe('prisma utilisateur query', () => {
       const prenomOuNomOuEmail = 'nonexistent@example.com'
 
       // WHEN
-      const result = await utilisateurLoader.findMesUtilisateursEtLeTotal(
+      const result = await utilisateurLoader.mesUtilisateursEtLeTotal(
         utilisateurAuthentifie,
         pageCourante,
         utilisateursParPage,
@@ -811,7 +811,7 @@ describe('prisma utilisateur query', () => {
       const prenomOuNomOuEmail = 'NonExistentName'
 
       // WHEN
-      const result = await utilisateurLoader.findMesUtilisateursEtLeTotal(
+      const result = await utilisateurLoader.mesUtilisateursEtLeTotal(
         utilisateurAuthentifie,
         pageCourante,
         utilisateursParPage,

--- a/src/gateways/PrismaUtilisateurLoader.test.ts
+++ b/src/gateways/PrismaUtilisateurLoader.test.ts
@@ -1,3 +1,5 @@
+import { Prisma } from '@prisma/client'
+
 import { PrismaUtilisateurLoader } from './PrismaUtilisateurLoader'
 import { creerUnDepartement, creerUneRegion, creerUneStructure, creerUnGroupement, creerUnUtilisateur } from './testHelper'
 import prisma from '../../prisma/prismaClient'
@@ -153,7 +155,8 @@ describe('prisma utilisateur query', () => {
         async (): Promise<UnUtilisateurReadModel> => utilisateurLoader.findByUid(ssoIdInexistant)
 
       // THEN
-      await expect(utilisateurReadModel).rejects.toThrow('L’utilisateur n’existe pas.')
+      await expect(utilisateurReadModel).rejects.toThrow(Prisma.PrismaClientKnownRequestError)
+      await expect(utilisateurReadModel).rejects.toMatchObject({ code: 'P2025' })
     })
 
     it('quand je cherche un utilisateur qui existe par son ssoId et dont le compte a été supprimé alors je ne le trouve pas', async () => {
@@ -167,7 +170,8 @@ describe('prisma utilisateur query', () => {
         async (): Promise<UnUtilisateurReadModel> => utilisateurLoader.findByUid(ssoIdExistant)
 
       // THEN
-      await expect(utilisateurReadModel).rejects.toThrow('L’utilisateur n’existe pas.')
+      await expect(utilisateurReadModel).rejects.toThrow(Prisma.PrismaClientKnownRequestError)
+      await expect(utilisateurReadModel).rejects.toMatchObject({ code: 'P2025' })
     })
   })
 

--- a/src/gateways/PrismaUtilisateurLoader.ts
+++ b/src/gateways/PrismaUtilisateurLoader.ts
@@ -13,7 +13,7 @@ export class PrismaUtilisateurLoader implements MesUtilisateursLoader {
     this.#dataResource = dataResource
   }
 
-  async findMesUtilisateursEtLeTotal(
+  async mesUtilisateursEtLeTotal(
     utilisateurCourant: UnUtilisateurReadModel,
     pageCourante: number,
     utilisateursParPage: number,

--- a/src/gateways/PrismaUtilisateurLoader.ts
+++ b/src/gateways/PrismaUtilisateurLoader.ts
@@ -4,7 +4,6 @@ import { organisation, toTypologieRole, UtilisateurEtSesRelationsRecord } from '
 import { Role } from '@/domain/Role'
 import { isNullish } from '@/shared/lang'
 import { MesUtilisateursLoader, UtilisateursCourantsEtTotalReadModel } from '@/use-cases/queries/RechercherMesUtilisateurs'
-import { UtilisateurNonTrouveError } from '@/use-cases/queries/RechercherUnUtilisateur'
 import { UnUtilisateurReadModel } from '@/use-cases/queries/shared/UnUtilisateurReadModel'
 
 export class PrismaUtilisateurLoader implements MesUtilisateursLoader {
@@ -130,7 +129,7 @@ export class PrismaUtilisateurLoader implements MesUtilisateursLoader {
   }
 
   async findByUid(uid: string): Promise<UnUtilisateurReadModel> {
-    const utilisateurRecord = await this.#dataResource.findUnique({
+    const utilisateurRecord = await this.#dataResource.findUniqueOrThrow({
       include: {
         relationDepartement: true,
         relationGroupement: true,
@@ -142,10 +141,6 @@ export class PrismaUtilisateurLoader implements MesUtilisateursLoader {
         ssoId: uid,
       },
     })
-
-    if (utilisateurRecord === null) {
-      throw new UtilisateurNonTrouveError()
-    }
 
     return transform(utilisateurRecord)
   }

--- a/src/gateways/PrismaUtilisateurRepository.test.ts
+++ b/src/gateways/PrismaUtilisateurRepository.test.ts
@@ -25,27 +25,29 @@ describe('utilisateur repository', () => {
   describe('recherche d’un utilisateur', () => {
     const repository = new PrismaUtilisateurRepository(prisma.utilisateurRecord)
 
-    it('l’utilisateur n’existe pas : pas de donnée', async () => {
+    it('l’utilisateur n’existe pas : erreur', async () => {
       // GIVEN
       const ssoIdInexistant = '6513cfb5-5b46-4188-a71f-5476dfee0e8e'
       await creerUnUtilisateur({ ssoId: ssoIdInexistant })
 
       // WHEN
-      const result = await repository.find(uidUtilisateurValue)
+      const result = repository.find(uidUtilisateurValue)
 
       // THEN
-      expect(result).toBeNull()
+      await expect(result).rejects.toThrow(Prisma.PrismaClientKnownRequestError)
+      await expect(result).rejects.toMatchObject({ code: 'P2025' })
     })
 
-    it('l’utilisateur est supprimé : pas de donnée', async () => {
+    it('l’utilisateur est supprimé : erreur', async () => {
       // GIVEN
       await creerUnUtilisateur({ isSupprime: true })
 
       // WHEN
-      const result = await repository.find(uidUtilisateurValue)
+      const result = repository.find(uidUtilisateurValue)
 
       // THEN
-      expect(result).toBeNull()
+      await expect(result).rejects.toThrow(Prisma.PrismaClientKnownRequestError)
+      await expect(result).rejects.toMatchObject({ code: 'P2025' })
     })
 
     describe('l’utilisateur existe : les données utilisateur sont reçues', () => {
@@ -158,7 +160,7 @@ describe('utilisateur repository', () => {
         const result = await repository.find(uidUtilisateurValue)
 
         // THEN
-        expect(result?.state).toStrictEqual(
+        expect(result.state).toStrictEqual(
           utilisateurFactory({
             uid: uidUtilisateur.state,
             ...expected,
@@ -189,7 +191,7 @@ describe('utilisateur repository', () => {
         const result = await repository.find(uidUtilisateurValue)
 
         // THEN
-        expect(result?.state.isActive).toBe(expectedIsActive)
+        expect(result.state.isActive).toBe(expectedIsActive)
       })
     })
   })

--- a/src/gateways/PrismaUtilisateurRepository.test.ts
+++ b/src/gateways/PrismaUtilisateurRepository.test.ts
@@ -31,7 +31,7 @@ describe('utilisateur repository', () => {
       await creerUnUtilisateur({ ssoId: ssoIdInexistant })
 
       // WHEN
-      const result = repository.find(uidUtilisateurValue)
+      const result = repository.get(uidUtilisateurValue)
 
       // THEN
       await expect(result).rejects.toThrow(Prisma.PrismaClientKnownRequestError)
@@ -43,7 +43,7 @@ describe('utilisateur repository', () => {
       await creerUnUtilisateur({ isSupprime: true })
 
       // WHEN
-      const result = repository.find(uidUtilisateurValue)
+      const result = repository.get(uidUtilisateurValue)
 
       // THEN
       await expect(result).rejects.toThrow(Prisma.PrismaClientKnownRequestError)
@@ -157,7 +157,7 @@ describe('utilisateur repository', () => {
         await creerUnUtilisateur({ ...createRecordWith })
 
         // WHEN
-        const result = await repository.find(uidUtilisateurValue)
+        const result = await repository.get(uidUtilisateurValue)
 
         // THEN
         expect(result.state).toStrictEqual(
@@ -188,7 +188,7 @@ describe('utilisateur repository', () => {
         await creerUnUtilisateur({ derniereConnexion })
 
         // WHEN
-        const result = await repository.find(uidUtilisateurValue)
+        const result = await repository.get(uidUtilisateurValue)
 
         // THEN
         expect(result.state.isActive).toBe(expectedIsActive)

--- a/src/gateways/PrismaUtilisateurRepository.ts
+++ b/src/gateways/PrismaUtilisateurRepository.ts
@@ -49,7 +49,7 @@ export class PrismaUtilisateurRepository implements UtilisateurRepository {
     }
   }
 
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
+  async get(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     const record = await this.#dataResource.findUniqueOrThrow({
       include: {
         relationDepartement: true,

--- a/src/gateways/PrismaUtilisateurRepository.ts
+++ b/src/gateways/PrismaUtilisateurRepository.ts
@@ -49,8 +49,8 @@ export class PrismaUtilisateurRepository implements UtilisateurRepository {
     }
   }
 
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur | null> {
-    const record = await this.#dataResource.findUnique({
+  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
+    const record = await this.#dataResource.findUniqueOrThrow({
       include: {
         relationDepartement: true,
         relationGroupement: true,
@@ -62,9 +62,6 @@ export class PrismaUtilisateurRepository implements UtilisateurRepository {
         ssoId: uid,
       },
     })
-    if (!record) {
-      return null
-    }
     return new UtilisateurFactory({
       departement: mapDepartement(record.relationDepartement),
       derniereConnexion: record.derniereConnexion ?? undefined,

--- a/src/use-cases/CommandHandler.ts
+++ b/src/use-cases/CommandHandler.ts
@@ -1,7 +1,7 @@
 import { Result, ResultOk, Struct } from '@/shared/lang'
 
 export interface CommandHandler<Command extends Struct, Failure = string, Success = ResultOk> {
-  execute(command: Command): ResultAsync<Failure, Success>
+  handle(command: Command): ResultAsync<Failure, Success>
 }
 
 export type ResultAsync<Failure, Success = ResultOk> = Promise<Result<Failure, Success>>

--- a/src/use-cases/QueryHandler.ts
+++ b/src/use-cases/QueryHandler.ts
@@ -1,5 +1,5 @@
 import { Struct } from '@/shared/lang'
 
 export interface QueryHandler<Query extends Struct, ReadModel> {
-  get(query: Query): Promise<ReadModel>
+  handle(query: Query): Promise<ReadModel>
 }

--- a/src/use-cases/commands/AjouterNoteDeContexteAGouvernance.test.ts
+++ b/src/use-cases/commands/AjouterNoteDeContexteAGouvernance.test.ts
@@ -1,6 +1,6 @@
 import { AjouterNoteDeContexteAGouvernance } from './AjouterNoteDeContexteAGouvernance'
-import { FindGouvernanceRepository, UpdateGouvernanceRepository } from './shared/GouvernanceRepository'
-import { FindUtilisateurRepository } from './shared/UtilisateurRepository'
+import { GetGouvernanceRepository, UpdateGouvernanceRepository } from './shared/GouvernanceRepository'
+import { GetUtilisateurRepository } from './shared/UtilisateurRepository'
 import { Gouvernance, GouvernanceUid } from '@/domain/Gouvernance'
 import { gouvernanceFactory, utilisateurFactory } from '@/domain/testHelper'
 import { Utilisateur, UtilisateurUid, UtilisateurUidState } from '@/domain/Utilisateur'
@@ -22,7 +22,7 @@ describe('ajouter une note de contexte à une gouvernance', () => {
     )
 
     // WHEN
-    const result = await ajouterNoteDeContexteAGouvernance.execute({
+    const result = await ajouterNoteDeContexteAGouvernance.handle({
       contenu,
       uidEditeur,
       uidGouvernance,
@@ -55,7 +55,7 @@ describe('ajouter une note de contexte à une gouvernance', () => {
     )
 
     // WHEN
-    const result = await ajouterNoteDeContexteAGouvernance.execute({ contenu, uidEditeur: 'utilisateurUsurpateur', uidGouvernance })
+    const result = await ajouterNoteDeContexteAGouvernance.handle({ contenu, uidEditeur: 'utilisateurUsurpateur', uidGouvernance })
 
     // THEN
     expect(spiedUtilisateurUidToFind).toBe('utilisateurUsurpateur')
@@ -73,7 +73,7 @@ describe('ajouter une note de contexte à une gouvernance', () => {
     )
 
     // WHEN
-    const result = await ajouterNoteDeContexteAGouvernance.execute({
+    const result = await ajouterNoteDeContexteAGouvernance.handle({
       contenu,
       uidEditeur,
       uidGouvernance,
@@ -94,8 +94,8 @@ let spiedGouvernanceUidToFind: GouvernanceUid | null
 let spiedGouvernanceToUpdate: Gouvernance | null
 let spiedUtilisateurUidToFind: string | null
 
-class GouvernanceRepositorySpy implements FindGouvernanceRepository, UpdateGouvernanceRepository {
-  async find(uid: GouvernanceUid): Promise<Gouvernance> {
+class GouvernanceRepositorySpy implements GetGouvernanceRepository, UpdateGouvernanceRepository {
+  async get(uid: GouvernanceUid): Promise<Gouvernance> {
     spiedGouvernanceUidToFind = uid
     return Promise.resolve(
       gouvernanceFactory({
@@ -117,7 +117,7 @@ class GouvernanceRepositorySpy implements FindGouvernanceRepository, UpdateGouve
 }
 
 class GouvernanceAvecNoteDeContexteRepositorySpy extends GouvernanceRepositorySpy {
-  override async find(uid: GouvernanceUid): Promise<Gouvernance> {
+  override async get(uid: GouvernanceUid): Promise<Gouvernance> {
     spiedGouvernanceUidToFind = uid
     return Promise.resolve(
       gouvernanceFactory({
@@ -139,15 +139,15 @@ class GouvernanceAvecNoteDeContexteRepositorySpy extends GouvernanceRepositorySp
   }
 }
 
-class GestionnaireRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
+class GestionnaireRepositorySpy implements GetUtilisateurRepository {
+  async get(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUtilisateurUidToFind = uid
     return Promise.resolve(utilisateurFactory({ codeOrganisation: '75', role: 'Gestionnaire département' }))
   }
 }
 
-class GestionnaireAutreRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
+class GestionnaireAutreRepositorySpy implements GetUtilisateurRepository {
+  async get(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUtilisateurUidToFind = uid
     return Promise.resolve(utilisateurFactory({ codeOrganisation: '10', role: 'Gestionnaire département' }))
   }

--- a/src/use-cases/commands/AjouterNoteDeContexteAGouvernance.ts
+++ b/src/use-cases/commands/AjouterNoteDeContexteAGouvernance.ts
@@ -22,14 +22,7 @@ export class AjouterNoteDeContexteAGouvernance implements CommandHandler<Command
 
   async execute(command: Command): ResultAsync<Failure> {
     const editeur = await this.#utilisateurRepository.find(command.uidEditeur)
-    if (!editeur) {
-      return 'editeurInexistant'
-    }
-
     const gouvernance = await this.#gouvernanceRepository.find(new GouvernanceUid(command.uidGouvernance))
-    if (!gouvernance) {
-      return 'gouvernanceInexistante'
-    }
     if (!gouvernance.peutEtreGerePar(editeur)) {
       return 'utilisateurNePeutPasAjouterNoteDeContexte'
     }
@@ -48,7 +41,7 @@ export class AjouterNoteDeContexteAGouvernance implements CommandHandler<Command
   }
 }
 
-type Failure = 'gouvernanceInexistante' | 'editeurInexistant' | 'utilisateurNePeutPasAjouterNoteDeContexte' | GouvernanceFailure
+type Failure = 'utilisateurNePeutPasAjouterNoteDeContexte' | GouvernanceFailure
 
 type Command = Readonly<{
   contenu: string
@@ -59,4 +52,3 @@ type Command = Readonly<{
 export interface GouvernanceRepository extends FindGouvernanceRepository, UpdateGouvernanceRepository {}
 
 type UtilisateurRepository = FindUtilisateurRepository
-

--- a/src/use-cases/commands/AjouterNoteDeContexteAGouvernance.ts
+++ b/src/use-cases/commands/AjouterNoteDeContexteAGouvernance.ts
@@ -1,6 +1,6 @@
 import { CommandHandler, ResultAsync } from '../CommandHandler'
-import { FindGouvernanceRepository, UpdateGouvernanceRepository } from './shared/GouvernanceRepository'
-import { FindUtilisateurRepository } from './shared/UtilisateurRepository'
+import { GetGouvernanceRepository, UpdateGouvernanceRepository } from './shared/GouvernanceRepository'
+import { GetUtilisateurRepository } from './shared/UtilisateurRepository'
 import { GouvernanceFailure, GouvernanceUid, NoteDeContexte } from '@/domain/Gouvernance'
 import { UtilisateurUid } from '@/domain/Utilisateur'
 import { isOk } from '@/shared/lang'
@@ -20,9 +20,9 @@ export class AjouterNoteDeContexteAGouvernance implements CommandHandler<Command
     this.#date = date
   }
 
-  async execute(command: Command): ResultAsync<Failure> {
-    const editeur = await this.#utilisateurRepository.find(command.uidEditeur)
-    const gouvernance = await this.#gouvernanceRepository.find(new GouvernanceUid(command.uidGouvernance))
+  async handle(command: Command): ResultAsync<Failure> {
+    const editeur = await this.#utilisateurRepository.get(command.uidEditeur)
+    const gouvernance = await this.#gouvernanceRepository.get(new GouvernanceUid(command.uidGouvernance))
     if (!gouvernance.peutEtreGerePar(editeur)) {
       return 'utilisateurNePeutPasAjouterNoteDeContexte'
     }
@@ -49,6 +49,6 @@ type Command = Readonly<{
   uidGouvernance: string
 }>
 
-export interface GouvernanceRepository extends FindGouvernanceRepository, UpdateGouvernanceRepository {}
+export interface GouvernanceRepository extends GetGouvernanceRepository, UpdateGouvernanceRepository {}
 
-type UtilisateurRepository = FindUtilisateurRepository
+type UtilisateurRepository = GetUtilisateurRepository

--- a/src/use-cases/commands/AjouterUnComite.test.ts
+++ b/src/use-cases/commands/AjouterUnComite.test.ts
@@ -32,7 +32,7 @@ describe('ajouter un comité à une gouvernance', () => {
       intention: 'sans date ni commentaire',
       type: typeValide,
     },
-  ])('étant donné une gouvernance existante, quand un comité est créé $intention par son gestionnaire, alors il est ajouté à cette gourvernance', async ({
+  ])('étant donné une gouvernance, quand un comité est créé $intention par son gestionnaire, alors il est ajouté à cette gourvernance', async ({
     commentaire,
     date,
     expectedDate,
@@ -125,7 +125,7 @@ describe('ajouter un comité à une gouvernance', () => {
       intention: 'de la date de comité qui est dans le passé',
       type: typeValide,
     },
-  ])('étant donné une gouvernance existante, quand un comité est créé par son gestionnaire mais que le comité n’est pas valide à cause $intention, alors une erreur est renvoyée', async ({ date, dateDeCreation, expectedFailure, frequence, type }) => {
+  ])('étant donné une gouvernance, quand un comité est créé par son gestionnaire mais que le comité n’est pas valide à cause $intention, alors une erreur est renvoyée', async ({ date, dateDeCreation, expectedFailure, frequence, type }) => {
     // GIVEN
     const ajouterUnComite = new AjouterUnComite(
       new GouvernanceRepositorySpy(),
@@ -150,7 +150,7 @@ describe('ajouter un comité à une gouvernance', () => {
     expect(spiedComiteToAdd).toBeNull()
   })
 
-  it('étant donné une gouvernance existante, quand un comité est créé par un gestionnaire autre que celui de la gouvernance, alors une erreur est renvoyée', async () => {
+  it('étant donné une gouvernance, quand un comité est créé par un gestionnaire autre que celui de la gouvernance, alors une erreur est renvoyée', async () => {
     // GIVEN
     const ajouterUnComite = new AjouterUnComite(
       new GouvernanceRepositorySpy(),
@@ -175,58 +175,6 @@ describe('ajouter un comité à une gouvernance', () => {
     expect(result).toBe('editeurNePeutPasAjouterComite')
     expect(spiedComiteToAdd).toBeNull()
   })
-
-  it('étant donné une gouvernance inexistante, quand un comité est créé, alors une erreur est renvoyée', async () => {
-    // GIVEN
-    const ajouterUnComite = new AjouterUnComite(
-      new GouvernanceInexistanteRepositorySpy(),
-      new GestionnaireRepositorySpy(),
-      new ComiteRepositorySpy(),
-      epochTime
-    )
-
-    // WHEN
-    const result = await ajouterUnComite.execute({
-      commentaire,
-      date,
-      frequence: frequenceValide,
-      type: typeValide,
-      uidEditeur,
-      uidGouvernance,
-    })
-
-    // THEN
-    expect(spiedUtilisateurUidToFind).toBe(uidEditeur)
-    expect(spiedGouvernanceUidToFind?.state).toStrictEqual(new GouvernanceUid(uidGouvernance).state)
-    expect(result).toBe('gouvernanceInexistante')
-    expect(spiedComiteToAdd).toBeNull()
-  })
-
-  it('étant donné un utilisateur inexistant, quand un comité est créé, alors une erreur est renvoyée', async () => {
-    // GIVEN
-    const ajouterUnComite = new AjouterUnComite(
-      new GouvernanceRepositorySpy(),
-      new GestionnaireInexistantRepositorySpy(),
-      new ComiteRepositorySpy(),
-      epochTime
-    )
-
-    // WHEN
-    const result = await ajouterUnComite.execute({
-      commentaire,
-      date,
-      frequence: frequenceValide,
-      type: typeValide,
-      uidEditeur,
-      uidGouvernance,
-    })
-
-    // THEN
-    expect(spiedUtilisateurUidToFind).toBe(uidEditeur)
-    expect(spiedGouvernanceUidToFind).toBeNull()
-    expect(result).toBe('editeurInexistant')
-    expect(spiedComiteToAdd).toBeNull()
-  })
 })
 
 const commentaire = 'un commentaire'
@@ -240,7 +188,7 @@ let spiedUtilisateurUidToFind: string | null
 let spiedComiteToAdd: Comite | null
 
 class GouvernanceRepositorySpy implements FindGouvernanceRepository {
-  async find(uid: GouvernanceUid): Promise<Gouvernance | null> {
+  async find(uid: GouvernanceUid): Promise<Gouvernance> {
     spiedGouvernanceUidToFind = uid
     return Promise.resolve(
       gouvernanceFactory({
@@ -256,29 +204,15 @@ class GouvernanceRepositorySpy implements FindGouvernanceRepository {
   }
 }
 
-class GouvernanceInexistanteRepositorySpy extends GouvernanceRepositorySpy {
-  override async find(uid: GouvernanceUid): Promise<Gouvernance | null> {
-    spiedGouvernanceUidToFind = uid
-    return Promise.resolve(null)
-  }
-}
-
 class GestionnaireRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur | null> {
+  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUtilisateurUidToFind = uid
     return Promise.resolve(utilisateurFactory({ codeOrganisation: '75', role: 'Gestionnaire département' }))
   }
 }
 
-class GestionnaireInexistantRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur | null> {
-    spiedUtilisateurUidToFind = uid
-    return Promise.resolve(null)
-  }
-}
-
 class GestionnaireAutreRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur | null> {
+  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUtilisateurUidToFind = uid
     return Promise.resolve(utilisateurFactory({ codeOrganisation: '10', role: 'Gestionnaire département' }))
   }

--- a/src/use-cases/commands/AjouterUnComite.test.ts
+++ b/src/use-cases/commands/AjouterUnComite.test.ts
@@ -1,7 +1,7 @@
 import { AjouterUnComite } from './AjouterUnComite'
 import { AddComiteRepository } from './shared/ComiteRepository'
-import { FindGouvernanceRepository } from './shared/GouvernanceRepository'
-import { FindUtilisateurRepository } from './shared/UtilisateurRepository'
+import { GetGouvernanceRepository } from './shared/GouvernanceRepository'
+import { GetUtilisateurRepository } from './shared/UtilisateurRepository'
 import { Comite } from '@/domain/Comite'
 import { Gouvernance, GouvernanceUid } from '@/domain/Gouvernance'
 import { comiteFactory, gouvernanceFactory, utilisateurFactory } from '@/domain/testHelper'
@@ -49,7 +49,7 @@ describe('ajouter un comité à une gouvernance', () => {
     )
 
     // WHEN
-    const result = await ajouterUnComite.execute({
+    const result = await ajouterUnComite.handle({
       commentaire,
       date,
       frequence,
@@ -135,7 +135,7 @@ describe('ajouter un comité à une gouvernance', () => {
     )
 
     // WHEN
-    const result = await ajouterUnComite.execute({
+    const result = await ajouterUnComite.handle({
       date,
       frequence,
       type,
@@ -160,7 +160,7 @@ describe('ajouter un comité à une gouvernance', () => {
     )
 
     // WHEN
-    const result = await ajouterUnComite.execute({
+    const result = await ajouterUnComite.handle({
       commentaire,
       date,
       frequence: frequenceValide,
@@ -187,8 +187,8 @@ let spiedGouvernanceUidToFind: GouvernanceUid | null
 let spiedUtilisateurUidToFind: string | null
 let spiedComiteToAdd: Comite | null
 
-class GouvernanceRepositorySpy implements FindGouvernanceRepository {
-  async find(uid: GouvernanceUid): Promise<Gouvernance> {
+class GouvernanceRepositorySpy implements GetGouvernanceRepository {
+  async get(uid: GouvernanceUid): Promise<Gouvernance> {
     spiedGouvernanceUidToFind = uid
     return Promise.resolve(
       gouvernanceFactory({
@@ -204,15 +204,15 @@ class GouvernanceRepositorySpy implements FindGouvernanceRepository {
   }
 }
 
-class GestionnaireRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
+class GestionnaireRepositorySpy implements GetUtilisateurRepository {
+  async get(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUtilisateurUidToFind = uid
     return Promise.resolve(utilisateurFactory({ codeOrganisation: '75', role: 'Gestionnaire département' }))
   }
 }
 
-class GestionnaireAutreRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
+class GestionnaireAutreRepositorySpy implements GetUtilisateurRepository {
+  async get(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUtilisateurUidToFind = uid
     return Promise.resolve(utilisateurFactory({ codeOrganisation: '10', role: 'Gestionnaire département' }))
   }

--- a/src/use-cases/commands/AjouterUnComite.ts
+++ b/src/use-cases/commands/AjouterUnComite.ts
@@ -25,15 +25,7 @@ export class AjouterUnComite implements CommandHandler<Command> {
 
   async execute(command: Command): ResultAsync<Failure> {
     const editeur = await this.#utilisateurRepository.find(command.uidEditeur)
-    if (!editeur) {
-      return 'editeurInexistant'
-    }
-
     const gouvernance = await this.#gouvernanceRepository.find(new GouvernanceUid(command.uidGouvernance))
-    if (!gouvernance) {
-      return 'gouvernanceInexistante'
-    }
-
     const dateDeCreation = this.#date
     const comite = Comite.create({
       commentaire: command.commentaire,
@@ -62,7 +54,7 @@ export class AjouterUnComite implements CommandHandler<Command> {
   }
 }
 
-type Failure = 'gouvernanceInexistante' | 'editeurInexistant' | 'editeurNePeutPasAjouterComite' | ComiteFailure
+type Failure = 'editeurNePeutPasAjouterComite' | ComiteFailure
 
 type Command = Readonly<{
   commentaire?: string

--- a/src/use-cases/commands/AjouterUnComite.ts
+++ b/src/use-cases/commands/AjouterUnComite.ts
@@ -1,7 +1,7 @@
 import { CommandHandler, ResultAsync } from '../CommandHandler'
 import { AddComiteRepository } from './shared/ComiteRepository'
-import { FindGouvernanceRepository } from './shared/GouvernanceRepository'
-import { FindUtilisateurRepository } from './shared/UtilisateurRepository'
+import { GetGouvernanceRepository } from './shared/GouvernanceRepository'
+import { GetUtilisateurRepository } from './shared/UtilisateurRepository'
 import { Comite, ComiteFailure } from '@/domain/Comite'
 import { GouvernanceUid } from '@/domain/Gouvernance'
 
@@ -23,9 +23,9 @@ export class AjouterUnComite implements CommandHandler<Command> {
     this.#date = date
   }
 
-  async execute(command: Command): ResultAsync<Failure> {
-    const editeur = await this.#utilisateurRepository.find(command.uidEditeur)
-    const gouvernance = await this.#gouvernanceRepository.find(new GouvernanceUid(command.uidGouvernance))
+  async handle(command: Command): ResultAsync<Failure> {
+    const editeur = await this.#utilisateurRepository.get(command.uidEditeur)
+    const gouvernance = await this.#gouvernanceRepository.get(new GouvernanceUid(command.uidGouvernance))
     const dateDeCreation = this.#date
     const comite = Comite.create({
       commentaire: command.commentaire,
@@ -65,8 +65,8 @@ type Command = Readonly<{
   uidGouvernance: string
 }>
 
-type GouvernanceRepository = FindGouvernanceRepository
+type GouvernanceRepository = GetGouvernanceRepository
 
-type UtilisateurRepository = FindUtilisateurRepository
+type UtilisateurRepository = GetUtilisateurRepository
 
 type ComiteRepository = AddComiteRepository

--- a/src/use-cases/commands/AjouterUneNotePrivee.test.ts
+++ b/src/use-cases/commands/AjouterUneNotePrivee.test.ts
@@ -1,6 +1,6 @@
 import { AjouterUneNotePrivee } from './AjouterUneNotePrivee'
-import { FindGouvernanceRepository, UpdateGouvernanceRepository } from './shared/GouvernanceRepository'
-import { FindUtilisateurRepository } from './shared/UtilisateurRepository'
+import { GetGouvernanceRepository, UpdateGouvernanceRepository } from './shared/GouvernanceRepository'
+import { GetUtilisateurRepository } from './shared/UtilisateurRepository'
 import { Gouvernance, GouvernanceUid } from '@/domain/Gouvernance'
 import { gouvernanceFactory, utilisateurFactory } from '@/domain/testHelper'
 import { Utilisateur, UtilisateurUid, UtilisateurUidState } from '@/domain/Utilisateur'
@@ -22,7 +22,7 @@ describe('ajouter une note privée à une gouvernance', () => {
     )
 
     // WHEN
-    const result = await ajouterNotePrivee.execute({
+    const result = await ajouterNotePrivee.handle({
       contenu,
       uidEditeur,
       uidGouvernance,
@@ -55,7 +55,7 @@ describe('ajouter une note privée à une gouvernance', () => {
     )
 
     // WHEN
-    const result = await ajouterNotePrivee.execute({ contenu, uidEditeur: 'utilisateurUsurpateur', uidGouvernance })
+    const result = await ajouterNotePrivee.handle({ contenu, uidEditeur: 'utilisateurUsurpateur', uidGouvernance })
 
     // THEN
     expect(spiedUtilisateurUidToFind).toBe('utilisateurUsurpateur')
@@ -73,7 +73,7 @@ describe('ajouter une note privée à une gouvernance', () => {
     )
 
     // WHEN
-    const result = await ajouterNotePrivee.execute({ contenu, uidEditeur, uidGouvernance })
+    const result = await ajouterNotePrivee.handle({ contenu, uidEditeur, uidGouvernance })
 
     // THEN
     expect(spiedUtilisateurUidToFind).toBe(uidEditeur)
@@ -90,8 +90,8 @@ let spiedGouvernanceUidToFind: GouvernanceUid | null
 let spiedGouvernanceToUpdate: Gouvernance | null
 let spiedUtilisateurUidToFind: string | null
 
-class GouvernanceRepositorySpy implements FindGouvernanceRepository, UpdateGouvernanceRepository {
-  async find(uid: GouvernanceUid): Promise<Gouvernance> {
+class GouvernanceRepositorySpy implements GetGouvernanceRepository, UpdateGouvernanceRepository {
+  async get(uid: GouvernanceUid): Promise<Gouvernance> {
     spiedGouvernanceUidToFind = uid
     return Promise.resolve(
       gouvernanceFactory({
@@ -113,7 +113,7 @@ class GouvernanceRepositorySpy implements FindGouvernanceRepository, UpdateGouve
 }
 
 class GouvernanceAvecNotePriveeRepositorySpy extends GouvernanceRepositorySpy {
-  override async find(uid: GouvernanceUid): Promise<Gouvernance> {
+  override async get(uid: GouvernanceUid): Promise<Gouvernance> {
     spiedGouvernanceUidToFind = uid
     return Promise.resolve(
       gouvernanceFactory({
@@ -129,15 +129,15 @@ class GouvernanceAvecNotePriveeRepositorySpy extends GouvernanceRepositorySpy {
   }
 }
 
-class GestionnaireRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
+class GestionnaireRepositorySpy implements GetUtilisateurRepository {
+  async get(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUtilisateurUidToFind = uid
     return Promise.resolve(utilisateurFactory({ codeOrganisation: '75', role: 'Gestionnaire département' }))
   }
 }
 
-class GestionnaireAutreRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
+class GestionnaireAutreRepositorySpy implements GetUtilisateurRepository {
+  async get(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUtilisateurUidToFind = uid
     return Promise.resolve(utilisateurFactory({ codeOrganisation: '10', role: 'Gestionnaire département' }))
   }

--- a/src/use-cases/commands/AjouterUneNotePrivee.test.ts
+++ b/src/use-cases/commands/AjouterUneNotePrivee.test.ts
@@ -13,7 +13,7 @@ describe('ajouter une note privée à une gouvernance', () => {
     spiedUtilisateurUidToFind = null
   })
 
-  it('étant donné une gouvernance existante, quand une note privée est créée par son gestionnaire, alors elle est ajoutée à cette gourvernance', async () => {
+  it('étant donné une gouvernance, quand une note privée est créée par son gestionnaire, alors elle est ajoutée à cette gourvernance', async () => {
     // GIVEN
     const ajouterNotePrivee = new AjouterUneNotePrivee(
       new GouvernanceRepositorySpy(),
@@ -46,7 +46,7 @@ describe('ajouter une note privée à une gouvernance', () => {
     expect(result).toBe('OK')
   })
 
-  it('étant donné une gouvernance existante, quand un note privée est créée par un gestionnaire qui n’a pas ce droit, alors une erreur est renvoyée', async () => {
+  it('étant donné une gouvernance, quand un note privée est créée par un gestionnaire qui n’a pas ce droit, alors une erreur est renvoyée', async () => {
     // GIVEN
     const ajouterNotePrivee = new AjouterUneNotePrivee(
       new GouvernanceRepositorySpy(),
@@ -64,7 +64,7 @@ describe('ajouter une note privée à une gouvernance', () => {
     expect(result).toBe('utilisateurNePeutPasAjouterNotePrivee')
   })
 
-  it('étant donné une gouvernance existante, quand un note privée est créée par un gestionnaire département mais qu’une note privée existe déjà, alors une erreur est renvoyée', async () => {
+  it('étant donné une gouvernance, quand un note privée est créée par un gestionnaire département mais qu’une note privée existe déjà, alors une erreur est renvoyée', async () => {
     // GIVEN
     const ajouterNotePrivee = new AjouterUneNotePrivee(
       new GouvernanceAvecNotePriveeRepositorySpy(),
@@ -81,50 +81,6 @@ describe('ajouter une note privée à une gouvernance', () => {
     expect(spiedGouvernanceToUpdate).toBeNull()
     expect(result).toBe('notePriveeDejaExistante')
   })
-
-  it('étant donné une gouvernance inexistante, quand une note privée est créée, alors une erreur est renvoyée', async () => {
-    // GIVEN
-    const ajouterNotePrivee = new AjouterUneNotePrivee(
-      new GouvernanceInexistanteRepositorySpy(),
-      new GestionnaireRepositorySpy(),
-      epochTime
-    )
-
-    // WHEN
-    const result = await ajouterNotePrivee.execute({
-      contenu,
-      uidEditeur,
-      uidGouvernance,
-    })
-
-    // THEN
-    expect(spiedUtilisateurUidToFind).toBe(uidEditeur)
-    expect(spiedGouvernanceUidToFind?.state).toStrictEqual(new GouvernanceUid(uidGouvernance).state)
-    expect(spiedGouvernanceToUpdate).toBeNull()
-    expect(result).toBe('gouvernanceInexistante')
-  })
-
-  it('étant donné un utilisateur inexistant, quand une note privée est créée, alors une erreur est renvoyée', async () => {
-    // GIVEN
-    const ajouterNotePrivee = new AjouterUneNotePrivee(
-      new GouvernanceInexistanteRepositorySpy(),
-      new GestionnaireInexistantRepositorySpy(),
-      epochTime
-    )
-
-    // WHEN
-    const result = await ajouterNotePrivee.execute({
-      contenu,
-      uidEditeur,
-      uidGouvernance,
-    })
-
-    // THEN
-    expect(spiedUtilisateurUidToFind).toBe(uidEditeur)
-    expect(spiedGouvernanceUidToFind).toBeNull()
-    expect(spiedGouvernanceToUpdate).toBeNull()
-    expect(result).toBe('editeurInexistant')
-  })
 })
 
 const contenu = 'Lorem ipsum dolor sit amet consectetur. Sagittis dui sapien libero tristique leo tortor.'
@@ -135,7 +91,7 @@ let spiedGouvernanceToUpdate: Gouvernance | null
 let spiedUtilisateurUidToFind: string | null
 
 class GouvernanceRepositorySpy implements FindGouvernanceRepository, UpdateGouvernanceRepository {
-  async find(uid: GouvernanceUid): Promise<Gouvernance | null> {
+  async find(uid: GouvernanceUid): Promise<Gouvernance> {
     spiedGouvernanceUidToFind = uid
     return Promise.resolve(
       gouvernanceFactory({
@@ -156,15 +112,8 @@ class GouvernanceRepositorySpy implements FindGouvernanceRepository, UpdateGouve
   }
 }
 
-class GouvernanceInexistanteRepositorySpy extends GouvernanceRepositorySpy {
-  override async find(uid: GouvernanceUid): Promise<Gouvernance | null> {
-    spiedGouvernanceUidToFind = uid
-    return Promise.resolve(null)
-  }
-}
-
 class GouvernanceAvecNotePriveeRepositorySpy extends GouvernanceRepositorySpy {
-  override async find(uid: GouvernanceUid): Promise<Gouvernance | null> {
+  override async find(uid: GouvernanceUid): Promise<Gouvernance> {
     spiedGouvernanceUidToFind = uid
     return Promise.resolve(
       gouvernanceFactory({
@@ -181,21 +130,14 @@ class GouvernanceAvecNotePriveeRepositorySpy extends GouvernanceRepositorySpy {
 }
 
 class GestionnaireRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur | null> {
+  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUtilisateurUidToFind = uid
     return Promise.resolve(utilisateurFactory({ codeOrganisation: '75', role: 'Gestionnaire département' }))
   }
 }
 
-class GestionnaireInexistantRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur | null> {
-    spiedUtilisateurUidToFind = uid
-    return Promise.resolve(null)
-  }
-}
-
 class GestionnaireAutreRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur | null> {
+  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUtilisateurUidToFind = uid
     return Promise.resolve(utilisateurFactory({ codeOrganisation: '10', role: 'Gestionnaire département' }))
   }

--- a/src/use-cases/commands/AjouterUneNotePrivee.ts
+++ b/src/use-cases/commands/AjouterUneNotePrivee.ts
@@ -1,6 +1,6 @@
 import { CommandHandler, ResultAsync } from '../CommandHandler'
-import { FindGouvernanceRepository, UpdateGouvernanceRepository } from './shared/GouvernanceRepository'
-import { FindUtilisateurRepository } from './shared/UtilisateurRepository'
+import { GetGouvernanceRepository, UpdateGouvernanceRepository } from './shared/GouvernanceRepository'
+import { GetUtilisateurRepository } from './shared/UtilisateurRepository'
 import { GouvernanceFailure, GouvernanceUid, NotePrivee } from '@/domain/Gouvernance'
 import { UtilisateurUid } from '@/domain/Utilisateur'
 import { isOk } from '@/shared/lang'
@@ -20,9 +20,9 @@ export class AjouterUneNotePrivee implements CommandHandler<Command> {
     this.#date = date
   }
 
-  async execute(command: Command): ResultAsync<Failure> {
-    const editeur = await this.#utilisateurRepository.find(command.uidEditeur)
-    const gouvernance = await this.#gouvernanceRepository.find(new GouvernanceUid(command.uidGouvernance))
+  async handle(command: Command): ResultAsync<Failure> {
+    const editeur = await this.#utilisateurRepository.get(command.uidEditeur)
+    const gouvernance = await this.#gouvernanceRepository.get(new GouvernanceUid(command.uidGouvernance))
     if (!gouvernance.laNotePriveePeutEtreGerePar(editeur)) {
       return 'utilisateurNePeutPasAjouterNotePrivee'
     }
@@ -46,6 +46,6 @@ type Command = Readonly<{
   uidGouvernance: string
 }>
 
-interface GouvernanceRepository extends FindGouvernanceRepository, UpdateGouvernanceRepository {}
+interface GouvernanceRepository extends GetGouvernanceRepository, UpdateGouvernanceRepository {}
 
-type UtilisateurRepository = FindUtilisateurRepository
+type UtilisateurRepository = GetUtilisateurRepository

--- a/src/use-cases/commands/AjouterUneNotePrivee.ts
+++ b/src/use-cases/commands/AjouterUneNotePrivee.ts
@@ -22,15 +22,7 @@ export class AjouterUneNotePrivee implements CommandHandler<Command> {
 
   async execute(command: Command): ResultAsync<Failure> {
     const editeur = await this.#utilisateurRepository.find(command.uidEditeur)
-    if (!editeur) {
-      return 'editeurInexistant'
-    }
-
     const gouvernance = await this.#gouvernanceRepository.find(new GouvernanceUid(command.uidGouvernance))
-    if (!gouvernance) {
-      return 'gouvernanceInexistante'
-    }
-
     if (!gouvernance.laNotePriveePeutEtreGerePar(editeur)) {
       return 'utilisateurNePeutPasAjouterNotePrivee'
     }
@@ -46,7 +38,7 @@ export class AjouterUneNotePrivee implements CommandHandler<Command> {
   }
 }
 
-type Failure = 'gouvernanceInexistante' | 'editeurInexistant' | 'utilisateurNePeutPasAjouterNotePrivee' | GouvernanceFailure
+type Failure = 'utilisateurNePeutPasAjouterNotePrivee' | GouvernanceFailure
 
 type Command = Readonly<{
   contenu: string

--- a/src/use-cases/commands/ChangerMonRole.test.ts
+++ b/src/use-cases/commands/ChangerMonRole.test.ts
@@ -1,5 +1,5 @@
 import { ChangerMonRole } from './ChangerMonRole'
-import { FindUtilisateurRepository, UpdateUtilisateurRepository } from './shared/UtilisateurRepository'
+import { GetUtilisateurRepository, UpdateUtilisateurRepository } from './shared/UtilisateurRepository'
 import { utilisateurFactory } from '@/domain/testHelper'
 import { Utilisateur, UtilisateurUidState } from '@/domain/Utilisateur'
 
@@ -14,7 +14,7 @@ describe('changer mon rôle', () => {
     const changerMonRole = new ChangerMonRole(utilisateurRepository)
 
     // WHEN
-    const result = await changerMonRole.execute({
+    const result = await changerMonRole.handle({
       nouveauRole,
       uidUtilisateurCourant: 'utilisateurSuperAdminUid',
     })
@@ -34,7 +34,7 @@ describe('changer mon rôle', () => {
     const changerMonRole = new ChangerMonRole(utilisateurRepository)
 
     // WHEN
-    const result = await changerMonRole.execute({
+    const result = await changerMonRole.handle({
       nouveauRole,
       uidUtilisateurCourant: 'utilisateurNonSuperAdminUid',
     })
@@ -60,8 +60,8 @@ const utilisateurByUid: Readonly<Record<string, Utilisateur>> = {
   }),
 }
 
-const utilisateurRepository = new class implements FindUtilisateurRepository, UpdateUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
+const utilisateurRepository = new class implements GetUtilisateurRepository, UpdateUtilisateurRepository {
+  async get(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     return Promise.resolve(utilisateurByUid[uid])
   }
 

--- a/src/use-cases/commands/ChangerMonRole.test.ts
+++ b/src/use-cases/commands/ChangerMonRole.test.ts
@@ -43,22 +43,6 @@ describe('changer mon rôle', () => {
     expect(result).toBe('utilisateurNonAutoriseAChangerSonRole')
     expect(spiedUtilisateur).toStrictEqual(nullUtilisateur)
   })
-
-  it('mon compte est introuvable : pas de modification possible', async () => {
-    // GIVEN
-    const nouveauRole = 'Pilote politique publique'
-    const changerMonRole = new ChangerMonRole(utilisateurRepository)
-
-    // WHEN
-    const result = await changerMonRole.execute({
-      nouveauRole,
-      uidUtilisateurCourant: 'utilisateurIntrouvableUid',
-    })
-
-    // THEN
-    expect(result).toBe('utilisateurCourantInexistant')
-    expect(spiedUtilisateur).toStrictEqual(nullUtilisateur)
-  })
 })
 
 const nullUtilisateur = {} as Utilisateur
@@ -77,8 +61,8 @@ const utilisateurByUid: Readonly<Record<string, Utilisateur>> = {
 }
 
 const utilisateurRepository = new class implements FindUtilisateurRepository, UpdateUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur | null> {
-    return Promise.resolve(utilisateurByUid[uid] ?? null)
+  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
+    return Promise.resolve(utilisateurByUid[uid])
   }
 
   async update(utilisateur: Utilisateur): Promise<void> {

--- a/src/use-cases/commands/ChangerMonRole.ts
+++ b/src/use-cases/commands/ChangerMonRole.ts
@@ -1,5 +1,5 @@
 import { CommandHandler, ResultAsync } from '../CommandHandler'
-import { FindUtilisateurRepository, UpdateUtilisateurRepository } from './shared/UtilisateurRepository'
+import { GetUtilisateurRepository, UpdateUtilisateurRepository } from './shared/UtilisateurRepository'
 import { TypologieRole } from '@/domain/Role'
 import { UtilisateurFailure } from '@/domain/Utilisateur'
 import { isOk } from '@/shared/lang'
@@ -11,8 +11,8 @@ export class ChangerMonRole implements CommandHandler<Command> {
     this.#utilisateurRepository = utilisateurRepository
   }
 
-  async execute(command: Command): ResultAsync<Failure> {
-    const utilisateurCourant = await this.#utilisateurRepository.find(command.uidUtilisateurCourant)
+  async handle(command: Command): ResultAsync<Failure> {
+    const utilisateurCourant = await this.#utilisateurRepository.get(command.uidUtilisateurCourant)
     const result = utilisateurCourant.changerRole(command.nouveauRole)
     if (isOk(result)) {
       await this.#utilisateurRepository.update(utilisateurCourant)
@@ -29,4 +29,4 @@ type Command = Readonly<{
   uidUtilisateurCourant: string
 }>
 
-interface UtilisateurRepository extends FindUtilisateurRepository, UpdateUtilisateurRepository {}
+interface UtilisateurRepository extends GetUtilisateurRepository, UpdateUtilisateurRepository {}

--- a/src/use-cases/commands/ChangerMonRole.ts
+++ b/src/use-cases/commands/ChangerMonRole.ts
@@ -13,10 +13,6 @@ export class ChangerMonRole implements CommandHandler<Command> {
 
   async execute(command: Command): ResultAsync<Failure> {
     const utilisateurCourant = await this.#utilisateurRepository.find(command.uidUtilisateurCourant)
-    if (!utilisateurCourant) {
-      return 'utilisateurCourantInexistant'
-    }
-
     const result = utilisateurCourant.changerRole(command.nouveauRole)
     if (isOk(result)) {
       await this.#utilisateurRepository.update(utilisateurCourant)
@@ -26,7 +22,7 @@ export class ChangerMonRole implements CommandHandler<Command> {
   }
 }
 
-type Failure = UtilisateurFailure | 'utilisateurCourantInexistant'
+type Failure = UtilisateurFailure
 
 type Command = Readonly<{
   nouveauRole: TypologieRole

--- a/src/use-cases/commands/CorrigerNomPrenomSiAbsents.test.ts
+++ b/src/use-cases/commands/CorrigerNomPrenomSiAbsents.test.ts
@@ -1,6 +1,6 @@
 import { CorrigerNomPrenomSiAbsents } from './CorrigerNomPrenomSiAbsents'
 import {
-  FindUtilisateurRepository,
+  GetUtilisateurRepository,
   UpdateUtilisateurRepository,
 } from './shared/UtilisateurRepository'
 import { utilisateurFactory } from '@/domain/testHelper'
@@ -21,7 +21,7 @@ describe('corriger nom prenom si absents', () => {
     const utilisateurRepository = new UtilisateurRepositorySpy()
 
     // WHEN
-    const result = await new CorrigerNomPrenomSiAbsents(utilisateurRepository).execute({
+    const result = await new CorrigerNomPrenomSiAbsents(utilisateurRepository).handle({
       actuels: {
         nom,
         prenom,
@@ -70,7 +70,7 @@ describe('corriger nom prenom si absents', () => {
       const utilisateurRepository = new UtilisateurRepositorySpy()
 
       // WHEN
-      const result = await new CorrigerNomPrenomSiAbsents(utilisateurRepository).execute({
+      const result = await new CorrigerNomPrenomSiAbsents(utilisateurRepository).handle({
         actuels: {
           nom,
           prenom,
@@ -133,7 +133,7 @@ describe('corriger nom prenom si absents', () => {
       const utilisateurRepository = new UtilisateurRepositorySpy()
 
       // WHEN
-      const result = await new CorrigerNomPrenomSiAbsents(utilisateurRepository).execute({
+      const result = await new CorrigerNomPrenomSiAbsents(utilisateurRepository).handle({
         actuels: {
           nom,
           prenom,
@@ -159,8 +159,8 @@ describe('corriger nom prenom si absents', () => {
 let spiedUidToFind: string | null
 let spiedUtilisateurToUpdate: Utilisateur | null
 
-class UtilisateurRepositorySpy implements FindUtilisateurRepository, UpdateUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
+class UtilisateurRepositorySpy implements GetUtilisateurRepository, UpdateUtilisateurRepository {
+  async get(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUidToFind = uid
     return Promise.resolve(utilisateurFactory({ nom: 'Tartempion', prenom: 'Michel' }))
   }

--- a/src/use-cases/commands/CorrigerNomPrenomSiAbsents.test.ts
+++ b/src/use-cases/commands/CorrigerNomPrenomSiAbsents.test.ts
@@ -41,50 +41,6 @@ describe('corriger nom prenom si absents', () => {
 
   it.each([
     {
-      desc: 'le nom est absent',
-      nomAvantCorrection: valeurNomOuPrenomAbsent,
-      prenomAvantCorrection: 'Michel',
-    },
-    {
-      desc: 'le prénom est absent',
-      nomAvantCorrection: 'Tartempion',
-      prenomAvantCorrection: valeurNomOuPrenomAbsent,
-    },
-    {
-      desc: 'le prénom et le nom sont absents',
-      nomAvantCorrection: valeurNomOuPrenomAbsent,
-      prenomAvantCorrection: valeurNomOuPrenomAbsent,
-    },
-  ])(
-    '$desc, mais l’utilisateur est introuvable : la notification de compte inexistant est émise et aucune mise à jour n’est effectuée',
-    async ({ nomAvantCorrection, prenomAvantCorrection }) => {
-      // GIVEN
-      const nom = nomAvantCorrection
-      const prenom = prenomAvantCorrection
-      const utilisateurRepository = new UtilisateurRepositoryUtilisateurIntrouvableSpy()
-
-      // WHEN
-      const result = await new CorrigerNomPrenomSiAbsents(utilisateurRepository).execute({
-        actuels: {
-          nom,
-          prenom,
-        },
-        corriges: {
-          nom: 'Dugenoux',
-          prenom: 'Micheline',
-        },
-        uidUtilisateurCourant: 'fooId',
-      })
-
-      // THEN
-      expect(result).toBe('utilisateurCourantInexistant')
-      expect(spiedUidToFind).toBe('fooId')
-      expect(spiedUtilisateurToUpdate).toBeNull()
-    }
-  )
-
-  it.each([
-    {
       correctionNom: valeurNomOuPrenomAbsent,
       correctionPrenom: 'Micheline',
       desc: 'le nom est absent',
@@ -207,19 +163,6 @@ class UtilisateurRepositorySpy implements FindUtilisateurRepository, UpdateUtili
   async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUidToFind = uid
     return Promise.resolve(utilisateurFactory({ nom: 'Tartempion', prenom: 'Michel' }))
-  }
-
-  async update(utilisateur: Utilisateur): Promise<void> {
-    spiedUtilisateurToUpdate = utilisateur
-    return Promise.resolve()
-  }
-}
-
-class UtilisateurRepositoryUtilisateurIntrouvableSpy
-implements FindUtilisateurRepository, UpdateUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<null> {
-    spiedUidToFind = uid
-    return Promise.resolve(null)
   }
 
   async update(utilisateur: Utilisateur): Promise<void> {

--- a/src/use-cases/commands/CorrigerNomPrenomSiAbsents.ts
+++ b/src/use-cases/commands/CorrigerNomPrenomSiAbsents.ts
@@ -20,10 +20,6 @@ export class CorrigerNomPrenomSiAbsents implements CommandHandler<Command, Failu
     }
 
     const utilisateurCourant = await this.#utilisateurRepository.find(uidUtilisateurCourant)
-    if (!utilisateurCourant) {
-      return Promise.resolve('utilisateurCourantInexistant')
-    }
-
     if (isPrenomAbsent) {
       if (this.#valeurNomOuPrenomAbsent === corriges.prenom) {
         return 'miseAJourInvalide'
@@ -54,7 +50,7 @@ type Command = Readonly<{
   uidUtilisateurCourant: string
 }>
 
-type Failure = 'utilisateurCourantInexistant' | 'miseAJourInvalide'
+type Failure = 'miseAJourInvalide'
 
 type Success = 'okAvecMiseAJour' | 'okSansMiseAJour'
 

--- a/src/use-cases/commands/CorrigerNomPrenomSiAbsents.ts
+++ b/src/use-cases/commands/CorrigerNomPrenomSiAbsents.ts
@@ -1,5 +1,5 @@
 import { CommandHandler, ResultAsync } from '../CommandHandler'
-import { FindUtilisateurRepository, UpdateUtilisateurRepository } from './shared/UtilisateurRepository'
+import { GetUtilisateurRepository, UpdateUtilisateurRepository } from './shared/UtilisateurRepository'
 import config from '@/use-cases/config.json'
 
 export class CorrigerNomPrenomSiAbsents implements CommandHandler<Command, Failure, Success> {
@@ -11,7 +11,7 @@ export class CorrigerNomPrenomSiAbsents implements CommandHandler<Command, Failu
     this.#valeurNomOuPrenomAbsent = config.absenceNomOuPrenom
   }
 
-  async execute(command: Command): ResultAsync<Failure, Success> {
+  async handle(command: Command): ResultAsync<Failure, Success> {
     const { actuels, corriges, uidUtilisateurCourant } = command
     const isPrenomAbsent = this.#valeurNomOuPrenomAbsent === actuels.prenom
     const isNomAbsent = this.#valeurNomOuPrenomAbsent === actuels.nom
@@ -19,7 +19,7 @@ export class CorrigerNomPrenomSiAbsents implements CommandHandler<Command, Failu
       return 'okSansMiseAJour'
     }
 
-    const utilisateurCourant = await this.#utilisateurRepository.find(uidUtilisateurCourant)
+    const utilisateurCourant = await this.#utilisateurRepository.get(uidUtilisateurCourant)
     if (isPrenomAbsent) {
       if (this.#valeurNomOuPrenomAbsent === corriges.prenom) {
         return 'miseAJourInvalide'
@@ -54,4 +54,4 @@ type Failure = 'miseAJourInvalide'
 
 type Success = 'okAvecMiseAJour' | 'okSansMiseAJour'
 
-interface UtilisateurRepository extends FindUtilisateurRepository, UpdateUtilisateurRepository {}
+interface UtilisateurRepository extends GetUtilisateurRepository, UpdateUtilisateurRepository {}

--- a/src/use-cases/commands/InviterUnUtilisateur.test.ts
+++ b/src/use-cases/commands/InviterUnUtilisateur.test.ts
@@ -181,30 +181,6 @@ describe('inviter un utilisateur', () => {
     expect(spiedIsSuperAdmin).toBeNull()
   })
 
-  it('étant donné que le compte de l’utilisateur courant n’existe plus, quand il invite un autre utilisateur, alors il y a une erreur', async () => {
-    // GIVEN
-    const repository = new RepositorySpy(null)
-    const emailGatewayFactory = emailGatewayFactorySpy
-    const inviterUnUtilisateur = new InviterUnUtilisateur(repository, emailGatewayFactory, epochTime)
-    const roleUtilisateurAInviter: TypologieRole = 'Instructeur'
-
-    // WHEN
-    const result = await inviterUnUtilisateur.execute({
-      email: 'martin.tartempion@example.net',
-      nom: 'Tartempion',
-      prenom: 'Martin',
-      role: { type: roleUtilisateurAInviter },
-      uidUtilisateurCourant: 'utilisateurInexistantUid',
-    })
-
-    // THEN
-    expect(result).toBe('utilisateurCourantInexistant')
-    expect(spiedUidToFind).toBe('utilisateurInexistantUid')
-    expect(spiedUtilisateurToAdd).toBeNull()
-    expect(spiedDestinataire).toBe('')
-    expect(spiedIsSuperAdmin).toBeNull()
-  })
-
   it('étant donné que l’utilisateur à inviter existe déjà, quand l’utilisateur courant l’invite, alors il y a une erreur', async () => {
     // GIVEN
     const date = epochTime
@@ -243,13 +219,13 @@ let spiedDestinataire: string
 let spiedIsSuperAdmin: boolean | null
 
 class RepositorySpy implements AddUtilisateurRepository, FindUtilisateurRepository {
-  readonly #utilisateurCourant: Utilisateur | null
+  readonly #utilisateurCourant: Utilisateur
 
-  constructor(utilisateurCourant: Utilisateur | null) {
+  constructor(utilisateurCourant: Utilisateur) {
     this.#utilisateurCourant = utilisateurCourant
   }
 
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur | null> {
+  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUidToFind = uid
     return Promise.resolve(this.#utilisateurCourant)
   }

--- a/src/use-cases/commands/InviterUnUtilisateur.test.ts
+++ b/src/use-cases/commands/InviterUnUtilisateur.test.ts
@@ -1,6 +1,6 @@
 import { InviterUnUtilisateur } from './InviterUnUtilisateur'
 import { EmailGateway } from './shared/EmailGateway'
-import { AddUtilisateurRepository, FindUtilisateurRepository } from './shared/UtilisateurRepository'
+import { AddUtilisateurRepository, GetUtilisateurRepository } from './shared/UtilisateurRepository'
 import { TypologieRole } from '@/domain/Role'
 import { utilisateurFactory } from '@/domain/testHelper'
 import { Utilisateur, UtilisateurUidState } from '@/domain/Utilisateur'
@@ -124,7 +124,7 @@ describe('inviter un utilisateur', () => {
         )
 
         // WHEN
-        const result = await inviterUnUtilisateur.execute({
+        const result = await inviterUnUtilisateur.handle({
           email: 'martine.dugenoux@example.com',
           nom: 'Dugenoux',
           prenom: 'Martine',
@@ -165,7 +165,7 @@ describe('inviter un utilisateur', () => {
     const roleUtilisateurAInviter: TypologieRole = 'Instructeur'
 
     // WHEN
-    const result = await inviterUnUtilisateur.execute({
+    const result = await inviterUnUtilisateur.handle({
       email: 'martin.tartempion@example.net',
       nom: 'Tartempion',
       prenom: 'Martin',
@@ -196,7 +196,7 @@ describe('inviter un utilisateur', () => {
     const roleUtilisateurAInviter: TypologieRole = 'Instructeur'
 
     // WHEN
-    const result = await inviterUnUtilisateur.execute({
+    const result = await inviterUnUtilisateur.handle({
       email: 'martin.tartempion@example.net',
       nom: 'Tartempion',
       prenom: 'Martin',
@@ -218,14 +218,14 @@ let spiedUtilisateurToAdd: Utilisateur | null
 let spiedDestinataire: string
 let spiedIsSuperAdmin: boolean | null
 
-class RepositorySpy implements AddUtilisateurRepository, FindUtilisateurRepository {
+class RepositorySpy implements AddUtilisateurRepository, GetUtilisateurRepository {
   readonly #utilisateurCourant: Utilisateur
 
   constructor(utilisateurCourant: Utilisateur) {
     this.#utilisateurCourant = utilisateurCourant
   }
 
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
+  async get(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUidToFind = uid
     return Promise.resolve(this.#utilisateurCourant)
   }

--- a/src/use-cases/commands/InviterUnUtilisateur.ts
+++ b/src/use-cases/commands/InviterUnUtilisateur.ts
@@ -21,10 +21,6 @@ export class InviterUnUtilisateur implements CommandHandler<Command> {
 
   async execute(command: Command): ResultAsync<Failure> {
     const utilisateurCourant = await this.#utilisateurRepository.find(command.uidUtilisateurCourant)
-    if (!utilisateurCourant) {
-      return 'utilisateurCourantInexistant'
-    }
-
     const utilisateurCourantState = utilisateurCourant.state
     const utilisateurACreer = new UtilisateurFactory({
       departement: utilisateurCourantState.departement,
@@ -69,6 +65,6 @@ type Command = Readonly<{
   uidUtilisateurCourant: string
 }>
 
-type Failure = 'utilisateurNePeutPasGererUtilisateurACreer' | 'emailExistant' | 'utilisateurCourantInexistant'
+type Failure = 'utilisateurNePeutPasGererUtilisateurACreer' | 'emailExistant'
 
 interface UtilisateurRepository extends FindUtilisateurRepository, AddUtilisateurRepository {}

--- a/src/use-cases/commands/InviterUnUtilisateur.ts
+++ b/src/use-cases/commands/InviterUnUtilisateur.ts
@@ -1,6 +1,6 @@
 import { CommandHandler, ResultAsync } from '../CommandHandler'
 import { EmailGatewayFactory } from './shared/EmailGateway'
-import { AddUtilisateurRepository, FindUtilisateurRepository } from './shared/UtilisateurRepository'
+import { AddUtilisateurRepository, GetUtilisateurRepository } from './shared/UtilisateurRepository'
 import { TypologieRole } from '@/domain/Role'
 import { UtilisateurFactory } from '@/domain/UtilisateurFactory'
 
@@ -19,8 +19,8 @@ export class InviterUnUtilisateur implements CommandHandler<Command> {
     this.#date = date
   }
 
-  async execute(command: Command): ResultAsync<Failure> {
-    const utilisateurCourant = await this.#utilisateurRepository.find(command.uidUtilisateurCourant)
+  async handle(command: Command): ResultAsync<Failure> {
+    const utilisateurCourant = await this.#utilisateurRepository.get(command.uidUtilisateurCourant)
     const utilisateurCourantState = utilisateurCourant.state
     const utilisateurACreer = new UtilisateurFactory({
       departement: utilisateurCourantState.departement,
@@ -67,4 +67,4 @@ type Command = Readonly<{
 
 type Failure = 'utilisateurNePeutPasGererUtilisateurACreer' | 'emailExistant'
 
-interface UtilisateurRepository extends FindUtilisateurRepository, AddUtilisateurRepository {}
+interface UtilisateurRepository extends GetUtilisateurRepository, AddUtilisateurRepository {}

--- a/src/use-cases/commands/MettreAJourDateDeDerniereConnexion.test.ts
+++ b/src/use-cases/commands/MettreAJourDateDeDerniereConnexion.test.ts
@@ -10,18 +10,6 @@ describe('mettre à jour la date de dernière connexion à chaque connexion', ()
     spiedUtilisateurToUpdate = null
   })
 
-  it('étant donné que le compte de l’utilisateur courant n’existe plus, quand sa date de dernière connexion doit être mise à jour, alors il y a une erreur', async () => {
-    // GIVEN
-    const uidUtilisateurCourant = 'fooId'
-    const repository = new UtilisateurInexistantRepositorySpy()
-    const mettreAJourDateDerniereConnexion = new MettreAJourDateDeDerniereConnexion(repository, epochTime)
-    // WHEN
-    const result = await mettreAJourDateDerniereConnexion.execute({ uidUtilisateurCourant })
-    // THEN
-    expect(result).toBe('utilisateurCourantInexistant')
-    expect(spiedUidToFind).toBe('fooId')
-  })
-
   it('étant donné une nouvelle date de connexion d’un utilisateur, quand une mise à jour est demandée, alors elle est mise à jour', async () => {
     // GIVEN
     const uidUtilisateurCourant = 'fooId'
@@ -62,22 +50,11 @@ let spiedUidToFind: string | null
 let spiedUtilisateurToUpdate: Utilisateur | null
 
 class UtilisateurRepositorySpy implements UpdateUtilisateurRepository, FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur | null> {
+  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUidToFind = uid
     return Promise.resolve(utilisateurFactory({
       uid: { email: 'martin.tartempion@example.net', value: 'fooId' },
     }))
-  }
-
-  async update(utilisateur: Utilisateur): Promise<void> {
-    spiedUtilisateurToUpdate = utilisateur
-    return Promise.resolve()
-  }
-}
-class UtilisateurInexistantRepositorySpy implements UpdateUtilisateurRepository, FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur | null> {
-    spiedUidToFind = uid
-    return Promise.resolve(null)
   }
 
   async update(utilisateur: Utilisateur): Promise<void> {

--- a/src/use-cases/commands/MettreAJourDateDeDerniereConnexion.test.ts
+++ b/src/use-cases/commands/MettreAJourDateDeDerniereConnexion.test.ts
@@ -1,5 +1,5 @@
 import { MettreAJourDateDeDerniereConnexion } from './MettreAJourDateDeDerniereConnexion'
-import { FindUtilisateurRepository, UpdateUtilisateurRepository } from './shared/UtilisateurRepository'
+import { GetUtilisateurRepository, UpdateUtilisateurRepository } from './shared/UtilisateurRepository'
 import { utilisateurFactory } from '@/domain/testHelper'
 import { Utilisateur, UtilisateurUidState } from '@/domain/Utilisateur'
 import { epochTime, invalidDate } from '@/shared/testHelper'
@@ -18,7 +18,7 @@ describe('mettre à jour la date de dernière connexion à chaque connexion', ()
     const mettreAJourDateDerniereConnexion = new MettreAJourDateDeDerniereConnexion(repository, date)
 
     // WHEN
-    const result = await mettreAJourDateDerniereConnexion.execute({ uidUtilisateurCourant })
+    const result = await mettreAJourDateDerniereConnexion.handle({ uidUtilisateurCourant })
 
     // THEN
     expect(result).toBe('OK')
@@ -39,7 +39,7 @@ describe('mettre à jour la date de dernière connexion à chaque connexion', ()
     const mettreAJourDateDerniereConnexion = new MettreAJourDateDeDerniereConnexion(repository, invalidDate)
 
     // WHEN
-    const asyncResult = mettreAJourDateDerniereConnexion.execute({ uidUtilisateurCourant })
+    const asyncResult = mettreAJourDateDerniereConnexion.handle({ uidUtilisateurCourant })
 
     // THEN
     await expect(asyncResult).rejects.toThrow('dateDeDerniereConnexionInvalide')
@@ -49,8 +49,8 @@ describe('mettre à jour la date de dernière connexion à chaque connexion', ()
 let spiedUidToFind: string | null
 let spiedUtilisateurToUpdate: Utilisateur | null
 
-class UtilisateurRepositorySpy implements UpdateUtilisateurRepository, FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
+class UtilisateurRepositorySpy implements UpdateUtilisateurRepository, GetUtilisateurRepository {
+  async get(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUidToFind = uid
     return Promise.resolve(utilisateurFactory({
       uid: { email: 'martin.tartempion@example.net', value: 'fooId' },

--- a/src/use-cases/commands/MettreAJourDateDeDerniereConnexion.ts
+++ b/src/use-cases/commands/MettreAJourDateDeDerniereConnexion.ts
@@ -13,17 +13,13 @@ export class MettreAJourDateDeDerniereConnexion implements CommandHandler<Comman
 
   async execute(command: Command): ResultAsync<Failure> {
     const utilisateurCourant = await this.#utilisateurRepository.find(command.uidUtilisateurCourant)
-    if (!utilisateurCourant) {
-      return 'utilisateurCourantInexistant'
-    }
-
     utilisateurCourant.changerDateDeDerniereConnexion(this.#date)
     await this.#utilisateurRepository.update(utilisateurCourant)
     return 'OK'
   }
 }
 
-type Failure = 'utilisateurCourantInexistant' | 'dateInvalide' | UtilisateurFailure
+type Failure = 'dateInvalide' | UtilisateurFailure
 
 type Command = Readonly<{
   uidUtilisateurCourant: string

--- a/src/use-cases/commands/MettreAJourDateDeDerniereConnexion.ts
+++ b/src/use-cases/commands/MettreAJourDateDeDerniereConnexion.ts
@@ -1,5 +1,5 @@
 import { CommandHandler, ResultAsync } from '../CommandHandler'
-import { FindUtilisateurRepository, UpdateUtilisateurRepository } from './shared/UtilisateurRepository'
+import { GetUtilisateurRepository, UpdateUtilisateurRepository } from './shared/UtilisateurRepository'
 import { UtilisateurFailure } from '@/domain/Utilisateur'
 
 export class MettreAJourDateDeDerniereConnexion implements CommandHandler<Command> {
@@ -11,8 +11,8 @@ export class MettreAJourDateDeDerniereConnexion implements CommandHandler<Comman
     this.#date = date
   }
 
-  async execute(command: Command): ResultAsync<Failure> {
-    const utilisateurCourant = await this.#utilisateurRepository.find(command.uidUtilisateurCourant)
+  async handle(command: Command): ResultAsync<Failure> {
+    const utilisateurCourant = await this.#utilisateurRepository.get(command.uidUtilisateurCourant)
     utilisateurCourant.changerDateDeDerniereConnexion(this.#date)
     await this.#utilisateurRepository.update(utilisateurCourant)
     return 'OK'
@@ -25,4 +25,4 @@ type Command = Readonly<{
   uidUtilisateurCourant: string
 }>
 
-interface UtilisateurRepository extends FindUtilisateurRepository, UpdateUtilisateurRepository {}
+interface UtilisateurRepository extends GetUtilisateurRepository, UpdateUtilisateurRepository {}

--- a/src/use-cases/commands/MettreAJourUidALaPremiereConnexion.test.ts
+++ b/src/use-cases/commands/MettreAJourUidALaPremiereConnexion.test.ts
@@ -29,30 +29,13 @@ describe('mettre à jour l’identifiant unique à la première connexion', () =
       },
     }).state)
   })
-
-  it('quand l’utilisateur se connecte pour la première fois mais qu’il n’existe pas, alors un message d’erreur est renvoyé', async () => {
-    // GIVEN
-    const emailAsUid = 'fake-email@example.com'
-    const uid = 'fooId'
-    const mettreAJourUidALaPremiereConnexion = new MettreAJourUidALaPremiereConnexion(
-      new UtilisateurIntrouvableRepositorySpy()
-    )
-
-    // WHEN
-    const result = await mettreAJourUidALaPremiereConnexion.execute({ emailAsUid, uid })
-
-    // THEN
-    expect(result).toBe('utilisateurCourantInexistant')
-    expect(spiedUidToFind).toBe(emailAsUid)
-    expect(spiedUtilisateurToUpdate).toBeNull()
-  })
 })
 
 let spiedUidToFind: string | null
 let spiedUtilisateurToUpdate: Utilisateur | null
 
 class UtilisateurRepositorySpy implements UpdateUtilisateurUidRepository, FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur | null> {
+  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUidToFind = uid
     return Promise.resolve(utilisateurFactory({
       derniereConnexion: undefined,
@@ -63,12 +46,5 @@ class UtilisateurRepositorySpy implements UpdateUtilisateurUidRepository, FindUt
   async updateUid(utilisateur: Utilisateur): Promise<void> {
     spiedUtilisateurToUpdate = utilisateur
     return Promise.resolve()
-  }
-}
-
-class UtilisateurIntrouvableRepositorySpy extends UtilisateurRepositorySpy {
-  override async find(uid: UtilisateurUidState['value']): Promise<null> {
-    spiedUidToFind = uid
-    return Promise.resolve(null)
   }
 }

--- a/src/use-cases/commands/MettreAJourUidALaPremiereConnexion.test.ts
+++ b/src/use-cases/commands/MettreAJourUidALaPremiereConnexion.test.ts
@@ -1,5 +1,5 @@
 import { MettreAJourUidALaPremiereConnexion } from './MettreAJourUidALaPremiereConnexion'
-import { FindUtilisateurRepository, UpdateUtilisateurUidRepository } from './shared/UtilisateurRepository'
+import { GetUtilisateurRepository, UpdateUtilisateurUidRepository } from './shared/UtilisateurRepository'
 import { utilisateurFactory } from '@/domain/testHelper'
 import { Utilisateur, UtilisateurUidState } from '@/domain/Utilisateur'
 
@@ -16,7 +16,7 @@ describe('mettre à jour l’identifiant unique à la première connexion', () =
     const mettreAJourUidALaPremiereConnexion = new MettreAJourUidALaPremiereConnexion(new UtilisateurRepositorySpy())
 
     // WHEN
-    const result = await mettreAJourUidALaPremiereConnexion.execute({ emailAsUid, uid })
+    const result = await mettreAJourUidALaPremiereConnexion.handle({ emailAsUid, uid })
 
     // THEN
     expect(result).toBe('OK')
@@ -34,8 +34,8 @@ describe('mettre à jour l’identifiant unique à la première connexion', () =
 let spiedUidToFind: string | null
 let spiedUtilisateurToUpdate: Utilisateur | null
 
-class UtilisateurRepositorySpy implements UpdateUtilisateurUidRepository, FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
+class UtilisateurRepositorySpy implements UpdateUtilisateurUidRepository, GetUtilisateurRepository {
+  async get(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUidToFind = uid
     return Promise.resolve(utilisateurFactory({
       derniereConnexion: undefined,

--- a/src/use-cases/commands/MettreAJourUidALaPremiereConnexion.ts
+++ b/src/use-cases/commands/MettreAJourUidALaPremiereConnexion.ts
@@ -1,5 +1,5 @@
 import { CommandHandler, ResultAsync } from '../CommandHandler'
-import { FindUtilisateurRepository, UpdateUtilisateurUidRepository } from './shared/UtilisateurRepository'
+import { GetUtilisateurRepository, UpdateUtilisateurUidRepository } from './shared/UtilisateurRepository'
 import { UtilisateurFactory } from '@/domain/UtilisateurFactory'
 
 export class MettreAJourUidALaPremiereConnexion implements CommandHandler<Command> {
@@ -9,8 +9,8 @@ export class MettreAJourUidALaPremiereConnexion implements CommandHandler<Comman
     this.#utilisateurRepository = utilisateurRepository
   }
 
-  async execute(command: Command): ResultAsync<never> {
-    const utilisateurCourant = await this.#utilisateurRepository.find(command.emailAsUid)
+  async handle(command: Command): ResultAsync<never> {
+    const utilisateurCourant = await this.#utilisateurRepository.get(command.emailAsUid)
 
     const utilisateurAvecNouvelUid = UtilisateurFactory.avecNouvelUid(utilisateurCourant, command.uid)
     await this.#utilisateurRepository.updateUid(utilisateurAvecNouvelUid)
@@ -24,4 +24,4 @@ type Command = Readonly<{
   uid: string
 }>
 
-type UtilisateurRepository = FindUtilisateurRepository & UpdateUtilisateurUidRepository
+type UtilisateurRepository = GetUtilisateurRepository & UpdateUtilisateurUidRepository

--- a/src/use-cases/commands/MettreAJourUidALaPremiereConnexion.ts
+++ b/src/use-cases/commands/MettreAJourUidALaPremiereConnexion.ts
@@ -9,12 +9,8 @@ export class MettreAJourUidALaPremiereConnexion implements CommandHandler<Comman
     this.#utilisateurRepository = utilisateurRepository
   }
 
-  async execute(command: Command): ResultAsync<Failure> {
+  async execute(command: Command): ResultAsync<never> {
     const utilisateurCourant = await this.#utilisateurRepository.find(command.emailAsUid)
-
-    if (!utilisateurCourant) {
-      return 'utilisateurCourantInexistant'
-    }
 
     const utilisateurAvecNouvelUid = UtilisateurFactory.avecNouvelUid(utilisateurCourant, command.uid)
     await this.#utilisateurRepository.updateUid(utilisateurAvecNouvelUid)
@@ -22,8 +18,6 @@ export class MettreAJourUidALaPremiereConnexion implements CommandHandler<Comman
     return 'OK'
   }
 }
-
-type Failure = 'utilisateurCourantInexistant'
 
 type Command = Readonly<{
   emailAsUid: string

--- a/src/use-cases/commands/ModifierMesInformationsPersonnelles.test.ts
+++ b/src/use-cases/commands/ModifierMesInformationsPersonnelles.test.ts
@@ -4,77 +4,64 @@ import { utilisateurFactory } from '@/domain/testHelper'
 import { Utilisateur } from '@/domain/Utilisateur'
 
 describe('modifier mes informations personnelles', () => {
-  it('quand le compte n’existe pas alors pas de modification possible', async () => {
-    // GIVEN
-    const commandHandler = new ModifierMesInformationsPersonnelles(
-      new RepositoryUtilisateurIntrouvableStub()
-    )
-
-    // WHEN
-    const result = await commandHandler.execute(informationsPersonnellesModifiees)
-
-    // THEN
-    expect(result).toBe('utilisateurCourantInexistant')
-  })
-
-  describe('quand le compte existe', () => {
-    describe('il n’est pas modifié si les modifications sont invalides', () => {
-      it.each([
-        {
-          desc: 'le prénom doit être renseigné',
-          expectedResult: 'prenomAbsent',
-          modification: { prenom: '' },
-        },
-        {
-          desc: 'le nom doit être renseigné',
-          expectedResult: 'nomAbsent',
-          modification: { nom: '' },
-        },
-        {
-          desc: 'l’email, si renseigné, doit être valide',
-          expectedResult: 'emailInvalide',
-          modification: { emailDeContact: 'example@example' },
-        },
-        {
-          desc: 'le téléphone, si renseigné, doit être valide',
-          expectedResult: 'telephoneInvalide',
-          modification: { telephone: '000' },
-        },
-      ])('$desc', async ({ modification, expectedResult }) => {
-        // GIVEN
-        const utilisateur = utilisateurFactory()
-        const commandHandler = new ModifierMesInformationsPersonnelles(new RepositoryStub(utilisateur))
-
-        // WHEN
-        const result = await commandHandler.execute({ ...informationsPersonnellesModifiees,
-          modification: {
-            ...informationsPersonnellesModifiees.modification,
-            ...modification,
-          } })
-
-        // THEN
-        expect(result).toBe(expectedResult)
-      })
-    })
-
-    it('il est modifié si les modifications sont valides', async () => {
+  describe('le compte n’est pas modifié si les modifications sont invalides', () => {
+    it.each([
+      {
+        desc: 'le prénom doit être renseigné',
+        expectedResult: 'prenomAbsent',
+        modification: { prenom: '' },
+      },
+      {
+        desc: 'le nom doit être renseigné',
+        expectedResult: 'nomAbsent',
+        modification: { nom: '' },
+      },
+      {
+        desc: 'l’email, si renseigné, doit être valide',
+        expectedResult: 'emailInvalide',
+        modification: { emailDeContact: 'example@example' },
+      },
+      {
+        desc: 'le téléphone, si renseigné, doit être valide',
+        expectedResult: 'telephoneInvalide',
+        modification: { telephone: '000' },
+      },
+    ])('$desc', async ({ modification, expectedResult }) => {
       // GIVEN
       const utilisateur = utilisateurFactory()
       const commandHandler = new ModifierMesInformationsPersonnelles(new RepositoryStub(utilisateur))
 
       // WHEN
-      const result = await commandHandler.execute(informationsPersonnellesModifiees)
+      const result = await commandHandler.execute({
+        ...informationsPersonnellesModifiees,
+        modification: {
+          ...informationsPersonnellesModifiees.modification,
+          ...modification,
+        },
+      })
 
       // THEN
-      const utilisateurApresMiseAJour = utilisateurFactory({
-        emailDeContact: 'martine.dugenoux@example.com',
-        nom: 'Dugenoux',
-        prenom: 'Martine',
-        telephone: '0102030406',
-      })
-      expect(result).toBe('OK')
-      expect(utilisateurApresMiseAJour.state).toStrictEqual(utilisateur.state)
+      expect(result).toBe(expectedResult)
     })
+  })
+
+  it('le compte est modifié si les modifications sont valides', async () => {
+    // GIVEN
+    const utilisateur = utilisateurFactory()
+    const commandHandler = new ModifierMesInformationsPersonnelles(new RepositoryStub(utilisateur))
+
+    // WHEN
+    const result = await commandHandler.execute(informationsPersonnellesModifiees)
+
+    // THEN
+    const utilisateurApresMiseAJour = utilisateurFactory({
+      emailDeContact: 'martine.dugenoux@example.com',
+      nom: 'Dugenoux',
+      prenom: 'Martine',
+      telephone: '0102030406',
+    })
+    expect(result).toBe('OK')
+    expect(utilisateurApresMiseAJour.state).toStrictEqual(utilisateur.state)
   })
 })
 
@@ -89,23 +76,17 @@ const informationsPersonnellesModifiees = {
 }
 
 class RepositoryStub implements FindUtilisateurRepository, UpdateUtilisateurRepository {
-  readonly #utilisateur: Utilisateur | null
+  readonly #utilisateur: Utilisateur
 
-  constructor(utilisateur: Utilisateur | null = null) {
+  constructor(utilisateur: Utilisateur) {
     this.#utilisateur = utilisateur
   }
 
-  async find(): Promise<Utilisateur | null> {
+  async find(): Promise<Utilisateur> {
     return Promise.resolve(this.#utilisateur)
   }
 
   async update(): Promise<void> {
     return Promise.resolve()
-  }
-}
-
-class RepositoryUtilisateurIntrouvableStub extends RepositoryStub {
-  override async find(): Promise<null> {
-    return Promise.resolve(null)
   }
 }

--- a/src/use-cases/commands/ModifierMesInformationsPersonnelles.test.ts
+++ b/src/use-cases/commands/ModifierMesInformationsPersonnelles.test.ts
@@ -1,5 +1,5 @@
 import { ModifierMesInformationsPersonnelles } from './ModifierMesInformationsPersonnelles'
-import { FindUtilisateurRepository, UpdateUtilisateurRepository } from './shared/UtilisateurRepository'
+import { GetUtilisateurRepository, UpdateUtilisateurRepository } from './shared/UtilisateurRepository'
 import { utilisateurFactory } from '@/domain/testHelper'
 import { Utilisateur } from '@/domain/Utilisateur'
 
@@ -32,7 +32,7 @@ describe('modifier mes informations personnelles', () => {
       const commandHandler = new ModifierMesInformationsPersonnelles(new RepositoryStub(utilisateur))
 
       // WHEN
-      const result = await commandHandler.execute({
+      const result = await commandHandler.handle({
         ...informationsPersonnellesModifiees,
         modification: {
           ...informationsPersonnellesModifiees.modification,
@@ -51,7 +51,7 @@ describe('modifier mes informations personnelles', () => {
     const commandHandler = new ModifierMesInformationsPersonnelles(new RepositoryStub(utilisateur))
 
     // WHEN
-    const result = await commandHandler.execute(informationsPersonnellesModifiees)
+    const result = await commandHandler.handle(informationsPersonnellesModifiees)
 
     // THEN
     const utilisateurApresMiseAJour = utilisateurFactory({
@@ -75,14 +75,14 @@ const informationsPersonnellesModifiees = {
   uidUtilisateurCourant: 'fooId',
 }
 
-class RepositoryStub implements FindUtilisateurRepository, UpdateUtilisateurRepository {
+class RepositoryStub implements GetUtilisateurRepository, UpdateUtilisateurRepository {
   readonly #utilisateur: Utilisateur
 
   constructor(utilisateur: Utilisateur) {
     this.#utilisateur = utilisateur
   }
 
-  async find(): Promise<Utilisateur> {
+  async get(): Promise<Utilisateur> {
     return Promise.resolve(this.#utilisateur)
   }
 

--- a/src/use-cases/commands/ModifierMesInformationsPersonnelles.ts
+++ b/src/use-cases/commands/ModifierMesInformationsPersonnelles.ts
@@ -17,9 +17,6 @@ export class ModifierMesInformationsPersonnelles implements CommandHandler<Comma
     } = command
 
     const utilisateurCourant = await this.#utilisateurRepository.find(uidUtilisateurCourant)
-    if (!utilisateurCourant) {
-      return 'utilisateurCourantInexistant'
-    }
 
     const changerPrenomResult = utilisateurCourant.changerPrenom(prenom)
     if (!isOk(changerPrenomResult)) {
@@ -56,6 +53,6 @@ type Command = Readonly<{
   uidUtilisateurCourant: string
 }>
 
-type Failure = 'utilisateurCourantInexistant' | UtilisateurFailure
+type Failure = UtilisateurFailure
 
 interface UtilisateurRepository extends FindUtilisateurRepository, UpdateUtilisateurRepository {}

--- a/src/use-cases/commands/ModifierMesInformationsPersonnelles.ts
+++ b/src/use-cases/commands/ModifierMesInformationsPersonnelles.ts
@@ -1,5 +1,5 @@
 import { CommandHandler, ResultAsync } from '../CommandHandler'
-import { FindUtilisateurRepository, UpdateUtilisateurRepository } from './shared/UtilisateurRepository'
+import { GetUtilisateurRepository, UpdateUtilisateurRepository } from './shared/UtilisateurRepository'
 import { UtilisateurFailure } from '@/domain/Utilisateur'
 import { isOk } from '@/shared/lang'
 
@@ -10,13 +10,13 @@ export class ModifierMesInformationsPersonnelles implements CommandHandler<Comma
     this.#utilisateurRepository = utilisateurRepository
   }
 
-  async execute(command: Command): ResultAsync<Failure> {
+  async handle(command: Command): ResultAsync<Failure> {
     const {
       modification: { nom, prenom, emailDeContact: email, telephone },
       uidUtilisateurCourant,
     } = command
 
-    const utilisateurCourant = await this.#utilisateurRepository.find(uidUtilisateurCourant)
+    const utilisateurCourant = await this.#utilisateurRepository.get(uidUtilisateurCourant)
 
     const changerPrenomResult = utilisateurCourant.changerPrenom(prenom)
     if (!isOk(changerPrenomResult)) {
@@ -55,4 +55,4 @@ type Command = Readonly<{
 
 type Failure = UtilisateurFailure
 
-interface UtilisateurRepository extends FindUtilisateurRepository, UpdateUtilisateurRepository {}
+interface UtilisateurRepository extends GetUtilisateurRepository, UpdateUtilisateurRepository {}

--- a/src/use-cases/commands/ModifierUnComite.test.ts
+++ b/src/use-cases/commands/ModifierUnComite.test.ts
@@ -33,7 +33,7 @@ describe('modifier un comité', () => {
       intention: 'sans date ni commentaire',
       type: typeValide,
     },
-  ])('étant donné une gouvernance existante, quand un comité est modifié $intention par son gestionnaire, alors il est modifié', async ({
+  ])('étant donné une gouvernance, quand un comité est modifié $intention par son gestionnaire, alors il est modifié', async ({
     commentaire,
     date,
     expectedDate,
@@ -125,7 +125,7 @@ describe('modifier un comité', () => {
       intention: 'de la date de comité qui est dans le passé',
       type: typeValide,
     },
-  ])('étant donné une gouvernance existante, quand un comité est modifié par son gestionnaire mais que le comité n’est pas valide à cause $intention, alors une erreur est renvoyée', async ({ date, dateDeModification, expectedFailure, frequence, type }) => {
+  ])('étant donné une gouvernance, quand un comité est modifié par son gestionnaire mais que le comité n’est pas valide à cause $intention, alors une erreur est renvoyée', async ({ date, dateDeModification, expectedFailure, frequence, type }) => {
     // GIVEN
     const modifierUnComite = new ModifierUnComite(
       new GouvernanceRepositorySpy(),
@@ -151,7 +151,7 @@ describe('modifier un comité', () => {
     expect(spiedComiteToModify).toBeNull()
   })
 
-  it('étant donné une gouvernance existante, quand un comité est modifié par un gestionnaire autre que celui de la gouvernance, alors une erreur est renvoyée', async () => {
+  it('étant donné une gouvernance, quand un comité est modifié par un gestionnaire autre que celui de la gouvernance, alors une erreur est renvoyée', async () => {
     // GIVEN
     const modifierUnComite = new ModifierUnComite(
       new GouvernanceRepositorySpy(),
@@ -177,88 +177,6 @@ describe('modifier un comité', () => {
     expect(result).toBe('editeurNePeutPasModifierComite')
     expect(spiedComiteToModify).toBeNull()
   })
-
-  it('étant donné une gouvernance inexistante, quand un comité est modifié, alors une erreur est renvoyée', async () => {
-    // GIVEN
-    const modifierUnComite = new ModifierUnComite(
-      new GouvernanceInexistanteRepositorySpy(),
-      new GestionnaireRepositorySpy(),
-      new ComiteRepositorySpy(),
-      epochTime
-    )
-
-    // WHEN
-    const result = await modifierUnComite.execute({
-      commentaire,
-      date,
-      frequence: frequenceValide,
-      type: typeValide,
-      uid: uidComite,
-      uidEditeur,
-      uidGouvernance,
-    })
-
-    // THEN
-    expect(spiedUtilisateurUidToFind).toBe(uidEditeur)
-    expect(spiedGouvernanceUidToFind?.state).toStrictEqual(new GouvernanceUid(uidGouvernance).state)
-    expect(result).toBe('gouvernanceInexistante')
-    expect(spiedComiteToModify).toBeNull()
-  })
-
-  it('étant donné un utilisateur inexistant, quand un comité est modifié, alors une erreur est renvoyée', async () => {
-    // GIVEN
-    const modifierUnComite = new ModifierUnComite(
-      new GouvernanceRepositorySpy(),
-      new GestionnaireInexistantRepositorySpy(),
-      new ComiteRepositorySpy(),
-      epochTime
-    )
-
-    // WHEN
-    const result = await modifierUnComite.execute({
-      commentaire,
-      date,
-      frequence: frequenceValide,
-      type: typeValide,
-      uid: uidComite,
-      uidEditeur,
-      uidGouvernance,
-    })
-
-    // THEN
-    expect(spiedUtilisateurUidToFind).toBe(uidEditeur)
-    expect(result).toBe('editeurInexistant')
-    expect(spiedGouvernanceUidToFind).toBeNull()
-    expect(spiedComiteToModify).toBeNull()
-  })
-
-  it('étant donné un comité inexistant, quand un comité est modifié, alors une erreur est renvoyée', async () => {
-    // GIVEN
-    const modifierUnComite = new ModifierUnComite(
-      new GouvernanceRepositorySpy(),
-      new GestionnaireRepositorySpy(),
-      new ComiteInexistantRepositorySpy(),
-      epochTime
-    )
-
-    // WHEN
-    const result = await modifierUnComite.execute({
-      commentaire,
-      date,
-      frequence: frequenceValide,
-      type: typeValide,
-      uid: uidComite,
-      uidEditeur,
-      uidGouvernance,
-    })
-
-    // THEN
-    expect(spiedUtilisateurUidToFind).toBe(uidEditeur)
-    expect(spiedGouvernanceUidToFind?.state).toStrictEqual(new GouvernanceUid(uidGouvernance).state)
-    expect(spiedComiteUidToFind).toBe(uidComite)
-    expect(result).toBe('comiteInexistant')
-    expect(spiedComiteToModify).toBeNull()
-  })
 })
 
 const commentaire = 'un commentaire'
@@ -275,7 +193,7 @@ let spiedComiteToModify: Comite | null
 let spiedComiteUidToFind: Comite['uid']['state']['value'] | null
 
 class GouvernanceRepositorySpy implements FindGouvernanceRepository {
-  async find(uid: GouvernanceUid): Promise<Gouvernance | null> {
+  async find(uid: GouvernanceUid): Promise<Gouvernance> {
     spiedGouvernanceUidToFind = uid
     return Promise.resolve(
       gouvernanceFactory({
@@ -291,15 +209,8 @@ class GouvernanceRepositorySpy implements FindGouvernanceRepository {
   }
 }
 
-class GouvernanceInexistanteRepositorySpy extends GouvernanceRepositorySpy {
-  override async find(uid: GouvernanceUid): Promise<Gouvernance | null> {
-    spiedGouvernanceUidToFind = uid
-    return Promise.resolve(null)
-  }
-}
-
 class GestionnaireRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur | null> {
+  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUtilisateurUidToFind = uid
     return Promise.resolve(utilisateurFactory({
       codeOrganisation: '75',
@@ -309,22 +220,15 @@ class GestionnaireRepositorySpy implements FindUtilisateurRepository {
   }
 }
 
-class GestionnaireInexistantRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur | null> {
-    spiedUtilisateurUidToFind = uid
-    return Promise.resolve(null)
-  }
-}
-
 class GestionnaireAutreRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur | null> {
+  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUtilisateurUidToFind = uid
     return Promise.resolve(utilisateurFactory({ codeOrganisation: '10', role: 'Gestionnaire département' }))
   }
 }
 
 class ComiteRepositorySpy implements UpdateComiteRepository, FindComiteRepository {
-  async find(uid: Comite['uid']['state']['value']): Promise<Comite | null> {
+  async find(uid: Comite['uid']['state']['value']): Promise<Comite> {
     spiedComiteUidToFind = uid
     return Promise.resolve(comiteFactory({
       uid: { value: uidComite },
@@ -336,12 +240,5 @@ class ComiteRepositorySpy implements UpdateComiteRepository, FindComiteRepositor
   async update(comite: Comite): Promise<void> {
     spiedComiteToModify = comite
     return Promise.resolve()
-  }
-}
-
-class ComiteInexistantRepositorySpy extends ComiteRepositorySpy {
-  override async find(uid: Comite['uid']['state']['value']): Promise<Comite | null> {
-    spiedComiteUidToFind = uid
-    return Promise.resolve(null)
   }
 }

--- a/src/use-cases/commands/ModifierUnComite.test.ts
+++ b/src/use-cases/commands/ModifierUnComite.test.ts
@@ -1,7 +1,7 @@
 import { ModifierUnComite } from './ModifierUnComite'
-import { FindComiteRepository, UpdateComiteRepository } from './shared/ComiteRepository'
-import { FindGouvernanceRepository } from './shared/GouvernanceRepository'
-import { FindUtilisateurRepository } from './shared/UtilisateurRepository'
+import { GetComiteRepository, UpdateComiteRepository } from './shared/ComiteRepository'
+import { GetGouvernanceRepository } from './shared/GouvernanceRepository'
+import { GetUtilisateurRepository } from './shared/UtilisateurRepository'
 import { Comite } from '@/domain/Comite'
 import { Gouvernance, GouvernanceUid } from '@/domain/Gouvernance'
 import { comiteFactory, gouvernanceFactory, utilisateurFactory } from '@/domain/testHelper'
@@ -50,7 +50,7 @@ describe('modifier un comité', () => {
     )
 
     // WHEN
-    const result = await modifierUnComite.execute({
+    const result = await modifierUnComite.handle({
       commentaire,
       date,
       frequence,
@@ -135,7 +135,7 @@ describe('modifier un comité', () => {
     )
 
     // WHEN
-    const result = await modifierUnComite.execute({
+    const result = await modifierUnComite.handle({
       date,
       frequence,
       type,
@@ -161,7 +161,7 @@ describe('modifier un comité', () => {
     )
 
     // WHEN
-    const result = await modifierUnComite.execute({
+    const result = await modifierUnComite.handle({
       commentaire,
       date,
       frequence: frequenceValide,
@@ -192,8 +192,8 @@ let spiedUtilisateurUidToFind: UtilisateurUidState['value'] | null
 let spiedComiteToModify: Comite | null
 let spiedComiteUidToFind: Comite['uid']['state']['value'] | null
 
-class GouvernanceRepositorySpy implements FindGouvernanceRepository {
-  async find(uid: GouvernanceUid): Promise<Gouvernance> {
+class GouvernanceRepositorySpy implements GetGouvernanceRepository {
+  async get(uid: GouvernanceUid): Promise<Gouvernance> {
     spiedGouvernanceUidToFind = uid
     return Promise.resolve(
       gouvernanceFactory({
@@ -209,8 +209,8 @@ class GouvernanceRepositorySpy implements FindGouvernanceRepository {
   }
 }
 
-class GestionnaireRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
+class GestionnaireRepositorySpy implements GetUtilisateurRepository {
+  async get(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUtilisateurUidToFind = uid
     return Promise.resolve(utilisateurFactory({
       codeOrganisation: '75',
@@ -220,15 +220,15 @@ class GestionnaireRepositorySpy implements FindUtilisateurRepository {
   }
 }
 
-class GestionnaireAutreRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
+class GestionnaireAutreRepositorySpy implements GetUtilisateurRepository {
+  async get(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUtilisateurUidToFind = uid
     return Promise.resolve(utilisateurFactory({ codeOrganisation: '10', role: 'Gestionnaire département' }))
   }
 }
 
-class ComiteRepositorySpy implements UpdateComiteRepository, FindComiteRepository {
-  async find(uid: Comite['uid']['state']['value']): Promise<Comite> {
+class ComiteRepositorySpy implements UpdateComiteRepository, GetComiteRepository {
+  async get(uid: Comite['uid']['state']['value']): Promise<Comite> {
     spiedComiteUidToFind = uid
     return Promise.resolve(comiteFactory({
       uid: { value: uidComite },

--- a/src/use-cases/commands/ModifierUnComite.ts
+++ b/src/use-cases/commands/ModifierUnComite.ts
@@ -1,7 +1,7 @@
 import { CommandHandler, ResultAsync } from '../CommandHandler'
-import { FindComiteRepository, UpdateComiteRepository } from './shared/ComiteRepository'
-import { FindGouvernanceRepository } from './shared/GouvernanceRepository'
-import { FindUtilisateurRepository } from './shared/UtilisateurRepository'
+import { GetComiteRepository, UpdateComiteRepository } from './shared/ComiteRepository'
+import { GetGouvernanceRepository } from './shared/GouvernanceRepository'
+import { GetUtilisateurRepository } from './shared/UtilisateurRepository'
 import { Comite, ComiteFailure } from '@/domain/Comite'
 import { GouvernanceUid } from '@/domain/Gouvernance'
 
@@ -23,10 +23,10 @@ export class ModifierUnComite implements CommandHandler<Command> {
     this.#date = date
   }
 
-  async execute(command: Command): ResultAsync<Failure> {
-    const editeur = await this.#utilisateurRepository.find(command.uidEditeur)
-    const gouvernance = await this.#gouvernanceRepository.find(new GouvernanceUid(command.uidGouvernance))
-    const comite = await this.#comiteRepository.find(command.uid)
+  async handle(command: Command): ResultAsync<Failure> {
+    const editeur = await this.#utilisateurRepository.get(command.uidEditeur)
+    const gouvernance = await this.#gouvernanceRepository.get(new GouvernanceUid(command.uidGouvernance))
+    const comite = await this.#comiteRepository.get(command.uid)
     const dateDeModification = this.#date
     const comiteModifie = Comite.create({
       commentaire: command.commentaire,
@@ -65,8 +65,8 @@ type Command = Readonly<{
   uidGouvernance: string
 }>
 
-type GouvernanceRepository = FindGouvernanceRepository
+type GouvernanceRepository = GetGouvernanceRepository
 
-type UtilisateurRepository = FindUtilisateurRepository
+type UtilisateurRepository = GetUtilisateurRepository
 
-interface ComiteRepository extends UpdateComiteRepository, FindComiteRepository {}
+interface ComiteRepository extends UpdateComiteRepository, GetComiteRepository {}

--- a/src/use-cases/commands/ModifierUnComite.ts
+++ b/src/use-cases/commands/ModifierUnComite.ts
@@ -25,20 +25,8 @@ export class ModifierUnComite implements CommandHandler<Command> {
 
   async execute(command: Command): ResultAsync<Failure> {
     const editeur = await this.#utilisateurRepository.find(command.uidEditeur)
-    if (!editeur) {
-      return 'editeurInexistant'
-    }
-
     const gouvernance = await this.#gouvernanceRepository.find(new GouvernanceUid(command.uidGouvernance))
-    if (!gouvernance) {
-      return 'gouvernanceInexistante'
-    }
-
     const comite = await this.#comiteRepository.find(command.uid)
-    if (!comite) {
-      return 'comiteInexistant'
-    }
-
     const dateDeModification = this.#date
     const comiteModifie = Comite.create({
       commentaire: command.commentaire,
@@ -65,7 +53,7 @@ export class ModifierUnComite implements CommandHandler<Command> {
   }
 }
 
-type Failure = 'gouvernanceInexistante' | 'editeurInexistant' | 'comiteInexistant' | 'editeurNePeutPasModifierComite' | ComiteFailure
+type Failure = 'editeurNePeutPasModifierComite' | ComiteFailure
 
 type Command = Readonly<{
   commentaire?: string

--- a/src/use-cases/commands/ModifierUneNoteDeContexte.test.ts
+++ b/src/use-cases/commands/ModifierUneNoteDeContexte.test.ts
@@ -1,6 +1,6 @@
 import { ModifierUneNoteDeContexte } from './ModifierUneNoteDeContexte'
-import { FindGouvernanceRepository, UpdateGouvernanceRepository } from './shared/GouvernanceRepository'
-import { FindUtilisateurRepository } from './shared/UtilisateurRepository'
+import { GetGouvernanceRepository, UpdateGouvernanceRepository } from './shared/GouvernanceRepository'
+import { GetUtilisateurRepository } from './shared/UtilisateurRepository'
 import { Gouvernance, GouvernanceUid } from '@/domain/Gouvernance'
 import { gouvernanceFactory, utilisateurFactory } from '@/domain/testHelper'
 import { Utilisateur, UtilisateurUid, UtilisateurUidState } from '@/domain/Utilisateur'
@@ -24,7 +24,7 @@ describe('modifier une note de contexte', () => {
     )
 
     // WHEN
-    const result = await modifierNoteDeContexte.execute({
+    const result = await modifierNoteDeContexte.handle({
       contenu,
       uidEditeur,
       uidGouvernance,
@@ -57,7 +57,7 @@ describe('modifier une note de contexte', () => {
     )
 
     // WHEN
-    const result = await modifierNoteDeContexte.execute({ contenu, uidEditeur: 'utilisateurUsurpateur', uidGouvernance })
+    const result = await modifierNoteDeContexte.handle({ contenu, uidEditeur: 'utilisateurUsurpateur', uidGouvernance })
 
     // THEN
     expect(spiedUtilisateurUidToFind).toBe('utilisateurUsurpateur')
@@ -75,7 +75,7 @@ describe('modifier une note de contexte', () => {
     )
 
     // WHEN
-    const result = await modifierNoteDeContexte.execute({ contenu, uidEditeur, uidGouvernance })
+    const result = await modifierNoteDeContexte.handle({ contenu, uidEditeur, uidGouvernance })
 
     // THEN
     expect(spiedUtilisateurUidToFind).toBe(uidEditeur)
@@ -93,8 +93,8 @@ let spiedGouvernanceUidToFind: GouvernanceUid | null
 let spiedGouvernanceToUpdate: Gouvernance | null
 let spiedUtilisateurUidToFind: string | null
 
-class GouvernanceRepositorySpy implements FindGouvernanceRepository, UpdateGouvernanceRepository {
-  async find(uid: GouvernanceUid): Promise<Gouvernance> {
+class GouvernanceRepositorySpy implements GetGouvernanceRepository, UpdateGouvernanceRepository {
+  async get(uid: GouvernanceUid): Promise<Gouvernance> {
     spiedGouvernanceUidToFind = uid
     return Promise.resolve(
       gouvernanceFactory({
@@ -122,7 +122,7 @@ class GouvernanceRepositorySpy implements FindGouvernanceRepository, UpdateGouve
 }
 
 class GouvernanceSansNoteDeContexteRepositorySpy extends GouvernanceRepositorySpy {
-  override async find(uid: GouvernanceUid): Promise<Gouvernance> {
+  override async get(uid: GouvernanceUid): Promise<Gouvernance> {
     spiedGouvernanceUidToFind = uid
     return Promise.resolve(
       gouvernanceFactory({
@@ -132,8 +132,8 @@ class GouvernanceSansNoteDeContexteRepositorySpy extends GouvernanceRepositorySp
   }
 }
 
-class GestionnaireRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
+class GestionnaireRepositorySpy implements GetUtilisateurRepository {
+  async get(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUtilisateurUidToFind = uid
     return Promise.resolve(utilisateurFactory({
       codeOrganisation: '75',
@@ -143,8 +143,8 @@ class GestionnaireRepositorySpy implements FindUtilisateurRepository {
   }
 }
 
-class GestionnaireAutreRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
+class GestionnaireAutreRepositorySpy implements GetUtilisateurRepository {
+  async get(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUtilisateurUidToFind = uid
     return Promise.resolve(utilisateurFactory({ codeOrganisation: '10', role: 'Gestionnaire département' }))
   }

--- a/src/use-cases/commands/ModifierUneNoteDeContexte.test.ts
+++ b/src/use-cases/commands/ModifierUneNoteDeContexte.test.ts
@@ -6,14 +6,14 @@ import { gouvernanceFactory, utilisateurFactory } from '@/domain/testHelper'
 import { Utilisateur, UtilisateurUid, UtilisateurUidState } from '@/domain/Utilisateur'
 import { epochTime } from '@/shared/testHelper'
 
-describe('modifier une note de contexte à une gouvernance', () => {
+describe('modifier une note de contexte', () => {
   beforeEach(() => {
     spiedGouvernanceUidToFind = null
     spiedGouvernanceToUpdate = null
     spiedUtilisateurUidToFind = null
   })
 
-  it('étant donné une gouvernance existante, quand une note de contexte est modifiée par son gestionnaire, alors elle est modifiée', async () => {
+  it('étant donné une gouvernance, quand une note de contexte est modifiée par son gestionnaire, alors elle est modifiée', async () => {
     // GIVEN
     const dateDeModification = epochTime
     const uidEditeur = 'userFooId2'
@@ -48,7 +48,7 @@ describe('modifier une note de contexte à une gouvernance', () => {
     expect(result).toBe('OK')
   })
 
-  it('étant donné une gouvernance existante, quand un note de contexte est modifiée par un gestionnaire qui n’a pas ce droit, alors une erreur est renvoyée', async () => {
+  it('étant donné une gouvernance, quand un note de contexte est modifiée par un gestionnaire qui n’a pas ce droit, alors une erreur est renvoyée', async () => {
     // GIVEN
     const modifierNoteDeContexte = new ModifierUneNoteDeContexte(
       new GouvernanceRepositorySpy(),
@@ -66,7 +66,7 @@ describe('modifier une note de contexte à une gouvernance', () => {
     expect(result).toBe('editeurNePeutPasModifierNoteDeContexte')
   })
 
-  it('étant donné une gouvernance existante, quand un note de contexte est modifiée par un gestionnaire département mais qu’une note de contexte n’existe pas, alors une erreur est renvoyée', async () => {
+  it('étant donné une gouvernance, quand un note de contexte est modifiée par un gestionnaire département mais qu’une note de contexte n’existe pas, alors une erreur est renvoyée', async () => {
     // GIVEN
     const modifierNoteDeContexte = new ModifierUneNoteDeContexte(
       new GouvernanceSansNoteDeContexteRepositorySpy(),
@@ -83,50 +83,6 @@ describe('modifier une note de contexte à une gouvernance', () => {
     expect(spiedGouvernanceToUpdate).toBeNull()
     expect(result).toBe('noteDeContexteInexistante')
   })
-
-  it('étant donné une gouvernance inexistante, quand une note de contexte est modifiée, alors une erreur est renvoyée', async () => {
-    // GIVEN
-    const modifierNoteDeContexte = new ModifierUneNoteDeContexte(
-      new GouvernanceInexistanteRepositorySpy(),
-      new GestionnaireRepositorySpy(),
-      epochTime
-    )
-
-    // WHEN
-    const result = await modifierNoteDeContexte.execute({
-      contenu,
-      uidEditeur,
-      uidGouvernance,
-    })
-
-    // THEN
-    expect(spiedUtilisateurUidToFind).toBe(uidEditeur)
-    expect(spiedGouvernanceUidToFind?.state).toStrictEqual(new GouvernanceUid(uidGouvernance).state)
-    expect(spiedGouvernanceToUpdate).toBeNull()
-    expect(result).toBe('gouvernanceInexistante')
-  })
-
-  it('étant donné un utilisateur inexistant, quand une note de contexte est modifiée, alors une erreur est renvoyée', async () => {
-    // GIVEN
-    const modifierNoteDeContexte = new ModifierUneNoteDeContexte(
-      new GouvernanceInexistanteRepositorySpy(),
-      new GestionnaireInexistantRepositorySpy(),
-      epochTime
-    )
-
-    // WHEN
-    const result = await modifierNoteDeContexte.execute({
-      contenu,
-      uidEditeur,
-      uidGouvernance,
-    })
-
-    // THEN
-    expect(spiedUtilisateurUidToFind).toBe(uidEditeur)
-    expect(spiedGouvernanceUidToFind).toBeNull()
-    expect(spiedGouvernanceToUpdate).toBeNull()
-    expect(result).toBe('editeurInexistant')
-  })
 })
 
 const contenu = '<p>Lorem ipsum dolor sit amet consectetur. Sagittis dui sapien libero tristique leo tortor.<p>'
@@ -138,7 +94,7 @@ let spiedGouvernanceToUpdate: Gouvernance | null
 let spiedUtilisateurUidToFind: string | null
 
 class GouvernanceRepositorySpy implements FindGouvernanceRepository, UpdateGouvernanceRepository {
-  async find(uid: GouvernanceUid): Promise<Gouvernance | null> {
+  async find(uid: GouvernanceUid): Promise<Gouvernance> {
     spiedGouvernanceUidToFind = uid
     return Promise.resolve(
       gouvernanceFactory({
@@ -165,15 +121,8 @@ class GouvernanceRepositorySpy implements FindGouvernanceRepository, UpdateGouve
   }
 }
 
-class GouvernanceInexistanteRepositorySpy extends GouvernanceRepositorySpy {
-  override async find(uid: GouvernanceUid): Promise<Gouvernance | null> {
-    spiedGouvernanceUidToFind = uid
-    return Promise.resolve(null)
-  }
-}
-
 class GouvernanceSansNoteDeContexteRepositorySpy extends GouvernanceRepositorySpy {
-  override async find(uid: GouvernanceUid): Promise<Gouvernance | null> {
+  override async find(uid: GouvernanceUid): Promise<Gouvernance> {
     spiedGouvernanceUidToFind = uid
     return Promise.resolve(
       gouvernanceFactory({
@@ -184,7 +133,7 @@ class GouvernanceSansNoteDeContexteRepositorySpy extends GouvernanceRepositorySp
 }
 
 class GestionnaireRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur | null> {
+  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUtilisateurUidToFind = uid
     return Promise.resolve(utilisateurFactory({
       codeOrganisation: '75',
@@ -194,15 +143,8 @@ class GestionnaireRepositorySpy implements FindUtilisateurRepository {
   }
 }
 
-class GestionnaireInexistantRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur | null> {
-    spiedUtilisateurUidToFind = uid
-    return Promise.resolve(null)
-  }
-}
-
 class GestionnaireAutreRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur | null> {
+  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUtilisateurUidToFind = uid
     return Promise.resolve(utilisateurFactory({ codeOrganisation: '10', role: 'Gestionnaire département' }))
   }

--- a/src/use-cases/commands/ModifierUneNoteDeContexte.ts
+++ b/src/use-cases/commands/ModifierUneNoteDeContexte.ts
@@ -1,6 +1,6 @@
 import { CommandHandler, ResultAsync } from '../CommandHandler'
-import { FindGouvernanceRepository, UpdateGouvernanceRepository } from './shared/GouvernanceRepository'
-import { FindUtilisateurRepository } from './shared/UtilisateurRepository'
+import { GetGouvernanceRepository, UpdateGouvernanceRepository } from './shared/GouvernanceRepository'
+import { GetUtilisateurRepository } from './shared/UtilisateurRepository'
 import { GouvernanceFailure, GouvernanceUid, NoteDeContexte } from '@/domain/Gouvernance'
 import { UtilisateurUid } from '@/domain/Utilisateur'
 import { isOk } from '@/shared/lang'
@@ -20,9 +20,9 @@ export class ModifierUneNoteDeContexte implements CommandHandler<Command> {
     this.#date = date
   }
 
-  async execute(command: Command): ResultAsync<Failure> {
-    const editeur = await this.#utilisateurRepository.find(command.uidEditeur)
-    const gouvernance = await this.#gouvernanceRepository.find(new GouvernanceUid(command.uidGouvernance))
+  async handle(command: Command): ResultAsync<Failure> {
+    const editeur = await this.#utilisateurRepository.get(command.uidEditeur)
+    const gouvernance = await this.#gouvernanceRepository.get(new GouvernanceUid(command.uidGouvernance))
     if (!gouvernance.peutEtreGerePar(editeur)) {
       return 'editeurNePeutPasModifierNoteDeContexte'
     }
@@ -45,6 +45,6 @@ type Command = Readonly<{
   uidGouvernance: string
 }>
 
-interface GouvernanceRepository extends FindGouvernanceRepository, UpdateGouvernanceRepository {}
+interface GouvernanceRepository extends GetGouvernanceRepository, UpdateGouvernanceRepository {}
 
-type UtilisateurRepository = FindUtilisateurRepository
+type UtilisateurRepository = GetUtilisateurRepository

--- a/src/use-cases/commands/ModifierUneNoteDeContexte.ts
+++ b/src/use-cases/commands/ModifierUneNoteDeContexte.ts
@@ -22,14 +22,7 @@ export class ModifierUneNoteDeContexte implements CommandHandler<Command> {
 
   async execute(command: Command): ResultAsync<Failure> {
     const editeur = await this.#utilisateurRepository.find(command.uidEditeur)
-    if (!editeur) {
-      return 'editeurInexistant'
-    }
-
     const gouvernance = await this.#gouvernanceRepository.find(new GouvernanceUid(command.uidGouvernance))
-    if (!gouvernance) {
-      return 'gouvernanceInexistante'
-    }
     if (!gouvernance.peutEtreGerePar(editeur)) {
       return 'editeurNePeutPasModifierNoteDeContexte'
     }
@@ -44,7 +37,7 @@ export class ModifierUneNoteDeContexte implements CommandHandler<Command> {
   }
 }
 
-type Failure = 'gouvernanceInexistante' | 'editeurInexistant' | 'editeurNePeutPasModifierNoteDeContexte' | GouvernanceFailure
+type Failure = 'editeurNePeutPasModifierNoteDeContexte' | GouvernanceFailure
 
 type Command = Readonly<{
   contenu: string

--- a/src/use-cases/commands/ModifierUneNotePrivee.test.ts
+++ b/src/use-cases/commands/ModifierUneNotePrivee.test.ts
@@ -1,6 +1,6 @@
 import { ModifierUneNotePrivee } from './ModifierUneNotePrivee'
-import { FindGouvernanceRepository, UpdateGouvernanceRepository } from './shared/GouvernanceRepository'
-import { FindUtilisateurRepository } from './shared/UtilisateurRepository'
+import { GetGouvernanceRepository, UpdateGouvernanceRepository } from './shared/GouvernanceRepository'
+import { GetUtilisateurRepository } from './shared/UtilisateurRepository'
 import { Gouvernance, GouvernanceUid } from '@/domain/Gouvernance'
 import { gouvernanceFactory, utilisateurFactory } from '@/domain/testHelper'
 import { Utilisateur, UtilisateurUid, UtilisateurUidState } from '@/domain/Utilisateur'
@@ -24,7 +24,7 @@ describe('modifier une note privée', () => {
     )
 
     // WHEN
-    const result = await modifierNotePrivee.execute({
+    const result = await modifierNotePrivee.handle({
       contenu,
       uidEditeur,
       uidGouvernance,
@@ -57,7 +57,7 @@ describe('modifier une note privée', () => {
     )
 
     // WHEN
-    const result = await modifierNotePrivee.execute({ contenu, uidEditeur: 'utilisateurUsurpateur', uidGouvernance })
+    const result = await modifierNotePrivee.handle({ contenu, uidEditeur: 'utilisateurUsurpateur', uidGouvernance })
 
     // THEN
     expect(spiedUtilisateurUidToFind).toBe('utilisateurUsurpateur')
@@ -75,7 +75,7 @@ describe('modifier une note privée', () => {
     )
 
     // WHEN
-    const result = await modifierNotePrivee.execute({ contenu, uidEditeur, uidGouvernance })
+    const result = await modifierNotePrivee.handle({ contenu, uidEditeur, uidGouvernance })
 
     // THEN
     expect(spiedUtilisateurUidToFind).toBe(uidEditeur)
@@ -93,8 +93,8 @@ let spiedGouvernanceUidToFind: GouvernanceUid | null
 let spiedGouvernanceToUpdate: Gouvernance | null
 let spiedUtilisateurUidToFind: string | null
 
-class GouvernanceRepositorySpy implements FindGouvernanceRepository, UpdateGouvernanceRepository {
-  async find(uid: GouvernanceUid): Promise<Gouvernance> {
+class GouvernanceRepositorySpy implements GetGouvernanceRepository, UpdateGouvernanceRepository {
+  async get(uid: GouvernanceUid): Promise<Gouvernance> {
     spiedGouvernanceUidToFind = uid
     return Promise.resolve(
       gouvernanceFactory({
@@ -122,7 +122,7 @@ class GouvernanceRepositorySpy implements FindGouvernanceRepository, UpdateGouve
 }
 
 class GouvernanceSansNotePriveeRepositorySpy extends GouvernanceRepositorySpy {
-  override async find(uid: GouvernanceUid): Promise<Gouvernance> {
+  override async get(uid: GouvernanceUid): Promise<Gouvernance> {
     spiedGouvernanceUidToFind = uid
     return Promise.resolve(
       gouvernanceFactory({
@@ -132,8 +132,8 @@ class GouvernanceSansNotePriveeRepositorySpy extends GouvernanceRepositorySpy {
   }
 }
 
-class GestionnaireRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
+class GestionnaireRepositorySpy implements GetUtilisateurRepository {
+  async get(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUtilisateurUidToFind = uid
     return Promise.resolve(utilisateurFactory({
       codeOrganisation: '75',
@@ -143,8 +143,8 @@ class GestionnaireRepositorySpy implements FindUtilisateurRepository {
   }
 }
 
-class GestionnaireAutreRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
+class GestionnaireAutreRepositorySpy implements GetUtilisateurRepository {
+  async get(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUtilisateurUidToFind = uid
     return Promise.resolve(utilisateurFactory({ codeOrganisation: '10', role: 'Gestionnaire département' }))
   }

--- a/src/use-cases/commands/ModifierUneNotePrivee.test.ts
+++ b/src/use-cases/commands/ModifierUneNotePrivee.test.ts
@@ -6,14 +6,14 @@ import { gouvernanceFactory, utilisateurFactory } from '@/domain/testHelper'
 import { Utilisateur, UtilisateurUid, UtilisateurUidState } from '@/domain/Utilisateur'
 import { epochTime } from '@/shared/testHelper'
 
-describe('modifier une note privée à une gouvernance', () => {
+describe('modifier une note privée', () => {
   beforeEach(() => {
     spiedGouvernanceUidToFind = null
     spiedGouvernanceToUpdate = null
     spiedUtilisateurUidToFind = null
   })
 
-  it('étant donné une gouvernance existante, quand une note privée est modifiée par son gestionnaire, alors elle est modifiée', async () => {
+  it('étant donné une gouvernance, quand une note privée est modifiée par son gestionnaire, alors elle est modifiée', async () => {
     // GIVEN
     const dateDeModification = epochTime
     const uidEditeur = 'userFooId2'
@@ -48,7 +48,7 @@ describe('modifier une note privée à une gouvernance', () => {
     expect(result).toBe('OK')
   })
 
-  it('étant donné une gouvernance existante, quand un note privée est modifiée par un gestionnaire qui n’a pas ce droit, alors une erreur est renvoyée', async () => {
+  it('étant donné une gouvernance, quand un note privée est modifiée par un gestionnaire qui n’a pas ce droit, alors une erreur est renvoyée', async () => {
     // GIVEN
     const modifierNotePrivee = new ModifierUneNotePrivee(
       new GouvernanceRepositorySpy(),
@@ -66,7 +66,7 @@ describe('modifier une note privée à une gouvernance', () => {
     expect(result).toBe('editeurNePeutPasModifierNotePrivee')
   })
 
-  it('étant donné une gouvernance existante, quand un note privée est modifiée par un gestionnaire département mais qu’une note privée n’existe pas, alors une erreur est renvoyée', async () => {
+  it('étant donné une gouvernance, quand un note privée est modifiée par un gestionnaire département mais qu’une note privée n’existe pas, alors une erreur est renvoyée', async () => {
     // GIVEN
     const modifierNotePrivee = new ModifierUneNotePrivee(
       new GouvernanceSansNotePriveeRepositorySpy(),
@@ -83,50 +83,6 @@ describe('modifier une note privée à une gouvernance', () => {
     expect(spiedGouvernanceToUpdate).toBeNull()
     expect(result).toBe('notePriveeInexistante')
   })
-
-  it('étant donné une gouvernance inexistante, quand une note privée est modifiée, alors une erreur est renvoyée', async () => {
-    // GIVEN
-    const modifierNotePrivee = new ModifierUneNotePrivee(
-      new GouvernanceInexistanteRepositorySpy(),
-      new GestionnaireRepositorySpy(),
-      epochTime
-    )
-
-    // WHEN
-    const result = await modifierNotePrivee.execute({
-      contenu,
-      uidEditeur,
-      uidGouvernance,
-    })
-
-    // THEN
-    expect(spiedUtilisateurUidToFind).toBe(uidEditeur)
-    expect(spiedGouvernanceUidToFind?.state).toStrictEqual(new GouvernanceUid(uidGouvernance).state)
-    expect(spiedGouvernanceToUpdate).toBeNull()
-    expect(result).toBe('gouvernanceInexistante')
-  })
-
-  it('étant donné un utilisateur inexistant, quand une note privée est modifiée, alors une erreur est renvoyée', async () => {
-    // GIVEN
-    const modifierNotePrivee = new ModifierUneNotePrivee(
-      new GouvernanceInexistanteRepositorySpy(),
-      new GestionnaireInexistantRepositorySpy(),
-      epochTime
-    )
-
-    // WHEN
-    const result = await modifierNotePrivee.execute({
-      contenu,
-      uidEditeur,
-      uidGouvernance,
-    })
-
-    // THEN
-    expect(spiedUtilisateurUidToFind).toBe(uidEditeur)
-    expect(spiedGouvernanceUidToFind).toBeNull()
-    expect(spiedGouvernanceToUpdate).toBeNull()
-    expect(result).toBe('editeurInexistant')
-  })
 })
 
 const contenu = 'Lorem ipsum dolor sit amet consectetur. Sagittis dui sapien libero tristique leo tortor.'
@@ -138,7 +94,7 @@ let spiedGouvernanceToUpdate: Gouvernance | null
 let spiedUtilisateurUidToFind: string | null
 
 class GouvernanceRepositorySpy implements FindGouvernanceRepository, UpdateGouvernanceRepository {
-  async find(uid: GouvernanceUid): Promise<Gouvernance | null> {
+  async find(uid: GouvernanceUid): Promise<Gouvernance> {
     spiedGouvernanceUidToFind = uid
     return Promise.resolve(
       gouvernanceFactory({
@@ -165,15 +121,8 @@ class GouvernanceRepositorySpy implements FindGouvernanceRepository, UpdateGouve
   }
 }
 
-class GouvernanceInexistanteRepositorySpy extends GouvernanceRepositorySpy {
-  override async find(uid: GouvernanceUid): Promise<Gouvernance | null> {
-    spiedGouvernanceUidToFind = uid
-    return Promise.resolve(null)
-  }
-}
-
 class GouvernanceSansNotePriveeRepositorySpy extends GouvernanceRepositorySpy {
-  override async find(uid: GouvernanceUid): Promise<Gouvernance | null> {
+  override async find(uid: GouvernanceUid): Promise<Gouvernance> {
     spiedGouvernanceUidToFind = uid
     return Promise.resolve(
       gouvernanceFactory({
@@ -184,7 +133,7 @@ class GouvernanceSansNotePriveeRepositorySpy extends GouvernanceRepositorySpy {
 }
 
 class GestionnaireRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur | null> {
+  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUtilisateurUidToFind = uid
     return Promise.resolve(utilisateurFactory({
       codeOrganisation: '75',
@@ -194,15 +143,8 @@ class GestionnaireRepositorySpy implements FindUtilisateurRepository {
   }
 }
 
-class GestionnaireInexistantRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur | null> {
-    spiedUtilisateurUidToFind = uid
-    return Promise.resolve(null)
-  }
-}
-
 class GestionnaireAutreRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur | null> {
+  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUtilisateurUidToFind = uid
     return Promise.resolve(utilisateurFactory({ codeOrganisation: '10', role: 'Gestionnaire département' }))
   }

--- a/src/use-cases/commands/ModifierUneNotePrivee.ts
+++ b/src/use-cases/commands/ModifierUneNotePrivee.ts
@@ -1,6 +1,6 @@
 import { CommandHandler, ResultAsync } from '../CommandHandler'
-import { FindGouvernanceRepository, UpdateGouvernanceRepository } from './shared/GouvernanceRepository'
-import { FindUtilisateurRepository } from './shared/UtilisateurRepository'
+import { GetGouvernanceRepository, UpdateGouvernanceRepository } from './shared/GouvernanceRepository'
+import { GetUtilisateurRepository } from './shared/UtilisateurRepository'
 import { GouvernanceFailure, GouvernanceUid, NotePrivee } from '@/domain/Gouvernance'
 import { UtilisateurUid } from '@/domain/Utilisateur'
 import { isOk } from '@/shared/lang'
@@ -20,9 +20,9 @@ export class ModifierUneNotePrivee implements CommandHandler<Command> {
     this.#date = date
   }
 
-  async execute(command: Command): ResultAsync<Failure> {
-    const editeur = await this.#utilisateurRepository.find(command.uidEditeur)
-    const gouvernance = await this.#gouvernanceRepository.find(new GouvernanceUid(command.uidGouvernance))
+  async handle(command: Command): ResultAsync<Failure> {
+    const editeur = await this.#utilisateurRepository.get(command.uidEditeur)
+    const gouvernance = await this.#gouvernanceRepository.get(new GouvernanceUid(command.uidGouvernance))
 
     if (!gouvernance.peutEtreGerePar(editeur)) {
       return 'editeurNePeutPasModifierNotePrivee'
@@ -49,6 +49,6 @@ type Command = Readonly<{
   uidGouvernance: string
 }>
 
-interface GouvernanceRepository extends FindGouvernanceRepository, UpdateGouvernanceRepository {}
+interface GouvernanceRepository extends GetGouvernanceRepository, UpdateGouvernanceRepository {}
 
-type UtilisateurRepository = FindUtilisateurRepository
+type UtilisateurRepository = GetUtilisateurRepository

--- a/src/use-cases/commands/ModifierUneNotePrivee.ts
+++ b/src/use-cases/commands/ModifierUneNotePrivee.ts
@@ -22,14 +22,7 @@ export class ModifierUneNotePrivee implements CommandHandler<Command> {
 
   async execute(command: Command): ResultAsync<Failure> {
     const editeur = await this.#utilisateurRepository.find(command.uidEditeur)
-    if (!editeur) {
-      return 'editeurInexistant'
-    }
-
     const gouvernance = await this.#gouvernanceRepository.find(new GouvernanceUid(command.uidGouvernance))
-    if (!gouvernance) {
-      return 'gouvernanceInexistante'
-    }
 
     if (!gouvernance.peutEtreGerePar(editeur)) {
       return 'editeurNePeutPasModifierNotePrivee'
@@ -48,7 +41,7 @@ export class ModifierUneNotePrivee implements CommandHandler<Command> {
   }
 }
 
-type Failure = 'gouvernanceInexistante' | 'editeurInexistant' | 'editeurNePeutPasModifierNotePrivee' | GouvernanceFailure
+type Failure = 'editeurNePeutPasModifierNotePrivee' | GouvernanceFailure
 
 type Command = Readonly<{
   contenu: string

--- a/src/use-cases/commands/ReinviterUnUtilisateur.test.ts
+++ b/src/use-cases/commands/ReinviterUnUtilisateur.test.ts
@@ -53,24 +53,6 @@ describe('réinviter un utilisateur', () => {
     expect(spiedUtilisateurToUpdate).toBeNull()
   })
 
-  it('étant donné que le compte de l’utilisateur courant est inexistant, quand il réinvite un autre utilisateur, alors il y a une erreur', async () => {
-    // GIVEN
-    const repository = new RepositorySpy()
-    const reinviterUnUtilisateur = new ReinviterUnUtilisateur(repository, emailGatewayFactorySpy, epochTime)
-    const command = {
-      uidUtilisateurAReinviter: 'uidUtilisateurAReinviterInactif',
-      uidUtilisateurCourant: 'utilisateurInexistantUid',
-    }
-
-    // WHEN
-    const result = await reinviterUnUtilisateur.execute(command)
-
-    // THEN
-    expect(result).toBe('utilisateurCourantInexistant')
-    expect(spiedUidToFind).toBe('utilisateurInexistantUid')
-    expect(spiedUtilisateurToUpdate).toBeNull()
-  })
-
   it('étant donné que le compte de l’utilisateur à réinviter est déjà actif, quand il est réinvité, alors il y a une erreur', async () => {
     // GIVEN
     const repository = new RepositorySpy()
@@ -86,24 +68,6 @@ describe('réinviter un utilisateur', () => {
     // THEN
     expect(result).toBe('utilisateurAReinviterDejaActif')
     expect(spiedUidToFind).toBe('uidUtilisateurAReinviterActif')
-    expect(spiedUtilisateurToUpdate).toBeNull()
-  })
-
-  it('étant donné que le compte de l’utilisateur est inexistant, quand il est réinvité, alors il y a une erreur', async () => {
-    // GIVEN
-    const repository = new RepositorySpy()
-    const reinviterUnUtilisateur = new ReinviterUnUtilisateur(repository, emailGatewayFactorySpy, epochTime)
-    const command = {
-      uidUtilisateurAReinviter: 'uidUtilisateurAReinviterInexistant',
-      uidUtilisateurCourant: 'uidUtilisateurCourantAvecRoleDifferent',
-    }
-
-    // WHEN
-    const result = await reinviterUnUtilisateur.execute(command)
-
-    // THEN
-    expect(result).toBe('utilisateurAReinviterInexistant')
-    expect(spiedUidToFind).toBe('uidUtilisateurAReinviterInexistant')
     expect(spiedUtilisateurToUpdate).toBeNull()
   })
 
@@ -156,7 +120,7 @@ let spiedUtilisateurToUpdate: Utilisateur | null
 let spiedDestinataire: string
 
 class RepositorySpy implements UpdateUtilisateurRepository, FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur | null> {
+  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUidToFind = uid
     return Promise.resolve(utilisateursByUid[uid])
   }

--- a/src/use-cases/commands/ReinviterUnUtilisateur.test.ts
+++ b/src/use-cases/commands/ReinviterUnUtilisateur.test.ts
@@ -1,6 +1,6 @@
 import { ReinviterUnUtilisateur } from './ReinviterUnUtilisateur'
 import { EmailGateway } from './shared/EmailGateway'
-import { FindUtilisateurRepository, UpdateUtilisateurRepository } from './shared/UtilisateurRepository'
+import { GetUtilisateurRepository, UpdateUtilisateurRepository } from './shared/UtilisateurRepository'
 import { utilisateurFactory } from '@/domain/testHelper'
 import { Utilisateur, UtilisateurUidState } from '@/domain/Utilisateur'
 import { epochTime, epochTimeMinusOneDay, invalidDate } from '@/shared/testHelper'
@@ -22,7 +22,7 @@ describe('réinviter un utilisateur', () => {
     }
 
     // WHEN
-    const result = await reinviterUnUtilisateur.execute(command)
+    const result = await reinviterUnUtilisateur.handle(command)
 
     // THEN
     expect(result).toBe('OK')
@@ -45,7 +45,7 @@ describe('réinviter un utilisateur', () => {
     }
 
     // WHEN
-    const result = await reinviterUnUtilisateur.execute(command)
+    const result = await reinviterUnUtilisateur.handle(command)
 
     // THEN
     expect(result).toBe('utilisateurNePeutPasGererUtilisateurAReinviter')
@@ -63,7 +63,7 @@ describe('réinviter un utilisateur', () => {
     }
 
     // WHEN
-    const result = await reinviterUnUtilisateur.execute(command)
+    const result = await reinviterUnUtilisateur.handle(command)
 
     // THEN
     expect(result).toBe('utilisateurAReinviterDejaActif')
@@ -85,7 +85,7 @@ describe('réinviter un utilisateur', () => {
     }
 
     // WHEN
-    const asyncResult = reinviterUnUtilisateur.execute(command)
+    const asyncResult = reinviterUnUtilisateur.handle(command)
 
     // THEN
     await expect(asyncResult).rejects.toThrow('dateDInvitationInvalide')
@@ -119,8 +119,8 @@ let spiedUidToFind: string
 let spiedUtilisateurToUpdate: Utilisateur | null
 let spiedDestinataire: string
 
-class RepositorySpy implements UpdateUtilisateurRepository, FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
+class RepositorySpy implements UpdateUtilisateurRepository, GetUtilisateurRepository {
+  async get(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUidToFind = uid
     return Promise.resolve(utilisateursByUid[uid])
   }

--- a/src/use-cases/commands/ReinviterUnUtilisateur.ts
+++ b/src/use-cases/commands/ReinviterUnUtilisateur.ts
@@ -1,6 +1,6 @@
 import { CommandHandler, ResultAsync } from '../CommandHandler'
 import { EmailGatewayFactory } from './shared/EmailGateway'
-import { FindUtilisateurRepository, UpdateUtilisateurRepository } from './shared/UtilisateurRepository'
+import { GetUtilisateurRepository, UpdateUtilisateurRepository } from './shared/UtilisateurRepository'
 import { UtilisateurFailure } from '@/domain/Utilisateur'
 
 export class ReinviterUnUtilisateur implements CommandHandler<Command> {
@@ -18,10 +18,10 @@ export class ReinviterUnUtilisateur implements CommandHandler<Command> {
     this.#date = date
   }
 
-  async execute(command: Command): ResultAsync<Failure> {
-    const utilisateurCourant = await this.#utilisateurRepository.find(command.uidUtilisateurCourant)
+  async handle(command: Command): ResultAsync<Failure> {
+    const utilisateurCourant = await this.#utilisateurRepository.get(command.uidUtilisateurCourant)
 
-    const utilisateurAReinviter = await this.#utilisateurRepository.find(command.uidUtilisateurAReinviter)
+    const utilisateurAReinviter = await this.#utilisateurRepository.get(command.uidUtilisateurAReinviter)
     if (utilisateurAReinviter.state.isActive) {
       return 'utilisateurAReinviterDejaActif'
     }
@@ -45,4 +45,4 @@ type Command = Readonly<{
   uidUtilisateurCourant: string
 }>
 
-interface UtilisateurRepository extends FindUtilisateurRepository, UpdateUtilisateurRepository {}
+interface UtilisateurRepository extends GetUtilisateurRepository, UpdateUtilisateurRepository {}

--- a/src/use-cases/commands/ReinviterUnUtilisateur.ts
+++ b/src/use-cases/commands/ReinviterUnUtilisateur.ts
@@ -20,14 +20,8 @@ export class ReinviterUnUtilisateur implements CommandHandler<Command> {
 
   async execute(command: Command): ResultAsync<Failure> {
     const utilisateurCourant = await this.#utilisateurRepository.find(command.uidUtilisateurCourant)
-    if (!utilisateurCourant) {
-      return 'utilisateurCourantInexistant'
-    }
 
     const utilisateurAReinviter = await this.#utilisateurRepository.find(command.uidUtilisateurAReinviter)
-    if (!utilisateurAReinviter) {
-      return 'utilisateurAReinviterInexistant'
-    }
     if (utilisateurAReinviter.state.isActive) {
       return 'utilisateurAReinviterDejaActif'
     }
@@ -44,12 +38,7 @@ export class ReinviterUnUtilisateur implements CommandHandler<Command> {
   }
 }
 
-type Failure =
-  | 'utilisateurCourantInexistant'
-  | 'utilisateurAReinviterInexistant'
-  | 'utilisateurAReinviterDejaActif'
-  | 'utilisateurNePeutPasGererUtilisateurAReinviter'
-  | UtilisateurFailure
+type Failure = 'utilisateurAReinviterDejaActif' | 'utilisateurNePeutPasGererUtilisateurAReinviter' | UtilisateurFailure
 
 type Command = Readonly<{
   uidUtilisateurAReinviter: string

--- a/src/use-cases/commands/SupprimerUnComite.test.ts
+++ b/src/use-cases/commands/SupprimerUnComite.test.ts
@@ -1,6 +1,6 @@
-import { DropComiteRepository, FindComiteRepository } from './shared/ComiteRepository'
-import { FindGouvernanceRepository } from './shared/GouvernanceRepository'
-import { FindUtilisateurRepository } from './shared/UtilisateurRepository'
+import { DropComiteRepository, GetComiteRepository } from './shared/ComiteRepository'
+import { GetGouvernanceRepository } from './shared/GouvernanceRepository'
+import { GetUtilisateurRepository } from './shared/UtilisateurRepository'
 import { SupprimerUnComite } from './SupprimerUnComite'
 import { Comite } from '@/domain/Comite'
 import { Gouvernance, GouvernanceUid } from '@/domain/Gouvernance'
@@ -24,7 +24,7 @@ describe('supprimer un comité', () => {
     )
 
     // WHEN
-    const result = await supprimerUnComite.execute({
+    const result = await supprimerUnComite.handle({
       uid: uidComite,
       uidEditeur,
       uidGouvernance,
@@ -60,7 +60,7 @@ describe('supprimer un comité', () => {
     )
 
     // WHEN
-    const result = await supprimerUnComite.execute({
+    const result = await supprimerUnComite.handle({
       uid: uidComite,
       uidEditeur,
       uidGouvernance,
@@ -83,8 +83,8 @@ let spiedUtilisateurUidToFind: UtilisateurUidState['value'] | null
 let spiedComiteToDrop: Comite | null
 let spiedComiteUidToFind: Comite['uid']['state']['value'] | null
 
-class GouvernanceRepositorySpy implements FindGouvernanceRepository {
-  async find(uid: GouvernanceUid): Promise<Gouvernance> {
+class GouvernanceRepositorySpy implements GetGouvernanceRepository {
+  async get(uid: GouvernanceUid): Promise<Gouvernance> {
     spiedGouvernanceUidToFind = uid
     return Promise.resolve(
       gouvernanceFactory({
@@ -100,8 +100,8 @@ class GouvernanceRepositorySpy implements FindGouvernanceRepository {
   }
 }
 
-class GestionnaireRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
+class GestionnaireRepositorySpy implements GetUtilisateurRepository {
+  async get(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUtilisateurUidToFind = uid
     return Promise.resolve(utilisateurFactory({
       codeOrganisation: '75',
@@ -111,15 +111,15 @@ class GestionnaireRepositorySpy implements FindUtilisateurRepository {
   }
 }
 
-class GestionnaireAutreRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
+class GestionnaireAutreRepositorySpy implements GetUtilisateurRepository {
+  async get(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUtilisateurUidToFind = uid
     return Promise.resolve(utilisateurFactory({ codeOrganisation: '10', role: 'Gestionnaire département' }))
   }
 }
 
-class ComiteRepositorySpy implements DropComiteRepository, FindComiteRepository {
-  async find(uid: Comite['uid']['state']['value']): Promise<Comite> {
+class ComiteRepositorySpy implements DropComiteRepository, GetComiteRepository {
+  async get(uid: Comite['uid']['state']['value']): Promise<Comite> {
     spiedComiteUidToFind = uid
     return Promise.resolve(comiteFactory({
       uid: { value: uidComite },

--- a/src/use-cases/commands/SupprimerUnComite.test.ts
+++ b/src/use-cases/commands/SupprimerUnComite.test.ts
@@ -15,7 +15,7 @@ describe('supprimer un comité', () => {
     spiedComiteUidToFind = null
   })
 
-  it('étant donné une gouvernance existante, quand un comité est supprimé par son gestionnaire, alors il est supprimé', async () => {
+  it('étant donné une gouvernance, quand un comité est supprimé par son gestionnaire, alors il est supprimé', async () => {
     // GIVEN
     const supprimerUnComite = new SupprimerUnComite(
       new GouvernanceRepositorySpy(),
@@ -51,7 +51,7 @@ describe('supprimer un comité', () => {
     expect(result).toBe('OK')
   })
 
-  it('étant donné une gouvernance existante, quand un comité est supprimé par un gestionnaire autre que celui de la gouvernance, alors une erreur est renvoyée', async () => {
+  it('étant donné une gouvernance, quand un comité est supprimé par un gestionnaire autre que celui de la gouvernance, alors une erreur est renvoyée', async () => {
     // GIVEN
     const supprimerUnComite = new SupprimerUnComite(
       new GouvernanceRepositorySpy(),
@@ -72,73 +72,6 @@ describe('supprimer un comité', () => {
     expect(result).toBe('editeurNePeutPasSupprimerComite')
     expect(spiedComiteToDrop).toBeNull()
   })
-
-  it('étant donné une gouvernance inexistante, quand un comité est supprimé, alors une erreur est renvoyée', async () => {
-    // GIVEN
-    const supprimerUnComite = new SupprimerUnComite(
-      new GouvernanceInexistanteRepositorySpy(),
-      new GestionnaireRepositorySpy(),
-      new ComiteRepositorySpy()
-    )
-
-    // WHEN
-    const result = await supprimerUnComite.execute({
-      uid: uidComite,
-      uidEditeur,
-      uidGouvernance,
-    })
-
-    // THEN
-    expect(spiedUtilisateurUidToFind).toBe(uidEditeur)
-    expect(spiedGouvernanceUidToFind?.state).toStrictEqual(new GouvernanceUid(uidGouvernance).state)
-    expect(result).toBe('gouvernanceInexistante')
-    expect(spiedComiteToDrop).toBeNull()
-  })
-
-  it('étant donné un utilisateur inexistant, quand un comité est supprimé, alors une erreur est renvoyée', async () => {
-    // GIVEN
-    const supprimerUnComite = new SupprimerUnComite(
-      new GouvernanceRepositorySpy(),
-      new GestionnaireInexistantRepositorySpy(),
-      new ComiteRepositorySpy()
-    )
-
-    // WHEN
-    const result = await supprimerUnComite.execute({
-      uid: uidComite,
-      uidEditeur,
-      uidGouvernance,
-    })
-
-    // THEN
-    expect(spiedUtilisateurUidToFind).toBe(uidEditeur)
-    expect(result).toBe('editeurInexistant')
-    expect(spiedGouvernanceUidToFind).toBeNull()
-    expect(spiedComiteToDrop).toBeNull()
-  })
-
-  it('étant donné un comité inexistant, quand un comité est supprimé, alors une erreur est renvoyée', async () => {
-    // GIVEN
-    const supprimerUnComite = new SupprimerUnComite(
-      new GouvernanceRepositorySpy(),
-      new GestionnaireRepositorySpy(),
-      new ComiteInexistantRepositorySpy()
-    )
-
-    // WHEN
-    const result = await supprimerUnComite.execute({
-      uid: uidComite,
-      uidEditeur,
-      uidGouvernance,
-    })
-
-    // THEN
-    expect(spiedUtilisateurUidToFind).toBe(uidEditeur)
-    expect(spiedGouvernanceUidToFind?.state).toStrictEqual(new GouvernanceUid(uidGouvernance).state)
-    expect(spiedComiteUidToFind).toBe(uidComite)
-    expect(result).toBe('comiteInexistant')
-    expect(spiedComiteToDrop).toBeNull()
-  })
 })
 
 const uidComite = 'comiteFooId'
@@ -151,7 +84,7 @@ let spiedComiteToDrop: Comite | null
 let spiedComiteUidToFind: Comite['uid']['state']['value'] | null
 
 class GouvernanceRepositorySpy implements FindGouvernanceRepository {
-  async find(uid: GouvernanceUid): Promise<Gouvernance | null> {
+  async find(uid: GouvernanceUid): Promise<Gouvernance> {
     spiedGouvernanceUidToFind = uid
     return Promise.resolve(
       gouvernanceFactory({
@@ -167,15 +100,8 @@ class GouvernanceRepositorySpy implements FindGouvernanceRepository {
   }
 }
 
-class GouvernanceInexistanteRepositorySpy extends GouvernanceRepositorySpy {
-  override async find(uid: GouvernanceUid): Promise<Gouvernance | null> {
-    spiedGouvernanceUidToFind = uid
-    return Promise.resolve(null)
-  }
-}
-
 class GestionnaireRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur | null> {
+  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUtilisateurUidToFind = uid
     return Promise.resolve(utilisateurFactory({
       codeOrganisation: '75',
@@ -185,22 +111,15 @@ class GestionnaireRepositorySpy implements FindUtilisateurRepository {
   }
 }
 
-class GestionnaireInexistantRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur | null> {
-    spiedUtilisateurUidToFind = uid
-    return Promise.resolve(null)
-  }
-}
-
 class GestionnaireAutreRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur | null> {
+  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUtilisateurUidToFind = uid
     return Promise.resolve(utilisateurFactory({ codeOrganisation: '10', role: 'Gestionnaire département' }))
   }
 }
 
 class ComiteRepositorySpy implements DropComiteRepository, FindComiteRepository {
-  async find(uid: Comite['uid']['state']['value']): Promise<Comite | null> {
+  async find(uid: Comite['uid']['state']['value']): Promise<Comite> {
     spiedComiteUidToFind = uid
     return Promise.resolve(comiteFactory({
       uid: { value: uidComite },
@@ -212,12 +131,5 @@ class ComiteRepositorySpy implements DropComiteRepository, FindComiteRepository 
   async drop(comite: Comite): Promise<void> {
     spiedComiteToDrop = comite
     return Promise.resolve()
-  }
-}
-
-class ComiteInexistantRepositorySpy extends ComiteRepositorySpy {
-  override async find(uid: Comite['uid']['state']['value']): Promise<Comite | null> {
-    spiedComiteUidToFind = uid
-    return Promise.resolve(null)
   }
 }

--- a/src/use-cases/commands/SupprimerUnComite.ts
+++ b/src/use-cases/commands/SupprimerUnComite.ts
@@ -1,7 +1,7 @@
 import { CommandHandler, ResultAsync } from '../CommandHandler'
-import { DropComiteRepository, FindComiteRepository } from './shared/ComiteRepository'
-import { FindGouvernanceRepository } from './shared/GouvernanceRepository'
-import { FindUtilisateurRepository } from './shared/UtilisateurRepository'
+import { DropComiteRepository, GetComiteRepository } from './shared/ComiteRepository'
+import { GetGouvernanceRepository } from './shared/GouvernanceRepository'
+import { GetUtilisateurRepository } from './shared/UtilisateurRepository'
 import { GouvernanceUid } from '@/domain/Gouvernance'
 
 export class SupprimerUnComite implements CommandHandler<Command> {
@@ -19,11 +19,11 @@ export class SupprimerUnComite implements CommandHandler<Command> {
     this.#comiteRepository = comiteRepository
   }
 
-  async execute(command: Command): ResultAsync<Failure> {
-    const editeur = await this.#utilisateurRepository.find(command.uidEditeur)
-    const gouvernance = await this.#gouvernanceRepository.find(new GouvernanceUid(command.uidGouvernance))
+  async handle(command: Command): ResultAsync<Failure> {
+    const editeur = await this.#utilisateurRepository.get(command.uidEditeur)
+    const gouvernance = await this.#gouvernanceRepository.get(new GouvernanceUid(command.uidGouvernance))
 
-    const comite = await this.#comiteRepository.find(command.uid)
+    const comite = await this.#comiteRepository.get(command.uid)
 
     if (!gouvernance.peutEtreGerePar(editeur)) {
       return 'editeurNePeutPasSupprimerComite'
@@ -43,8 +43,8 @@ type Command = Readonly<{
   uidGouvernance: string
 }>
 
-type GouvernanceRepository = FindGouvernanceRepository
+type GouvernanceRepository = GetGouvernanceRepository
 
-type UtilisateurRepository = FindUtilisateurRepository
+type UtilisateurRepository = GetUtilisateurRepository
 
-interface ComiteRepository extends DropComiteRepository, FindComiteRepository {}
+interface ComiteRepository extends DropComiteRepository, GetComiteRepository {}

--- a/src/use-cases/commands/SupprimerUnComite.ts
+++ b/src/use-cases/commands/SupprimerUnComite.ts
@@ -21,19 +21,9 @@ export class SupprimerUnComite implements CommandHandler<Command> {
 
   async execute(command: Command): ResultAsync<Failure> {
     const editeur = await this.#utilisateurRepository.find(command.uidEditeur)
-    if (!editeur) {
-      return 'editeurInexistant'
-    }
-
     const gouvernance = await this.#gouvernanceRepository.find(new GouvernanceUid(command.uidGouvernance))
-    if (!gouvernance) {
-      return 'gouvernanceInexistante'
-    }
 
     const comite = await this.#comiteRepository.find(command.uid)
-    if (!comite) {
-      return 'comiteInexistant'
-    }
 
     if (!gouvernance.peutEtreGerePar(editeur)) {
       return 'editeurNePeutPasSupprimerComite'
@@ -45,7 +35,7 @@ export class SupprimerUnComite implements CommandHandler<Command> {
   }
 }
 
-type Failure = 'gouvernanceInexistante' | 'editeurInexistant' | 'comiteInexistant' | 'editeurNePeutPasSupprimerComite'
+type Failure = 'editeurNePeutPasSupprimerComite'
 
 type Command = Readonly<{
   uid: string

--- a/src/use-cases/commands/SupprimerUnUtilisateur.test.ts
+++ b/src/use-cases/commands/SupprimerUnUtilisateur.test.ts
@@ -9,38 +9,6 @@ describe('supprimer un utilisateur', () => {
     spiedUtilisateurToDrop = null
   })
 
-  it('l’utilisateur courant n’existe pas : échec de suppression', async () => {
-    // GIVEN
-    const supprimerUnUtilisateur = new SupprimerUnUtilisateur(new UtilisateurRepositorySpy())
-
-    // WHEN
-    const result = await supprimerUnUtilisateur.execute({
-      uidUtilisateurASupprimer: 'utilisateurASupprimerExistantUid',
-      uidUtilisateurCourant: 'utilisateurCourantInexistantUid',
-    })
-
-    // THEN
-    expect(spiedUidsToFind).toStrictEqual(['utilisateurCourantInexistantUid'])
-    expect(spiedUtilisateurToDrop).toBeNull()
-    expect(result).toBe('utilisateurCourantInexistant')
-  })
-
-  it('l’utilisateur à supprimer n’existe pas : échec de suppression', async () => {
-    // GIVEN
-    const supprimerUnUtilisateur = new SupprimerUnUtilisateur(new UtilisateurRepositorySpy())
-
-    // WHEN
-    const result = await supprimerUnUtilisateur.execute({
-      uidUtilisateurASupprimer: 'utilisateurASupprimerInexistantUid',
-      uidUtilisateurCourant: 'utilisateurCourantExistantUid',
-    })
-
-    // THEN
-    expect(spiedUidsToFind).toStrictEqual(['utilisateurCourantExistantUid', 'utilisateurASupprimerInexistantUid'])
-    expect(spiedUtilisateurToDrop).toBeNull()
-    expect(result).toBe('compteASupprimerInexistant')
-  })
-
   it('l’utilisateur courant n’est pas autorisé à supprimer l’utilisateur qu’il souhaite supprimer : échec de suppression', async () => {
     // GIVEN
     const supprimerUnUtilisateur = new SupprimerUnUtilisateur(new UtilisateurRepositorySpy())
@@ -60,8 +28,8 @@ describe('supprimer un utilisateur', () => {
     expect(result).toBe('suppressionNonAutorisee')
   })
 
-  it('les deux utilisateurs existent et l’utilisateur courant est autorisé à supprimer celui qu’il souhaite' +
-    ' supprimer, mais ce dernier a été supprimé entre-temps : échec de la suppression', async () => {
+  it('l’utilisateur courant est autorisé à supprimer celui qu’il souhaite supprimer, mais ce dernier a été supprimé'
+    + ' entre-temps : échec de la suppression', async () => {
     // GIVEN
     const commandHandler = new SupprimerUnUtilisateur(new UtilisateursSuppressionConcurrenteRepositorySpy())
 
@@ -81,8 +49,8 @@ describe('supprimer un utilisateur', () => {
     expect(result).toBe('compteASupprimerDejaSupprime')
   })
 
-  it('les deux utilisateurs existent et l’utilisateur courant est autorisé à supprimer celui qu’il souhaite' +
-    ' supprimer, qui n’a pas été supprimé entre-temps : succès de la suppression', async () => {
+  it('l’utilisateur courant est autorisé à supprimer celui qu’il souhaite supprimer, qui n’a pas été supprimé'
+    + ' entre-temps : succès de la suppression', async () => {
     // GIVEN
     const commandHandler = new SupprimerUnUtilisateur(new UtilisateurRepositorySpy())
 
@@ -121,7 +89,7 @@ const spiedUidsToFind: Array<string> = []
 let spiedUtilisateurToDrop: Utilisateur | null
 
 class UtilisateurRepositorySpy implements FindUtilisateurRepository, DropUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur | null> {
+  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUidsToFind.push(uid)
     return Promise.resolve(utilisateursByUid[uid])
   }

--- a/src/use-cases/commands/SupprimerUnUtilisateur.test.ts
+++ b/src/use-cases/commands/SupprimerUnUtilisateur.test.ts
@@ -1,4 +1,4 @@
-import { DropUtilisateurRepository, FindUtilisateurRepository } from './shared/UtilisateurRepository'
+import { DropUtilisateurRepository, GetUtilisateurRepository } from './shared/UtilisateurRepository'
 import { SupprimerUnUtilisateur } from './SupprimerUnUtilisateur'
 import { utilisateurFactory } from '@/domain/testHelper'
 import { Utilisateur, UtilisateurUid, UtilisateurUidState } from '@/domain/Utilisateur'
@@ -14,7 +14,7 @@ describe('supprimer un utilisateur', () => {
     const supprimerUnUtilisateur = new SupprimerUnUtilisateur(new UtilisateurRepositorySpy())
 
     // WHEN
-    const result = await supprimerUnUtilisateur.execute({
+    const result = await supprimerUnUtilisateur.handle({
       uidUtilisateurASupprimer: 'utilisateurASupprimerExistantUid',
       uidUtilisateurCourant: 'utilisateurCourantExistantUid',
     })
@@ -34,7 +34,7 @@ describe('supprimer un utilisateur', () => {
     const commandHandler = new SupprimerUnUtilisateur(new UtilisateursSuppressionConcurrenteRepositorySpy())
 
     // WHEN
-    const result = await commandHandler.execute({
+    const result = await commandHandler.handle({
       uidUtilisateurASupprimer: 'utilisateurASupprimerExistantUid',
       uidUtilisateurCourant: 'utilisateurCourantExistantAutreUid',
     })
@@ -55,7 +55,7 @@ describe('supprimer un utilisateur', () => {
     const commandHandler = new SupprimerUnUtilisateur(new UtilisateurRepositorySpy())
 
     // WHEN
-    const result = await commandHandler.execute({
+    const result = await commandHandler.handle({
       uidUtilisateurASupprimer: 'utilisateurASupprimerExistantUid',
       uidUtilisateurCourant: 'utilisateurCourantExistantAutreUid',
     })
@@ -88,8 +88,8 @@ const utilisateursByUid: Readonly<Record<string, Utilisateur>> = {
 const spiedUidsToFind: Array<string> = []
 let spiedUtilisateurToDrop: Utilisateur | null
 
-class UtilisateurRepositorySpy implements FindUtilisateurRepository, DropUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
+class UtilisateurRepositorySpy implements GetUtilisateurRepository, DropUtilisateurRepository {
+  async get(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUidsToFind.push(uid)
     return Promise.resolve(utilisateursByUid[uid])
   }

--- a/src/use-cases/commands/SupprimerUnUtilisateur.ts
+++ b/src/use-cases/commands/SupprimerUnUtilisateur.ts
@@ -1,5 +1,5 @@
 import { CommandHandler, ResultAsync } from '../CommandHandler'
-import { DropUtilisateurRepository, FindUtilisateurRepository } from './shared/UtilisateurRepository'
+import { DropUtilisateurRepository, GetUtilisateurRepository } from './shared/UtilisateurRepository'
 
 export class SupprimerUnUtilisateur implements CommandHandler<Command> {
   readonly #utilisateurRepository: UtilisateurRepository
@@ -8,9 +8,9 @@ export class SupprimerUnUtilisateur implements CommandHandler<Command> {
     this.#utilisateurRepository = utilisateurRepository
   }
 
-  async execute(command: Command): ResultAsync<Failure> {
-    const utilisateurCourant = await this.#utilisateurRepository.find(command.uidUtilisateurCourant)
-    const utilisateurASupprimer = await this.#utilisateurRepository.find(command.uidUtilisateurASupprimer)
+  async handle(command: Command): ResultAsync<Failure> {
+    const utilisateurCourant = await this.#utilisateurRepository.get(command.uidUtilisateurCourant)
+    const utilisateurASupprimer = await this.#utilisateurRepository.get(command.uidUtilisateurASupprimer)
     if (!utilisateurCourant.peutGerer(utilisateurASupprimer)) {
       return 'suppressionNonAutorisee'
     }
@@ -28,4 +28,4 @@ type Command = Readonly<{
   uidUtilisateurASupprimer: string
 }>
 
-interface UtilisateurRepository extends FindUtilisateurRepository, DropUtilisateurRepository {}
+interface UtilisateurRepository extends GetUtilisateurRepository, DropUtilisateurRepository {}

--- a/src/use-cases/commands/SupprimerUnUtilisateur.ts
+++ b/src/use-cases/commands/SupprimerUnUtilisateur.ts
@@ -10,14 +10,7 @@ export class SupprimerUnUtilisateur implements CommandHandler<Command> {
 
   async execute(command: Command): ResultAsync<Failure> {
     const utilisateurCourant = await this.#utilisateurRepository.find(command.uidUtilisateurCourant)
-    if (!utilisateurCourant) {
-      return 'utilisateurCourantInexistant'
-    }
-
     const utilisateurASupprimer = await this.#utilisateurRepository.find(command.uidUtilisateurASupprimer)
-    if (!utilisateurASupprimer) {
-      return 'compteASupprimerInexistant'
-    }
     if (!utilisateurCourant.peutGerer(utilisateurASupprimer)) {
       return 'suppressionNonAutorisee'
     }
@@ -28,11 +21,7 @@ export class SupprimerUnUtilisateur implements CommandHandler<Command> {
   }
 }
 
-type Failure =
-  | 'utilisateurCourantInexistant'
-  | 'compteASupprimerInexistant'
-  | 'suppressionNonAutorisee'
-  | 'compteASupprimerDejaSupprime'
+type Failure = 'suppressionNonAutorisee' | 'compteASupprimerDejaSupprime'
 
 type Command = Readonly<{
   uidUtilisateurCourant: string

--- a/src/use-cases/commands/SupprimerUneNotePrivee.test.ts
+++ b/src/use-cases/commands/SupprimerUneNotePrivee.test.ts
@@ -1,5 +1,5 @@
-import { FindGouvernanceRepository, UpdateGouvernanceRepository } from './shared/GouvernanceRepository'
-import { FindUtilisateurRepository } from './shared/UtilisateurRepository'
+import { GetGouvernanceRepository, UpdateGouvernanceRepository } from './shared/GouvernanceRepository'
+import { GetUtilisateurRepository } from './shared/UtilisateurRepository'
 import { SupprimerUneNotePrivee } from './SupprimerUneNotePrivee'
 import { Gouvernance, GouvernanceUid } from '@/domain/Gouvernance'
 import { gouvernanceFactory, utilisateurFactory } from '@/domain/testHelper'
@@ -22,7 +22,7 @@ describe('supprimer une note privée d’une gouvernance', () => {
     )
 
     // WHEN
-    const result = await supprimerNotePrivee.execute({
+    const result = await supprimerNotePrivee.handle({
       uidEditeur,
       uidGouvernance,
     })
@@ -47,7 +47,7 @@ describe('supprimer une note privée d’une gouvernance', () => {
     )
 
     // WHEN
-    const result = await supprimerNotePrivee.execute({ uidEditeur: 'utilisateurUsurpateur', uidGouvernance })
+    const result = await supprimerNotePrivee.handle({ uidEditeur: 'utilisateurUsurpateur', uidGouvernance })
 
     // THEN
     expect(spiedUtilisateurUidToFind).toBe('utilisateurUsurpateur')
@@ -64,8 +64,8 @@ let spiedGouvernanceUidToFind: GouvernanceUid | null
 let spiedGouvernanceToUpdate: Gouvernance | null
 let spiedUtilisateurUidToFind: string | null
 
-class GouvernanceRepositorySpy implements FindGouvernanceRepository, UpdateGouvernanceRepository {
-  async find(uid: GouvernanceUid): Promise<Gouvernance> {
+class GouvernanceRepositorySpy implements GetGouvernanceRepository, UpdateGouvernanceRepository {
+  async get(uid: GouvernanceUid): Promise<Gouvernance> {
     spiedGouvernanceUidToFind = uid
     return Promise.resolve(
       gouvernanceFactory({
@@ -92,8 +92,8 @@ class GouvernanceRepositorySpy implements FindGouvernanceRepository, UpdateGouve
   }
 }
 
-class GestionnaireRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
+class GestionnaireRepositorySpy implements GetUtilisateurRepository {
+  async get(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUtilisateurUidToFind = uid
     return Promise.resolve(utilisateurFactory({
       codeOrganisation: '75',
@@ -103,8 +103,8 @@ class GestionnaireRepositorySpy implements FindUtilisateurRepository {
   }
 }
 
-class GestionnaireAutreRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
+class GestionnaireAutreRepositorySpy implements GetUtilisateurRepository {
+  async get(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUtilisateurUidToFind = uid
     return Promise.resolve(utilisateurFactory({ codeOrganisation: '10', role: 'Gestionnaire département' }))
   }

--- a/src/use-cases/commands/SupprimerUneNotePrivee.test.ts
+++ b/src/use-cases/commands/SupprimerUneNotePrivee.test.ts
@@ -13,7 +13,7 @@ describe('supprimer une note privée d’une gouvernance', () => {
     spiedUtilisateurUidToFind = null
   })
 
-  it('étant donné une gouvernance existante, quand une note privée est supprimée par son gestionnaire, alors elle est supprimée', async () => {
+  it('étant donné une gouvernance, quand une note privée est supprimée par son gestionnaire, alors elle est supprimée', async () => {
     // GIVEN
     const uidEditeur = 'userFooId2'
     const supprimerNotePrivee = new SupprimerUneNotePrivee(
@@ -39,7 +39,7 @@ describe('supprimer une note privée d’une gouvernance', () => {
     expect(result).toBe('OK')
   })
 
-  it('étant donné une gouvernance existante, quand un note privée est supprimée par un gestionnaire qui n’a pas ce droit, alors une erreur est renvoyée', async () => {
+  it('étant donné une gouvernance, quand un note privée est supprimée par un gestionnaire qui n’a pas ce droit, alors une erreur est renvoyée', async () => {
     // GIVEN
     const supprimerNotePrivee = new SupprimerUneNotePrivee(
       new GouvernanceRepositorySpy(),
@@ -55,46 +55,6 @@ describe('supprimer une note privée d’une gouvernance', () => {
     expect(spiedGouvernanceToUpdate).toBeNull()
     expect(result).toBe('editeurNePeutPasSupprimerNotePrivee')
   })
-
-  it('étant donné une gouvernance inexistante, quand une note privée est supprimée, alors une erreur est renvoyée', async () => {
-    // GIVEN
-    const supprimerNotePrivee = new SupprimerUneNotePrivee(
-      new GouvernanceInexistanteRepositorySpy(),
-      new GestionnaireRepositorySpy()
-    )
-
-    // WHEN
-    const result = await supprimerNotePrivee.execute({
-      uidEditeur,
-      uidGouvernance,
-    })
-
-    // THEN
-    expect(spiedUtilisateurUidToFind).toBe(uidEditeur)
-    expect(spiedGouvernanceUidToFind?.state).toStrictEqual(new GouvernanceUid(uidGouvernance).state)
-    expect(spiedGouvernanceToUpdate).toBeNull()
-    expect(result).toBe('gouvernanceInexistante')
-  })
-
-  it('étant donné un utilisateur inexistant, quand une note privée est supprimée, alors une erreur est renvoyée', async () => {
-    // GIVEN
-    const supprimerNotePrivee = new SupprimerUneNotePrivee(
-      new GouvernanceInexistanteRepositorySpy(),
-      new GestionnaireInexistantRepositorySpy()
-    )
-
-    // WHEN
-    const result = await supprimerNotePrivee.execute({
-      uidEditeur,
-      uidGouvernance,
-    })
-
-    // THEN
-    expect(spiedUtilisateurUidToFind).toBe(uidEditeur)
-    expect(spiedGouvernanceUidToFind).toBeNull()
-    expect(spiedGouvernanceToUpdate).toBeNull()
-    expect(result).toBe('editeurInexistant')
-  })
 })
 
 const uidGouvernance = 'gouvernanceFooId'
@@ -105,7 +65,7 @@ let spiedGouvernanceToUpdate: Gouvernance | null
 let spiedUtilisateurUidToFind: string | null
 
 class GouvernanceRepositorySpy implements FindGouvernanceRepository, UpdateGouvernanceRepository {
-  async find(uid: GouvernanceUid): Promise<Gouvernance | null> {
+  async find(uid: GouvernanceUid): Promise<Gouvernance> {
     spiedGouvernanceUidToFind = uid
     return Promise.resolve(
       gouvernanceFactory({
@@ -132,15 +92,8 @@ class GouvernanceRepositorySpy implements FindGouvernanceRepository, UpdateGouve
   }
 }
 
-class GouvernanceInexistanteRepositorySpy extends GouvernanceRepositorySpy {
-  override async find(uid: GouvernanceUid): Promise<Gouvernance | null> {
-    spiedGouvernanceUidToFind = uid
-    return Promise.resolve(null)
-  }
-}
-
 class GestionnaireRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur | null> {
+  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUtilisateurUidToFind = uid
     return Promise.resolve(utilisateurFactory({
       codeOrganisation: '75',
@@ -150,15 +103,8 @@ class GestionnaireRepositorySpy implements FindUtilisateurRepository {
   }
 }
 
-class GestionnaireInexistantRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur | null> {
-    spiedUtilisateurUidToFind = uid
-    return Promise.resolve(null)
-  }
-}
-
 class GestionnaireAutreRepositorySpy implements FindUtilisateurRepository {
-  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur | null> {
+  async find(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
     spiedUtilisateurUidToFind = uid
     return Promise.resolve(utilisateurFactory({ codeOrganisation: '10', role: 'Gestionnaire département' }))
   }

--- a/src/use-cases/commands/SupprimerUneNotePrivee.ts
+++ b/src/use-cases/commands/SupprimerUneNotePrivee.ts
@@ -17,14 +17,8 @@ export class SupprimerUneNotePrivee implements CommandHandler<Command> {
 
   async execute(command: Command): ResultAsync<Failure> {
     const editeur = await this.#utilisateurRepository.find(command.uidEditeur)
-    if (!editeur) {
-      return 'editeurInexistant'
-    }
 
     const gouvernance = await this.#gouvernanceRepository.find(new GouvernanceUid(command.uidGouvernance))
-    if (!gouvernance) {
-      return 'gouvernanceInexistante'
-    }
 
     if (!gouvernance.peutEtreGerePar(editeur)) {
       return 'editeurNePeutPasSupprimerNotePrivee'
@@ -38,7 +32,7 @@ export class SupprimerUneNotePrivee implements CommandHandler<Command> {
   }
 }
 
-type Failure = 'gouvernanceInexistante' | 'editeurInexistant' | 'editeurNePeutPasSupprimerNotePrivee'
+type Failure = 'editeurNePeutPasSupprimerNotePrivee'
 
 type Command = Readonly<{
   uidEditeur: string

--- a/src/use-cases/commands/SupprimerUneNotePrivee.ts
+++ b/src/use-cases/commands/SupprimerUneNotePrivee.ts
@@ -1,6 +1,6 @@
 import { CommandHandler, ResultAsync } from '../CommandHandler'
-import { FindGouvernanceRepository, UpdateGouvernanceRepository } from './shared/GouvernanceRepository'
-import { FindUtilisateurRepository } from './shared/UtilisateurRepository'
+import { GetGouvernanceRepository, UpdateGouvernanceRepository } from './shared/GouvernanceRepository'
+import { GetUtilisateurRepository } from './shared/UtilisateurRepository'
 import { GouvernanceUid } from '@/domain/Gouvernance'
 
 export class SupprimerUneNotePrivee implements CommandHandler<Command> {
@@ -15,10 +15,10 @@ export class SupprimerUneNotePrivee implements CommandHandler<Command> {
     this.#utilisateurRepository = utilisateurRepository
   }
 
-  async execute(command: Command): ResultAsync<Failure> {
-    const editeur = await this.#utilisateurRepository.find(command.uidEditeur)
+  async handle(command: Command): ResultAsync<Failure> {
+    const editeur = await this.#utilisateurRepository.get(command.uidEditeur)
 
-    const gouvernance = await this.#gouvernanceRepository.find(new GouvernanceUid(command.uidGouvernance))
+    const gouvernance = await this.#gouvernanceRepository.get(new GouvernanceUid(command.uidGouvernance))
 
     if (!gouvernance.peutEtreGerePar(editeur)) {
       return 'editeurNePeutPasSupprimerNotePrivee'
@@ -39,6 +39,6 @@ type Command = Readonly<{
   uidGouvernance: string
 }>
 
-interface GouvernanceRepository extends FindGouvernanceRepository, UpdateGouvernanceRepository {}
+interface GouvernanceRepository extends GetGouvernanceRepository, UpdateGouvernanceRepository {}
 
-type UtilisateurRepository = FindUtilisateurRepository
+type UtilisateurRepository = GetUtilisateurRepository

--- a/src/use-cases/commands/shared/ComiteRepository.ts
+++ b/src/use-cases/commands/shared/ComiteRepository.ts
@@ -1,7 +1,7 @@
 import { Comite } from '@/domain/Comite'
 
 export interface FindComiteRepository {
-  find(uid: Comite['uid']['state']['value']): Promise<Comite | null>
+  find(uid: Comite['uid']['state']['value']): Promise<Comite>
 }
 
 export interface AddComiteRepository {

--- a/src/use-cases/commands/shared/ComiteRepository.ts
+++ b/src/use-cases/commands/shared/ComiteRepository.ts
@@ -1,7 +1,7 @@
 import { Comite } from '@/domain/Comite'
 
-export interface FindComiteRepository {
-  find(uid: Comite['uid']['state']['value']): Promise<Comite>
+export interface GetComiteRepository {
+  get(uid: Comite['uid']['state']['value']): Promise<Comite>
 }
 
 export interface AddComiteRepository {
@@ -17,7 +17,7 @@ export interface DropComiteRepository {
 }
 
 export interface ComiteRepository extends
-  FindComiteRepository,
+  GetComiteRepository,
   DropComiteRepository,
   AddComiteRepository,
   UpdateComiteRepository {}

--- a/src/use-cases/commands/shared/GouvernanceRepository.ts
+++ b/src/use-cases/commands/shared/GouvernanceRepository.ts
@@ -1,7 +1,7 @@
 import { Gouvernance, GouvernanceUid } from '@/domain/Gouvernance'
 
-export interface FindGouvernanceRepository {
-  find(uid: GouvernanceUid): Promise<Gouvernance>
+export interface GetGouvernanceRepository {
+  get(uid: GouvernanceUid): Promise<Gouvernance>
 }
 
 export interface UpdateGouvernanceRepository {

--- a/src/use-cases/commands/shared/GouvernanceRepository.ts
+++ b/src/use-cases/commands/shared/GouvernanceRepository.ts
@@ -1,7 +1,7 @@
 import { Gouvernance, GouvernanceUid } from '@/domain/Gouvernance'
 
 export interface FindGouvernanceRepository {
-  find(uid: GouvernanceUid): Promise<Gouvernance | null>
+  find(uid: GouvernanceUid): Promise<Gouvernance>
 }
 
 export interface UpdateGouvernanceRepository {

--- a/src/use-cases/commands/shared/UtilisateurRepository.ts
+++ b/src/use-cases/commands/shared/UtilisateurRepository.ts
@@ -1,7 +1,7 @@
 import { Utilisateur, UtilisateurUidState } from '@/domain/Utilisateur'
 
 export interface FindUtilisateurRepository {
-  find(uid: UtilisateurUidState['value']): Promise<Utilisateur | null>
+  find(uid: UtilisateurUidState['value']): Promise<Utilisateur>
 }
 
 export interface DropUtilisateurRepository {

--- a/src/use-cases/commands/shared/UtilisateurRepository.ts
+++ b/src/use-cases/commands/shared/UtilisateurRepository.ts
@@ -1,7 +1,7 @@
 import { Utilisateur, UtilisateurUidState } from '@/domain/Utilisateur'
 
-export interface FindUtilisateurRepository {
-  find(uid: UtilisateurUidState['value']): Promise<Utilisateur>
+export interface GetUtilisateurRepository {
+  get(uid: UtilisateurUidState['value']): Promise<Utilisateur>
 }
 
 export interface DropUtilisateurRepository {
@@ -21,7 +21,7 @@ export interface AddUtilisateurRepository {
 }
 
 export interface UtilisateurRepository extends
-  FindUtilisateurRepository,
+  GetUtilisateurRepository,
   DropUtilisateurRepository,
   AddUtilisateurRepository,
   UpdateUtilisateurRepository {}

--- a/src/use-cases/queries/RechercherLesStructures.test.ts
+++ b/src/use-cases/queries/RechercherLesStructures.test.ts
@@ -9,18 +9,18 @@ describe('rechercher les structures', () => {
   it.each([
     {
       expectedArgs: ['la poste'],
-      expectedCall: 'findStructures',
+      expectedCall: 'structures',
       intention: ': le critère de correspondance est transmis',
     },
     {
       expectedArgs: ['la poste', '06'],
-      expectedCall: 'findStructuresByDepartement',
+      expectedCall: 'structuresByDepartement',
       intention: 'et par département : le critère de correspondance ainsi que le code du département sont transmis',
       zone: { code: '06', type: 'departement' } as const,
     },
     {
       expectedArgs: ['la poste', '93'],
-      expectedCall: 'findStructuresByRegion',
+      expectedCall: 'structuresByRegion',
       intention: 'et par région : le critère de correspondance ainsi que le code de la région sont transmis',
       zone: { code: '93', type: 'region' } as const,
     },
@@ -30,7 +30,7 @@ describe('rechercher les structures', () => {
     const rechercherLesStructures = new RechercherLesStructures(new StructuresLoaderSpy())
 
     // WHEN
-    await rechercherLesStructures.get(query)
+    await rechercherLesStructures.handle(query)
 
     // THEN
     expect(spiedCall).toBe(expectedCall)
@@ -39,25 +39,25 @@ describe('rechercher les structures', () => {
 })
 
 let spiedCall: keyof StructuresLoaderSpy | null
-let spiedArgs: Parameters<typeof StructuresLoaderSpy.prototype.findStructures>
-  | Parameters<typeof StructuresLoaderSpy.prototype.findStructuresByDepartement>
-  | Parameters<typeof StructuresLoaderSpy.prototype.findStructuresByRegion> | null
+let spiedArgs: Parameters<typeof StructuresLoaderSpy.prototype.structures>
+  | Parameters<typeof StructuresLoaderSpy.prototype.structuresByDepartement>
+  | Parameters<typeof StructuresLoaderSpy.prototype.structuresByRegion> | null
 
 class StructuresLoaderSpy implements StructureLoader {
-  async findStructures(match: string): Promise<StructuresReadModel> {
-    spiedCall = 'findStructures'
+  async structures(match: string): Promise<StructuresReadModel> {
+    spiedCall = 'structures'
     spiedArgs = [match]
     return Promise.resolve([])
   }
 
-  async findStructuresByDepartement(match: string, codeDepartement: string): Promise<StructuresReadModel> {
-    spiedCall = 'findStructuresByDepartement'
+  async structuresByDepartement(match: string, codeDepartement: string): Promise<StructuresReadModel> {
+    spiedCall = 'structuresByDepartement'
     spiedArgs = [match, codeDepartement]
     return Promise.resolve([])
   }
 
-  async findStructuresByRegion(match: string, codeRegion: string): Promise<StructuresReadModel> {
-    spiedCall = 'findStructuresByRegion'
+  async structuresByRegion(match: string, codeRegion: string): Promise<StructuresReadModel> {
+    spiedCall = 'structuresByRegion'
     spiedArgs = [match, codeRegion]
     return Promise.resolve([])
   }

--- a/src/use-cases/queries/RechercherLesStructures.ts
+++ b/src/use-cases/queries/RechercherLesStructures.ts
@@ -7,22 +7,22 @@ export class RechercherLesStructures implements QueryHandler<Query, StructuresRe
     this.#structureLoader = structureLoader
   }
 
-  async get(query: Query): Promise<StructuresReadModel> {
+  async handle(query: Query): Promise<StructuresReadModel> {
     switch (query.zone?.type) {
       case 'departement':
-        return this.#structureLoader.findStructuresByDepartement(query.match, query.zone.code)
+        return this.#structureLoader.structuresByDepartement(query.match, query.zone.code)
       case 'region':
-        return this.#structureLoader.findStructuresByRegion(query.match, query.zone.code)
+        return this.#structureLoader.structuresByRegion(query.match, query.zone.code)
       default:
-        return this.#structureLoader.findStructures(query.match)
+        return this.#structureLoader.structures(query.match)
     }
   }
 }
 
 export interface StructureLoader {
-  findStructures(match: string): Promise<StructuresReadModel>
-  findStructuresByDepartement(match: string, codeDepartement: string): Promise<StructuresReadModel>
-  findStructuresByRegion(match: string, codeRegion: string): Promise<StructuresReadModel>
+  structures(match: string): Promise<StructuresReadModel>
+  structuresByDepartement(match: string, codeDepartement: string): Promise<StructuresReadModel>
+  structuresByRegion(match: string, codeRegion: string): Promise<StructuresReadModel>
 }
 
 export type StructuresReadModel = ReadonlyArray<UneStructureReadModel>

--- a/src/use-cases/queries/RechercherMesUtilisateurs.test.ts
+++ b/src/use-cases/queries/RechercherMesUtilisateurs.test.ts
@@ -13,7 +13,7 @@ describe('rechercher mes utilisateurs', () => {
     const rechercherMesUtilisateurs = new RechercherMesUtilisateurs(mesUtilisateursLoader)
 
     // WHEN
-    await rechercherMesUtilisateurs.get({ uid })
+    await rechercherMesUtilisateurs.handle({ uid })
 
     // THEN
     expect(mesUtilisateursLoader.spiedFindByUidIdArgs).toStrictEqual([uid])
@@ -33,10 +33,10 @@ const dummyUtilisateur = utilisateurReadModelFactory()
 
 class MesUtilisateursLoaderSpy implements MesUtilisateursLoader {
   spiedFindMesUtilisateursEtLeTotalArgs:
-    Parameters<typeof MesUtilisateursLoaderSpy.prototype.findMesUtilisateursEtLeTotal> | undefined
+    Parameters<typeof MesUtilisateursLoaderSpy.prototype.mesUtilisateursEtLeTotal> | undefined
   spiedFindByUidIdArgs: Parameters<typeof MesUtilisateursLoaderSpy.prototype.findByUid> | undefined
 
-  async findMesUtilisateursEtLeTotal(
+  async mesUtilisateursEtLeTotal(
     utilisateur: UnUtilisateurReadModel,
     pageCourante: number,
     utilisateursParPage: number,

--- a/src/use-cases/queries/RechercherMesUtilisateurs.ts
+++ b/src/use-cases/queries/RechercherMesUtilisateurs.ts
@@ -12,7 +12,7 @@ export class RechercherMesUtilisateurs implements QueryHandler<
     this.#mesUtilisateursLoader = mesUtilisateursLoader
   }
 
-  async get({
+  async handle({
     uid,
     roles = [],
     pageCourante = 0,
@@ -25,7 +25,7 @@ export class RechercherMesUtilisateurs implements QueryHandler<
   }: Query): Promise<UtilisateursCourantsEtTotalReadModel> {
     const utilisateur = await this.#mesUtilisateursLoader.findByUid(uid)
 
-    return this.#mesUtilisateursLoader.findMesUtilisateursEtLeTotal(
+    return this.#mesUtilisateursLoader.mesUtilisateursEtLeTotal(
       utilisateur,
       pageCourante,
       utilisateursParPage,
@@ -45,7 +45,7 @@ export type UtilisateursCourantsEtTotalReadModel = Readonly<{
 }>
 
 export interface MesUtilisateursLoader extends UnUtilisateurLoader {
-  findMesUtilisateursEtLeTotal(
+  mesUtilisateursEtLeTotal(
     utilisateur: UnUtilisateurReadModel,
     pageCourante: number,
     utilisateursParPage: number,

--- a/src/use-cases/queries/RechercherUnUtilisateur.ts
+++ b/src/use-cases/queries/RechercherUnUtilisateur.ts
@@ -3,9 +3,3 @@ import { UnUtilisateurReadModel } from './shared/UnUtilisateurReadModel'
 export interface UnUtilisateurLoader {
   findByUid(uid: string): Promise<UnUtilisateurReadModel>
 }
-
-export class UtilisateurNonTrouveError extends Error {
-  constructor() {
-    super('L’utilisateur n’existe pas.')
-  }
-}

--- a/src/use-cases/queries/RecupererMesInformationsPersonnelles.ts
+++ b/src/use-cases/queries/RecupererMesInformationsPersonnelles.ts
@@ -1,5 +1,5 @@
 export interface MesInformationsPersonnellesLoader {
-  findByUid(uid: string): Promise<MesInformationsPersonnellesReadModel>
+  byUid(uid: string): Promise<MesInformationsPersonnellesReadModel>
 }
 
 export type MesInformationsPersonnellesReadModel = Readonly<{

--- a/src/use-cases/queries/RecupererMesMembres.test.ts
+++ b/src/use-cases/queries/RecupererMesMembres.test.ts
@@ -12,7 +12,7 @@ describe('recuperer mes membres', () => {
       const queryHandler = new RecupererMesMembres(new MesMembresLoaderStub())
 
       // WHEN
-      const mesMembres = await queryHandler.get({ codeDepartement: '69' })
+      const mesMembres = await queryHandler.handle({ codeDepartement: '69' })
 
       // THEN
       expect(mesMembres).toStrictEqual(mesMembresReadModelFactory({
@@ -31,7 +31,7 @@ describe('recuperer mes membres', () => {
 let mesMembresLoader: MesMembresReadModel
 
 class MesMembresLoaderStub extends MesMembresLoader {
-  protected async find(): Promise<MesMembresReadModel> {
+  protected async membres(): Promise<MesMembresReadModel> {
     return Promise.resolve(mesMembresLoader)
   }
 }

--- a/src/use-cases/queries/RecupererMesMembres.ts
+++ b/src/use-cases/queries/RecupererMesMembres.ts
@@ -8,7 +8,7 @@ export class RecupererMesMembres implements QueryHandler<Query, MesMembresReadMo
     this.#mesMembresLoader = mesMembresLoader
   }
 
-  async get(query: Query): Promise<MesMembresReadModel> {
+  async handle(query: Query): Promise<MesMembresReadModel> {
     return this.#mesMembresLoader.findMesMembres(query.codeDepartement, (mesMembres) => {
       return {
         ...mesMembres,
@@ -23,10 +23,10 @@ export abstract class MesMembresLoader {
     codeDepartement: string,
     operator: UnaryOperator<MesMembresReadModel>
   ): Promise<MesMembresReadModel> {
-    return this.find(codeDepartement).then(operator)
+    return this.membres(codeDepartement).then(operator)
   }
 
-  protected abstract find(codeDepartement: string): Promise<MesMembresReadModel>
+  protected abstract membres(codeDepartement: string): Promise<MesMembresReadModel>
 }
 
 function roleEtTypologieDistinct(membres: MesMembresReadModel['membres']): Pick<MesMembresReadModel, 'roles' | 'typologies'> {

--- a/src/use-cases/queries/RecupererUneGouvernance.test.ts
+++ b/src/use-cases/queries/RecupererUneGouvernance.test.ts
@@ -12,7 +12,7 @@ describe('recupererUneGouvernance', () => {
     const queryHandler = new RecupererUneGouvernance(new GouvernanceInexistanteLoaderStub())
 
     // WHEN
-    const gouvernance = await queryHandler.get({ codeDepartement: '69' })
+    const gouvernance = await queryHandler.handle({ codeDepartement: '69' })
 
     // THEN
     expect(gouvernance).toStrictEqual({ departement: 'Rhône', uid: 'gouvernanceFooId' })
@@ -23,7 +23,7 @@ describe('recupererUneGouvernance', () => {
     const queryHandler = new RecupererUneGouvernance(new GouvernanceExistanteLoaderStub())
 
     // WHEN
-    const gouvernance = await queryHandler.get({ codeDepartement: '69' })
+    const gouvernance = await queryHandler.handle({ codeDepartement: '69' })
 
     // THEN
     expect(gouvernance).toStrictEqual(gouvernanceEnrichie)
@@ -38,7 +38,7 @@ describe('recupererUneGouvernance', () => {
     const queryHandler = new RecupererUneGouvernance(new GouvernanceExistanteLoaderStub())
 
     // WHEN
-    const gouvernance = await queryHandler.get({ codeDepartement: '69' })
+    const gouvernance = await queryHandler.handle({ codeDepartement: '69' })
 
     // THEN
     expect(gouvernance).toStrictEqual(gouvernanceSansMembre)
@@ -71,7 +71,7 @@ describe('recupererUneGouvernance', () => {
     const queryHandler = new RecupererUneGouvernance(new GouvernanceExistanteLoaderStub())
 
     // WHEN
-    const gouvernance = await queryHandler.get({ codeDepartement: '69' })
+    const gouvernance = await queryHandler.handle({ codeDepartement: '69' })
 
     // THEN
     expect(gouvernance.membres).toStrictEqual([
@@ -123,7 +123,7 @@ describe('recupererUneGouvernance', () => {
     const queryHandler = new RecupererUneGouvernance(new GouvernanceExistanteLoaderStub())
 
     // WHEN
-    const gouvernance = await queryHandler.get({ codeDepartement: '69' })
+    const gouvernance = await queryHandler.handle({ codeDepartement: '69' })
 
     // THEN
     expect(gouvernance.membres).toStrictEqual([
@@ -173,13 +173,13 @@ const gouvernanceSansMembre: UneGouvernanceReadModel = {
 }
 
 class GouvernanceInexistanteLoaderStub extends UneGouvernanceReadModelLoader {
-  protected override async find(): Promise<UneGouvernanceReadModel> {
+  protected override async gouvernance(): Promise<UneGouvernanceReadModel> {
     return Promise.resolve({ departement: uneGouvernance.departement, uid: uneGouvernance.uid })
   }
 }
 
 class GouvernanceExistanteLoaderStub extends UneGouvernanceReadModelLoader {
-  protected async find(): Promise<UneGouvernanceReadModel> {
+  protected async gouvernance(): Promise<UneGouvernanceReadModel> {
     return Promise.resolve(uneGouvernance)
   }
 }

--- a/src/use-cases/queries/RecupererUneGouvernance.ts
+++ b/src/use-cases/queries/RecupererUneGouvernance.ts
@@ -8,7 +8,7 @@ export class RecupererUneGouvernance implements QueryHandler<Query, UneGouvernan
     this.#loader = loader
   }
 
-  async get({ codeDepartement }: Query): Promise<UneGouvernanceReadModel> {
+  async handle({ codeDepartement }: Query): Promise<UneGouvernanceReadModel> {
     return this.#loader.trouverEtEnrichir(codeDepartement, (gouvernance) => ({
       ...gouvernance,
       ...gouvernance.membres && {
@@ -26,10 +26,10 @@ export abstract class UneGouvernanceReadModelLoader {
     codeDepartement: string,
     enrichir: UnaryOperator<UneGouvernanceReadModel> = identity
   ): Promise<UneGouvernanceReadModel> {
-    return this.find(codeDepartement).then(enrichir)
+    return this.gouvernance(codeDepartement).then(enrichir)
   }
 
-  protected abstract find(codeDepartement: string): Promise<UneGouvernanceReadModel>
+  protected abstract gouvernance(codeDepartement: string): Promise<UneGouvernanceReadModel>
 }
 
 export type UneGouvernanceReadModel = Readonly<{


### PR DESCRIPTION
Les `findUnique` des adaptateurs de _repositories_ sont remplacés par des `findUniqueOrThrow`.

# Contrat du dev

## Qualité

- [x] Relire le code
- [x] [Relire les critères d'acceptation](https://github.com/anct-cnum/suite-gestionnaire-numerique/discussions/252)
- [x] Vérifier le coverage
- [x] Recetter l'application

## Facultatif mais fortement conseillé

- [x] Lancer les tests de mutation

> **Et n'oublie pas de vérifier ce que tu as fait en production !**
