### PR TITLE
Suppression de certains expect inutiles dans les commands

### DIFF
--- a/src/use-cases/commands/AjouterNoteDeContexteAGouvernance.test.ts
+++ b/src/use-cases/commands/AjouterNoteDeContexteAGouvernance.test.ts
@@ -58,8 +58,6 @@ describe('ajouter une note de contexte à une gouvernance', () => {
     const result = await ajouterNoteDeContexteAGouvernance.handle({ contenu, uidEditeur: 'utilisateurUsurpateur', uidGouvernance })
 
     // THEN
-    expect(spiedUtilisateurUidToFind).toBe('utilisateurUsurpateur')
-    expect(spiedGouvernanceUidToFind?.state).toStrictEqual(new GouvernanceUid(uidGouvernance).state)
     expect(spiedGouvernanceToUpdate).toBeNull()
     expect(result).toBe('utilisateurNePeutPasAjouterNoteDeContexte')
   })
@@ -80,10 +78,8 @@ describe('ajouter une note de contexte à une gouvernance', () => {
     })
 
     // THEN
-    expect(result).toBe('noteDeContexteDejaExistante')
-    expect(spiedUtilisateurUidToFind).toBe(uidEditeur)
-    expect(spiedGouvernanceUidToFind?.state).toStrictEqual(new GouvernanceUid(uidGouvernance).state)
     expect(spiedGouvernanceToUpdate).toBeNull()
+    expect(result).toBe('noteDeContexteDejaExistante')
   })
 })
 

--- a/src/use-cases/commands/AjouterUnComite.test.ts
+++ b/src/use-cases/commands/AjouterUnComite.test.ts
@@ -144,10 +144,8 @@ describe('ajouter un comité à une gouvernance', () => {
     })
 
     // THEN
-    expect(spiedUtilisateurUidToFind).toBe(uidEditeur)
-    expect(spiedGouvernanceUidToFind?.state).toStrictEqual(new GouvernanceUid(uidGouvernance).state)
-    expect(result).toBe(expectedFailure)
     expect(spiedComiteToAdd).toBeNull()
+    expect(result).toBe(expectedFailure)
   })
 
   it('étant donné une gouvernance, quand un comité est créé par un gestionnaire autre que celui de la gouvernance, alors une erreur est renvoyée', async () => {
@@ -170,10 +168,8 @@ describe('ajouter un comité à une gouvernance', () => {
     })
 
     // THEN
-    expect(spiedUtilisateurUidToFind).toBe('userFooId')
-    expect(spiedGouvernanceUidToFind?.state).toStrictEqual(new GouvernanceUid(uidGouvernance).state)
-    expect(result).toBe('editeurNePeutPasAjouterComite')
     expect(spiedComiteToAdd).toBeNull()
+    expect(result).toBe('editeurNePeutPasAjouterComite')
   })
 })
 

--- a/src/use-cases/commands/AjouterUneNotePrivee.test.ts
+++ b/src/use-cases/commands/AjouterUneNotePrivee.test.ts
@@ -58,8 +58,6 @@ describe('ajouter une note privée à une gouvernance', () => {
     const result = await ajouterNotePrivee.handle({ contenu, uidEditeur: 'utilisateurUsurpateur', uidGouvernance })
 
     // THEN
-    expect(spiedUtilisateurUidToFind).toBe('utilisateurUsurpateur')
-    expect(spiedGouvernanceUidToFind?.state).toStrictEqual(new GouvernanceUid(uidGouvernance).state)
     expect(spiedGouvernanceToUpdate).toBeNull()
     expect(result).toBe('utilisateurNePeutPasAjouterNotePrivee')
   })
@@ -76,8 +74,6 @@ describe('ajouter une note privée à une gouvernance', () => {
     const result = await ajouterNotePrivee.handle({ contenu, uidEditeur, uidGouvernance })
 
     // THEN
-    expect(spiedUtilisateurUidToFind).toBe(uidEditeur)
-    expect(spiedGouvernanceUidToFind?.state).toStrictEqual(new GouvernanceUid(uidGouvernance).state)
     expect(spiedGouvernanceToUpdate).toBeNull()
     expect(result).toBe('notePriveeDejaExistante')
   })

--- a/src/use-cases/commands/ModifierUnComite.test.ts
+++ b/src/use-cases/commands/ModifierUnComite.test.ts
@@ -145,10 +145,8 @@ describe('modifier un comité', () => {
     })
 
     // THEN
-    expect(spiedUtilisateurUidToFind).toBe(uidEditeur)
-    expect(spiedGouvernanceUidToFind?.state).toStrictEqual(new GouvernanceUid(uidGouvernance).state)
-    expect(result).toBe(expectedFailure)
     expect(spiedComiteToModify).toBeNull()
+    expect(result).toBe(expectedFailure)
   })
 
   it('étant donné une gouvernance, quand un comité est modifié par un gestionnaire autre que celui de la gouvernance, alors une erreur est renvoyée', async () => {
@@ -172,10 +170,8 @@ describe('modifier un comité', () => {
     })
 
     // THEN
-    expect(spiedUtilisateurUidToFind).toBe('userFooId')
-    expect(spiedGouvernanceUidToFind?.state).toStrictEqual(new GouvernanceUid(uidGouvernance).state)
-    expect(result).toBe('editeurNePeutPasModifierComite')
     expect(spiedComiteToModify).toBeNull()
+    expect(result).toBe('editeurNePeutPasModifierComite')
   })
 })
 

--- a/src/use-cases/commands/ModifierUneNoteDeContexte.test.ts
+++ b/src/use-cases/commands/ModifierUneNoteDeContexte.test.ts
@@ -60,8 +60,6 @@ describe('modifier une note de contexte', () => {
     const result = await modifierNoteDeContexte.handle({ contenu, uidEditeur: 'utilisateurUsurpateur', uidGouvernance })
 
     // THEN
-    expect(spiedUtilisateurUidToFind).toBe('utilisateurUsurpateur')
-    expect(spiedGouvernanceUidToFind?.state).toStrictEqual(new GouvernanceUid(uidGouvernance).state)
     expect(spiedGouvernanceToUpdate).toBeNull()
     expect(result).toBe('editeurNePeutPasModifierNoteDeContexte')
   })
@@ -78,8 +76,6 @@ describe('modifier une note de contexte', () => {
     const result = await modifierNoteDeContexte.handle({ contenu, uidEditeur, uidGouvernance })
 
     // THEN
-    expect(spiedUtilisateurUidToFind).toBe(uidEditeur)
-    expect(spiedGouvernanceUidToFind?.state).toStrictEqual(new GouvernanceUid(uidGouvernance).state)
     expect(spiedGouvernanceToUpdate).toBeNull()
     expect(result).toBe('noteDeContexteInexistante')
   })

--- a/src/use-cases/commands/ModifierUneNotePrivee.test.ts
+++ b/src/use-cases/commands/ModifierUneNotePrivee.test.ts
@@ -60,8 +60,6 @@ describe('modifier une note privée', () => {
     const result = await modifierNotePrivee.handle({ contenu, uidEditeur: 'utilisateurUsurpateur', uidGouvernance })
 
     // THEN
-    expect(spiedUtilisateurUidToFind).toBe('utilisateurUsurpateur')
-    expect(spiedGouvernanceUidToFind?.state).toStrictEqual(new GouvernanceUid(uidGouvernance).state)
     expect(spiedGouvernanceToUpdate).toBeNull()
     expect(result).toBe('editeurNePeutPasModifierNotePrivee')
   })
@@ -78,8 +76,6 @@ describe('modifier une note privée', () => {
     const result = await modifierNotePrivee.handle({ contenu, uidEditeur, uidGouvernance })
 
     // THEN
-    expect(spiedUtilisateurUidToFind).toBe(uidEditeur)
-    expect(spiedGouvernanceUidToFind?.state).toStrictEqual(new GouvernanceUid(uidGouvernance).state)
     expect(spiedGouvernanceToUpdate).toBeNull()
     expect(result).toBe('notePriveeInexistante')
   })

--- a/src/use-cases/commands/ReinviterUnUtilisateur.test.ts
+++ b/src/use-cases/commands/ReinviterUnUtilisateur.test.ts
@@ -13,79 +13,82 @@ describe('réinviter un utilisateur', () => {
 
   it('étant donné que l’utilisateur courant peut gérer l’utilisateur à réinviter, quand il le réinvite, la date d’invitation est mise à jour puis un e-mail lui est envoyé', async () => {
     // GIVEN
-    const date = epochTimeMinusOneDay
-    const repository = new RepositorySpy()
-    const reinviterUnUtilisateur = new ReinviterUnUtilisateur(repository, emailGatewayFactorySpy, date)
-    const command = {
-      uidUtilisateurAReinviter: 'uidUtilisateurAReinviterInactif',
-      uidUtilisateurCourant: 'uidUtilisateurCourantAvecMemeRole',
-    }
+    const reinviterUnUtilisateur = new ReinviterUnUtilisateur(
+      new RepositorySpy(),
+      emailGatewayFactorySpy,
+      epochTimeMinusOneDay
+    )
 
     // WHEN
-    const result = await reinviterUnUtilisateur.handle(command)
+    const result = await reinviterUnUtilisateur.handle({
+      uidUtilisateurAReinviter: 'uidUtilisateurAReinviterInactif',
+      uidUtilisateurCourant: 'uidUtilisateurCourantAvecMemeRole',
+    })
 
     // THEN
-    expect(result).toBe('OK')
+    expect(spiedDestinataire).toBe(spiedUtilisateurToUpdate?.state.emailDeContact)
     expect(spiedUtilisateurToUpdate?.state).toStrictEqual(utilisateurFactory({
       derniereConnexion: undefined,
-      inviteLe: date,
+      inviteLe: epochTimeMinusOneDay,
       role: 'Gestionnaire structure',
       uid: { email: 'uidUtilisateurAReinviterInactif', value: 'uidUtilisateurAReinviterInactif' },
     }).state)
-    expect(spiedDestinataire).toBe(spiedUtilisateurToUpdate?.state.emailDeContact)
+    expect(result).toBe('OK')
   })
 
   it('étant donné que l’utilisateur courant ne peut pas gérer l’utilisateur à réinviter, quand il le réinvite, alors il y a une erreur', async () => {
     // GIVEN
-    const repository = new RepositorySpy()
-    const reinviterUnUtilisateur = new ReinviterUnUtilisateur(repository, emailGatewayFactorySpy, epochTime)
-    const command = {
-      uidUtilisateurAReinviter: 'uidUtilisateurAReinviterInactif',
-      uidUtilisateurCourant: 'uidUtilisateurCourantAvecRoleDifferent',
-    }
+    const reinviterUnUtilisateur = new ReinviterUnUtilisateur(
+      new RepositorySpy(),
+      emailGatewayFactorySpy,
+      epochTime
+    )
 
     // WHEN
-    const result = await reinviterUnUtilisateur.handle(command)
+    const result = await reinviterUnUtilisateur.handle({
+      uidUtilisateurAReinviter: 'uidUtilisateurAReinviterInactif',
+      uidUtilisateurCourant: 'uidUtilisateurCourantAvecRoleDifferent',
+    })
 
     // THEN
-    expect(result).toBe('utilisateurNePeutPasGererUtilisateurAReinviter')
     expect(spiedUidToFind).toBe('uidUtilisateurAReinviterInactif')
     expect(spiedUtilisateurToUpdate).toBeNull()
+    expect(result).toBe('utilisateurNePeutPasGererUtilisateurAReinviter')
   })
 
   it('étant donné que le compte de l’utilisateur à réinviter est déjà actif, quand il est réinvité, alors il y a une erreur', async () => {
     // GIVEN
-    const repository = new RepositorySpy()
-    const reinviterUnUtilisateur = new ReinviterUnUtilisateur(repository, emailGatewayFactorySpy, epochTime)
-    const command = {
-      uidUtilisateurAReinviter: 'uidUtilisateurAReinviterActif',
-      uidUtilisateurCourant: 'uidUtilisateurCourantAvecRoleDifferent',
-    }
+    const reinviterUnUtilisateur = new ReinviterUnUtilisateur(
+      new RepositorySpy(),
+      emailGatewayFactorySpy,
+      epochTime
+    )
 
     // WHEN
-    const result = await reinviterUnUtilisateur.handle(command)
+    const result = await reinviterUnUtilisateur.handle({
+      uidUtilisateurAReinviter: 'uidUtilisateurAReinviterActif',
+      uidUtilisateurCourant: 'uidUtilisateurCourantAvecRoleDifferent',
+    })
 
     // THEN
-    expect(result).toBe('utilisateurAReinviterDejaActif')
     expect(spiedUidToFind).toBe('uidUtilisateurAReinviterActif')
     expect(spiedUtilisateurToUpdate).toBeNull()
+    expect(result).toBe('utilisateurAReinviterDejaActif')
   })
 
   it('étant donné une date invalide d’invitation d’un utilisateur, quand il est réinvité, alors il y a une erreur', async () => {
     // GIVEN
-    const repository = new RepositorySpy()
     const reinviterUnUtilisateur = new ReinviterUnUtilisateur(
-      repository,
+      new RepositorySpy(),
       emailGatewayFactorySpy,
       invalidDate
     )
-    const command = {
-      uidUtilisateurAReinviter: 'uidUtilisateurAReinviterInactif',
-      uidUtilisateurCourant: 'uidUtilisateurCourantAvecMemeRole',
-    }
 
     // WHEN
-    const asyncResult = reinviterUnUtilisateur.handle(command)
+    const asyncResult = reinviterUnUtilisateur.handle({
+      uidUtilisateurAReinviter: 'uidUtilisateurAReinviterInactif',
+      uidUtilisateurCourant: 'uidUtilisateurCourantAvecMemeRole',
+    })
 
     // THEN
     await expect(asyncResult).rejects.toThrow('dateDInvitationInvalide')

--- a/src/use-cases/commands/SupprimerUnComite.test.ts
+++ b/src/use-cases/commands/SupprimerUnComite.test.ts
@@ -67,10 +67,8 @@ describe('supprimer un comité', () => {
     })
 
     // THEN
-    expect(spiedUtilisateurUidToFind).toBe('userFooId')
-    expect(spiedGouvernanceUidToFind?.state).toStrictEqual(new GouvernanceUid(uidGouvernance).state)
-    expect(result).toBe('editeurNePeutPasSupprimerComite')
     expect(spiedComiteToDrop).toBeNull()
+    expect(result).toBe('editeurNePeutPasSupprimerComite')
   })
 })
 

--- a/src/use-cases/commands/SupprimerUnUtilisateur.test.ts
+++ b/src/use-cases/commands/SupprimerUnUtilisateur.test.ts
@@ -20,10 +20,6 @@ describe('supprimer un utilisateur', () => {
     })
 
     // THEN
-    expect(spiedUidsToFind).toStrictEqual([
-      'utilisateurCourantExistantUid',
-      'utilisateurASupprimerExistantUid',
-    ])
     expect(spiedUtilisateurToDrop).toBeNull()
     expect(result).toBe('suppressionNonAutorisee')
   })
@@ -40,10 +36,6 @@ describe('supprimer un utilisateur', () => {
     })
 
     // THEN
-    expect(spiedUidsToFind).toStrictEqual([
-      'utilisateurCourantExistantAutreUid',
-      'utilisateurASupprimerExistantUid',
-    ])
     expect(spiedUtilisateurToDrop).not.toBeNull()
     expect(spiedUtilisateurToDrop?.state).toStrictEqual(utilisateursByUid.utilisateurASupprimerExistantUid.state)
     expect(result).toBe('compteASupprimerDejaSupprime')

--- a/src/use-cases/commands/SupprimerUneNotePrivee.test.ts
+++ b/src/use-cases/commands/SupprimerUneNotePrivee.test.ts
@@ -50,8 +50,6 @@ describe('supprimer une note privée d’une gouvernance', () => {
     const result = await supprimerNotePrivee.handle({ uidEditeur: 'utilisateurUsurpateur', uidGouvernance })
 
     // THEN
-    expect(spiedUtilisateurUidToFind).toBe('utilisateurUsurpateur')
-    expect(spiedGouvernanceUidToFind?.state).toStrictEqual(new GouvernanceUid(uidGouvernance).state)
     expect(spiedGouvernanceToUpdate).toBeNull()
     expect(result).toBe('editeurNePeutPasSupprimerNotePrivee')
   })


### PR DESCRIPTION
Dans la lignée de [simplifier les commands](https://github.com/anct-cnum/suite-gestionnaire-numerique/pull/349), il s'avère que certains expect devenaient inutile car ils sont redondant avec le test passant.

# Contrat du dev

## Qualité

- [x] Relire le code
- [x] Vérifier le coverage

## Facultatif mais fortement conseillé

- [x] Lancer les tests de mutation

> **Et n'oublie pas de vérifier ce que tu as fait en production !**
