### PR TITLE
Simplification du nommage autour des drawers

### DIFF
--- a/src/components/FeuillesDeRoute/AjouterUneFeuilleDeRoute.test.tsx
+++ b/src/components/FeuillesDeRoute/AjouterUneFeuilleDeRoute.test.tsx
@@ -15,8 +15,8 @@ describe('ajouter une feuille de route', () => {
       jOuvreLeFormulairePourAjouterUneFeuilleDeRoute()
 
       // THEN
-      const drawer = screen.getByRole('dialog', { name: 'Ajouter une feuille de route' })
-      expect(drawer).toHaveAttribute('id', 'drawerId')
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Ajouter une feuille de route' })
+      expect(drawer).toHaveAttribute('id', 'drawerAjouterFeuilleDeRouteId')
       const titre = within(drawer).getByRole('heading', { level: 1, name: 'Ajouter une feuille de route' })
       expect(titre).toBeInTheDocument()
       const champsObligatoires = within(drawer).getByText(matchWithoutMarkup('Les champs avec * sont obligatoires.'), { selector: 'p' })
@@ -68,11 +68,11 @@ describe('ajouter une feuille de route', () => {
 
       // WHEN
       jOuvreLeFormulairePourAjouterUneFeuilleDeRoute()
-      const drawer = screen.getByRole('dialog', { name: 'Ajouter une feuille de route' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Ajouter une feuille de route' })
       const fermer = jeFermeLeFormulaire()
 
       // THEN
-      expect(fermer).toHaveAttribute('aria-controls', 'drawerId')
+      expect(fermer).toHaveAttribute('aria-controls', 'drawerAjouterFeuilleDeRouteId')
       expect(drawer).not.toBeVisible()
     })
 
@@ -84,7 +84,7 @@ describe('ajouter une feuille de route', () => {
 
       // WHEN
       jOuvreLeFormulairePourAjouterUneFeuilleDeRoute()
-      const drawer = screen.getByRole('dialog', { name: 'Ajouter une feuille de route' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Ajouter une feuille de route' })
       const nom = jeTapeLeNomDeLaFeuilleDeRoute('Feuille de route du Rhône')
       jeSelectionneUnMembre('membre2FooId')
       jeSelectionneUnPerimetre('Régional')

--- a/src/components/FeuillesDeRoute/AjouterUneFeuilleDeRoute.tsx
+++ b/src/components/FeuillesDeRoute/AjouterUneFeuilleDeRoute.tsx
@@ -23,7 +23,7 @@ export default function AjouterUneFeuilleDeRoute({
   const [isDisabled, setIsDisabled] = useState(false)
   // Stryker disable next-line BooleanLiteral
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
-  const drawerId = 'drawerId'
+  const drawerId = 'drawerAjouterFeuilleDeRouteId'
   const labelId = useId()
   const nomId = useId()
   const drawerRef = useRef<HTMLDialogElement>(null)

--- a/src/components/FeuillesDeRoute/DetailAction.test.tsx
+++ b/src/components/FeuillesDeRoute/DetailAction.test.tsx
@@ -15,7 +15,7 @@ describe('détail d’une action', () => {
       jOuvreUneAction()
 
       // THEN
-      const drawer = screen.getByRole('dialog', { name: 'Structurer une filière de reconditionnement locale 2' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Structurer une filière de reconditionnement locale 2' })
       expect(drawer).toHaveAttribute('id', 'drawerActionId')
       const titre = within(drawer).getByRole('heading', { level: 1, name: 'Structurer une filière de reconditionnement locale 2' })
       expect(titre).toBeInTheDocument()

--- a/src/components/FeuillesDeRoute/ResumeAction.tsx
+++ b/src/components/FeuillesDeRoute/ResumeAction.tsx
@@ -13,8 +13,8 @@ export default function ResumeAction({ actions }: Props): ReactElement {
   // Stryker disable next-line BooleanLiteral
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
   const [action, setAction] = useState<FeuilleDeRouteViewModel['actions'][number]>(actions[0])
-  const drawerActionId = 'drawerActionId'
-  const labelModifierComiteId = useId()
+  const drawerId = 'drawerActionId'
+  const labelId = useId()
 
   return (
     <>
@@ -29,7 +29,7 @@ export default function ResumeAction({ actions }: Props): ReactElement {
                 />
                 <div>
                   <button
-                    aria-controls={drawerActionId}
+                    aria-controls={drawerId}
                     className="fr-text--bold color-blue-france fr-mb-1w"
                     data-fr-opened="false"
                     onClick={() => {
@@ -61,15 +61,15 @@ export default function ResumeAction({ actions }: Props): ReactElement {
         closeDrawer={() => {
           setIsDrawerOpen(false)
         }}
-        id={drawerActionId}
+        id={drawerId}
         // Stryker disable next-line BooleanLiteral
         isFixedWidth={false}
         isOpen={isDrawerOpen}
-        labelId={labelModifierComiteId}
+        labelId={labelId}
       >
         <DetailAction
           action={action}
-          labelId={labelModifierComiteId}
+          labelId={labelId}
         />
       </Drawer>
     </>

--- a/src/components/Gouvernance/Comitologie/Comitologie.test.tsx
+++ b/src/components/Gouvernance/Comitologie/Comitologie.test.tsx
@@ -16,9 +16,9 @@ describe('comitologie', () => {
       jOuvreLeFormulairePourAjouterUnComite()
 
       // THEN
-      const ajouterUnComiteDrawer = screen.getByRole('dialog', { name: 'Ajouter un comité' })
-      expect(ajouterUnComiteDrawer).toHaveAttribute('id', 'drawerAjouterComiteId')
-      const formulaire = within(ajouterUnComiteDrawer).getByRole('form', { name: 'Ajouter un comité' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Ajouter un comité' })
+      expect(drawer).toHaveAttribute('id', 'drawerAjouterComiteId')
+      const formulaire = within(drawer).getByRole('form', { name: 'Ajouter un comité' })
       const titre = within(formulaire).getByRole('heading', { level: 1, name: 'Ajouter un comité' })
       expect(titre).toBeInTheDocument()
       const sousTitre = within(formulaire).getByText('Renseignez les comités prévus et la fréquence à laquelle ils se réunissent', { selector: 'p' })
@@ -67,7 +67,7 @@ describe('comitologie', () => {
 
       // WHEN
       jOuvreLeFormulairePourAjouterUnComite()
-      const drawer = screen.getByRole('dialog', { name: 'Ajouter un comité' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Ajouter un comité' })
       const fermer = jeFermeLeFormulairePourAjouterUnComite()
 
       // THEN
@@ -82,11 +82,11 @@ describe('comitologie', () => {
 
       // WHEN
       jOuvreLeFormulairePourAjouterUnComite()
-      const ajouterUnComiteDrawer = screen.getByRole('dialog', { name: 'Ajouter un comité' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Ajouter un comité' })
       jeSelectionneUnType('Technique')
       jeSelectionneUneFrequence('Annuelle')
-      const date = jeChoisisUneDate(ajouterUnComiteDrawer, '1970-01-02')
-      const commentaire = jeTapeUnCommentaire(ajouterUnComiteDrawer, 'commentaire')
+      const date = jeChoisisUneDate(drawer, '1970-01-02')
+      const commentaire = jeTapeUnCommentaire(drawer, 'commentaire')
       const enregistrer = jEnregistreLeComite()
 
       // THEN
@@ -98,7 +98,7 @@ describe('comitologie', () => {
       expect(mensuelle).toBeInTheDocument()
       expect(date).toHaveValue('')
       expect(commentaire).toHaveValue('')
-      expect(ajouterUnComiteDrawer).not.toBeVisible()
+      expect(drawer).not.toBeVisible()
       expect(ajouterUnComiteAction).toHaveBeenCalledWith({
         commentaire: 'commentaire',
         date: '1970-01-02',
@@ -165,9 +165,9 @@ describe('comitologie', () => {
       jOuvreLeFormulairePourModifierUnComite()
 
       // THEN
-      const detailsDUnComiteDrawer = screen.getByRole('dialog', { name: 'Détail du Comité technique' })
-      expect(detailsDUnComiteDrawer).toHaveAttribute('id', 'drawerModifierComiteId')
-      const formulaire = within(detailsDUnComiteDrawer).getByRole('form', { name: 'Détail du Comité technique' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Détail du Comité technique' })
+      expect(drawer).toHaveAttribute('id', 'drawerModifierComiteId')
+      const formulaire = within(drawer).getByRole('form', { name: 'Détail du Comité technique' })
       const titre = within(formulaire).getByRole('heading', { level: 1, name: 'Détail du Comité technique' })
       expect(titre).toBeInTheDocument()
       const sousTitre = within(formulaire).getByText('Renseignez les comités prévus et la fréquence à laquelle ils se réunissent', { selector: 'p' })
@@ -225,7 +225,7 @@ describe('comitologie', () => {
 
       // WHEN
       jOuvreLeFormulairePourModifierUnComite()
-      const drawer = screen.getByRole('dialog', { name: 'Détail du Comité technique' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Détail du Comité technique' })
       const fermer = jeFermeLeFormulairePourModifierUnComite()
 
       // THEN
@@ -240,11 +240,11 @@ describe('comitologie', () => {
 
       // WHEN
       jOuvreLeFormulairePourModifierUnComite()
-      const modifierUnComiteDrawer = screen.getByRole('dialog', { name: 'Détail du Comité technique' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Détail du Comité technique' })
       jeSelectionneUnType('Technique')
       jeSelectionneUneFrequence('Trimestrielle')
-      jeChoisisUneDate(modifierUnComiteDrawer, '2990-04-15')
-      jeTapeUnCommentaire(modifierUnComiteDrawer, 'un nouveau commentaire')
+      jeChoisisUneDate(drawer, '2990-04-15')
+      jeTapeUnCommentaire(drawer, 'un nouveau commentaire')
       const enregistrer = jEnregistreLeComite()
 
       // THEN
@@ -261,7 +261,7 @@ describe('comitologie', () => {
       })
       const notification = await screen.findByRole('alert')
       expect(notification.textContent).toBe('Comité modifié')
-      expect(modifierUnComiteDrawer).not.toBeVisible()
+      expect(drawer).not.toBeVisible()
       expect(enregistrer).toHaveAccessibleName('Enregistrer')
       expect(enregistrer).toBeEnabled()
     })
@@ -273,9 +273,9 @@ describe('comitologie', () => {
 
       // WHEN
       jOuvreLeFormulairePourModifierUnComite()
-      const modifierUnComiteDrawer = screen.getByRole('dialog', { name: 'Détail du Comité technique' })
-      jeChoisisUneDate(modifierUnComiteDrawer, '')
-      jeTapeUnCommentaire(modifierUnComiteDrawer, '')
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Détail du Comité technique' })
+      jeChoisisUneDate(drawer, '')
+      jeTapeUnCommentaire(drawer, '')
       jEnregistreLeComite()
 
       // THEN
@@ -299,8 +299,8 @@ describe('comitologie', () => {
 
       // WHEN
       jOuvreLeFormulairePourModifierUnComite()
-      const modifierUnComiteDrawer = screen.getByRole('dialog', { name: 'Détail du Comité technique' })
-      jeChoisisUneDate(modifierUnComiteDrawer, epochTimePlusOneDay.toISOString())
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Détail du Comité technique' })
+      jeChoisisUneDate(drawer, epochTimePlusOneDay.toISOString())
       jEnregistreLeComite()
 
       // THEN
@@ -315,7 +315,7 @@ describe('comitologie', () => {
 
       // WHEN
       jOuvreLeFormulairePourModifierUnComite()
-      const modifierUnComiteDrawer = screen.getByRole('dialog', { name: 'Détail du Comité technique' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Détail du Comité technique' })
       const supprimer = jeSupprimeLeComite()
 
       // THEN
@@ -328,7 +328,7 @@ describe('comitologie', () => {
       })
       const notification = await screen.findByRole('alert')
       expect(notification.textContent).toBe('Comité supprimé')
-      expect(modifierUnComiteDrawer).not.toBeVisible()
+      expect(drawer).not.toBeVisible()
       expect(supprimer).toHaveAccessibleName('Supprimer')
       expect(supprimer).toBeEnabled()
     })

--- a/src/components/Gouvernance/Comitologie/ComitologieRemplie.tsx
+++ b/src/components/Gouvernance/Comitologie/ComitologieRemplie.tsx
@@ -10,8 +10,8 @@ export default function ComitologieRemplie({ comites, dateAujourdhui, uidGouvern
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
   const [comite, setComite] = useState(comites[0])
   const drawerRef = useRef<HTMLDialogElement>(null)
-  const drawerModifierComiteId = 'drawerModifierComiteId'
-  const labelModifierComiteId = useId()
+  const drawerId = 'drawerModifierComiteId'
+  const labelId = useId()
 
   return (
     <>
@@ -31,7 +31,7 @@ export default function ComitologieRemplie({ comites, dateAujourdhui, uidGouvern
               </td>
               <td className="font-weight-700">
                 <button
-                  aria-controls={drawerModifierComiteId}
+                  aria-controls={drawerId}
                   className="primary font-weight-700 fr-px-0 no-hover d-block"
                   data-fr-opened="false"
                   onClick={() => {
@@ -58,11 +58,11 @@ export default function ComitologieRemplie({ comites, dateAujourdhui, uidGouvern
         closeDrawer={() => {
           setIsDrawerOpen(false)
         }}
-        id={drawerModifierComiteId}
+        id={drawerId}
         // Stryker disable next-line BooleanLiteral
         isFixedWidth={false}
         isOpen={isDrawerOpen}
-        labelId={labelModifierComiteId}
+        labelId={labelId}
         ref={drawerRef}
       >
         <ModifierUnComite
@@ -71,9 +71,9 @@ export default function ComitologieRemplie({ comites, dateAujourdhui, uidGouvern
           }}
           comite={comite}
           dateAujourdhui={dateAujourdhui}
-          id={drawerModifierComiteId}
+          id={drawerId}
           label={`Détail du ${comite.intitule}`}
-          labelId={labelModifierComiteId}
+          labelId={labelId}
           uidGouvernance={uidGouvernance}
         />
       </Drawer>

--- a/src/components/Gouvernance/FeuilleDeRoute/FeuilleDeRoute.test.tsx
+++ b/src/components/Gouvernance/FeuilleDeRoute/FeuilleDeRoute.test.tsx
@@ -29,7 +29,7 @@ describe('feuille de route', () => {
     jOuvreLesDetailsDUneFeuilleDeRoute()
 
     // THEN
-    const drawer = screen.getByRole('dialog', { name: 'Feuille de route inclusion' })
+    const drawer = screen.getByRole('dialog', { hidden: false, name: 'Feuille de route inclusion' })
     const titreDrawer = within(drawer).getByRole('heading', { level: 1, name: 'Feuille de route inclusion' })
     expect(titreDrawer).toBeInTheDocument()
     const responsableLabel = within(drawer).getByText('Responsable de la feuille de route')
@@ -98,7 +98,7 @@ describe('feuille de route', () => {
     jOuvreLesDetailsDUneFeuilleDeRoute()
 
     // THEN
-    const drawer = screen.getByRole('dialog', { name: 'Feuille de route inclusion' })
+    const drawer = screen.getByRole('dialog', { hidden: false, name: 'Feuille de route inclusion' })
     const beneficiairesDesSubventionsLabel = within(drawer).getByText('Bénéficiaire des subventions')
     expect(beneficiairesDesSubventionsLabel).toBeInTheDocument()
     const beneficiaireDesSubventionsFormationLabel = within(drawer).getByText('Bénéficiaire des subventions formation')
@@ -113,7 +113,7 @@ describe('feuille de route', () => {
 
     // WHEN
     jOuvreLesDetailsDUneFeuilleDeRoute()
-    const drawer = screen.getByRole('dialog', { name: 'Feuille de route inclusion' })
+    const drawer = screen.getByRole('dialog', { hidden: false, name: 'Feuille de route inclusion' })
     const fermer = jeFermeLesDetailsDUneFeuilleDeRoute()
 
     // THEN

--- a/src/components/Gouvernance/FeuilleDeRoute/FeuilleDeRouteRemplie.tsx
+++ b/src/components/Gouvernance/FeuilleDeRoute/FeuilleDeRouteRemplie.tsx
@@ -13,8 +13,8 @@ export default function FeuilleDeRouteRemplie({
   // Stryker disable next-line BooleanLiteral
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
   const [feuilleDeRoute, setFeuilleDeRoute] = useState<FeuilleDeRouteViewModel>(feuillesDeRoute[0])
-  const drawerFeuilleDeRouteId = 'drawerFeuilleDeRouteId'
-  const labelFeuilleDeRouteId = useId()
+  const drawerId = 'drawerFeuilleDeRouteId'
+  const labelId = useId()
 
   return (
     <>
@@ -34,7 +34,7 @@ export default function FeuilleDeRouteRemplie({
               </td>
               <td className="font-weight-700">
                 <button
-                  aria-controls={drawerFeuilleDeRouteId}
+                  aria-controls={drawerId}
                   className="primary font-weight-700 fr-px-0 no-hover d-block"
                   data-fr-opened="false"
                   onClick={() => {
@@ -61,15 +61,15 @@ export default function FeuilleDeRouteRemplie({
         closeDrawer={() => {
           setIsDrawerOpen(false)
         }}
-        id={drawerFeuilleDeRouteId}
+        id={drawerId}
         // Stryker disable next-line BooleanLiteral
         isFixedWidth={false}
         isOpen={isDrawerOpen}
-        labelId={labelFeuilleDeRouteId}
+        labelId={labelId}
       >
         <DetailsFeuilleDeRoute
           feuilleDeRoute={feuilleDeRoute}
-          labelId={labelFeuilleDeRouteId}
+          labelId={labelId}
         />
       </Drawer>
     </>

--- a/src/components/Gouvernance/Gouvernance.test.tsx
+++ b/src/components/Gouvernance/Gouvernance.test.tsx
@@ -85,8 +85,8 @@ describe('gouvernance', () => {
     jOuvreLeFormulairePourAjouterUnComite()
 
     // THEN
-    const ajouterUnComiteDrawer = screen.getByRole('dialog', { name: 'Ajouter un comité' })
-    expect(ajouterUnComiteDrawer).toBeVisible()
+    const drawer = screen.getByRole('dialog', { hidden: false, name: 'Ajouter un comité' })
+    expect(drawer).toBeVisible()
   })
 
   it('quand j’affiche une gouvernance sans comité et que je clique sur ajouter un comité puis que je clique sur fermer, alors le drawer se ferme', () => {
@@ -96,7 +96,7 @@ describe('gouvernance', () => {
 
     // WHEN
     jOuvreLeFormulairePourAjouterUnComite()
-    const drawer = screen.getByRole('dialog', { name: 'Ajouter un comité' })
+    const drawer = screen.getByRole('dialog', { hidden: false, name: 'Ajouter un comité' })
     const fermer = jeFermeLeFormulairePourAjouterUnComite()
 
     // THEN
@@ -542,7 +542,7 @@ describe('gouvernance', () => {
 
     // WHEN
     jouvreLeFormulairePourAjouterUneNoteDeContexte()
-    const drawer = screen.getByRole('dialog', { name: 'Note de contexte' })
+    const drawer = screen.getByRole('dialog', { hidden: false, name: 'Note de contexte' })
     const fermer = jeFermeLeFormulairePourAjouterUneNoteDeContexte()
 
     // THEN

--- a/src/components/Gouvernance/Membre/Membre.test.tsx
+++ b/src/components/Gouvernance/Membre/Membre.test.tsx
@@ -31,7 +31,7 @@ describe('membres', () => {
       jOuvreLesDetailsDuMembre('Préfecture du Rhône')
 
       // THEN
-      const drawer = screen.getByRole('dialog', { name: 'Préfecture du Rhône' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Préfecture du Rhône' })
       const absenceDeDonnee = within(drawer).queryByText('-')
       expect(absenceDeDonnee).not.toBeInTheDocument()
       const titreDrawer = within(drawer).getByRole('heading', { level: 1, name: 'Préfecture du Rhône' })
@@ -101,7 +101,7 @@ describe('membres', () => {
       jOuvreLesDetailsDuMembre('Préfecture du Rhône')
 
       // THEN
-      const drawer = screen.getByRole('dialog', { name: 'Préfecture du Rhône' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Préfecture du Rhône' })
       const absenceDeDonnee = within(drawer).getAllByText('-')
       expect(absenceDeDonnee).toHaveLength(1)
     })
@@ -139,7 +139,7 @@ describe('membres', () => {
       jOuvreLesDetailsDuMembre('Préfecture du Rhône')
 
       // THEN
-      const drawer = screen.getByRole('dialog', { name: 'Préfecture du Rhône' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Préfecture du Rhône' })
       const sectionFeuilleDeRoute = within(drawer).queryByText('Feuille de route')
       expect(sectionFeuilleDeRoute).not.toBeInTheDocument()
     })
@@ -196,7 +196,7 @@ describe('membres', () => {
         jOuvreLesDetailsDuMembre('Préfecture du Rhône')
 
         // THEN
-        const drawer = screen.getByRole('dialog', { name: 'Préfecture du Rhône' })
+        const drawer = screen.getByRole('dialog', { hidden: false, name: 'Préfecture du Rhône' })
         const feuilleDeRouteSingulierOuPluriel = within(drawer).getByText(result)
         expect(feuilleDeRouteSingulierOuPluriel).toBeInTheDocument()
       }
@@ -215,7 +215,7 @@ describe('membres', () => {
       jOuvreLesDetailsDuMembre('Préfecture du Rhône')
 
       // THEN
-      const drawer = screen.getByRole('dialog', { name: 'Préfecture du Rhône' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Préfecture du Rhône' })
       const intitule = within(drawer).queryByText(intituleAttendu)
       expect(intitule).toBeInTheDocument()
     })
@@ -232,7 +232,7 @@ describe('membres', () => {
       jOuvreLesDetailsDuMembre('Préfecture du Rhône')
 
       // THEN
-      const drawer = screen.getByRole('dialog', { name: 'Préfecture du Rhône' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Préfecture du Rhône' })
       const intitule = within(drawer).queryByText(intituleAttendu)
       expect(intitule).not.toBeInTheDocument()
     })
@@ -268,7 +268,7 @@ describe('membres', () => {
         jOuvreLesDetailsDuMembre('Préfecture du Rhône')
 
         // THEN
-        const drawer = screen.getByRole('dialog', { name: 'Préfecture du Rhône' })
+        const drawer = screen.getByRole('dialog', { hidden: false, name: 'Préfecture du Rhône' })
         const plusDeDetails = within(drawer).queryByText(matchWithoutMarkup('Plus de détails'))
         expect(plusDeDetails).not.toBeInTheDocument()
       })
@@ -298,7 +298,7 @@ describe('membres', () => {
       jOuvreLesDetailsDuMembre('Département du Rhône')
 
       // THEN
-      const drawer = screen.getByRole('dialog', { name: 'Département du Rhône' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Département du Rhône' })
       const absenceDeDonnee = within(drawer).queryByText('-')
       expect(absenceDeDonnee).not.toBeInTheDocument()
       const titreDrawer = within(drawer).getByRole('heading', { level: 1, name: 'Département du Rhône' })
@@ -365,7 +365,7 @@ describe('membres', () => {
       jOuvreLesDetailsDuMembre('Département du Rhône')
 
       // THEN
-      const drawer = screen.getByRole('dialog', { name: 'Département du Rhône' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Département du Rhône' })
       const absenceDeDonnee = within(drawer).getAllByText('-')
       expect(absenceDeDonnee).toHaveLength(1)
     })
@@ -402,7 +402,7 @@ describe('membres', () => {
       jOuvreLesDetailsDuMembre('Département du Rhône')
 
       // THEN
-      const drawer = screen.getByRole('dialog', { name: 'Département du Rhône' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Département du Rhône' })
       const sectionFeuilleDeRoute = within(drawer).queryByText('Feuille de route')
       expect(sectionFeuilleDeRoute).not.toBeInTheDocument()
     })
@@ -460,7 +460,7 @@ describe('membres', () => {
         jOuvreLesDetailsDuMembre('Département du Rhône')
 
         // THEN
-        const drawer = screen.getByRole('dialog', { name: 'Département du Rhône' })
+        const drawer = screen.getByRole('dialog', { hidden: false, name: 'Département du Rhône' })
         const feuilleDeRouteSingulierOuPluriel = within(drawer).getByText(result)
         expect(feuilleDeRouteSingulierOuPluriel).toBeInTheDocument()
       }
@@ -480,7 +480,7 @@ describe('membres', () => {
       jOuvreLesDetailsDuMembre('Département du Rhône')
 
       // THEN
-      const drawer = screen.getByRole('dialog', { name: 'Département du Rhône' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Département du Rhône' })
       const intitule = within(drawer).queryByText(intituleAttendu)
       expect(intitule).toBeInTheDocument()
     })
@@ -496,7 +496,7 @@ describe('membres', () => {
       jOuvreLesDetailsDuMembre('Département du Rhône')
 
       // THEN
-      const drawer = screen.getByRole('dialog', { name: 'Département du Rhône' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Département du Rhône' })
       const intitule = within(drawer).queryByText(intituleAttendu)
       expect(intitule).not.toBeInTheDocument()
     })
@@ -509,7 +509,7 @@ describe('membres', () => {
       jOuvreLesDetailsDuMembre('Département du Rhône')
 
       // THEN
-      const drawer = screen.getByRole('dialog', { name: 'Département du Rhône' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Département du Rhône' })
       const plusDeDetails = within(drawer).getByRole('link', { name: matchWithoutMarkup('Plus de détails') })
       expect(plusDeDetails).toHaveAttribute('href', '/')
       expect(plusDeDetails).toBeInTheDocument()
@@ -550,7 +550,7 @@ describe('membres', () => {
         jOuvreLesDetailsDuMembre('Département du Rhône')
 
         // THEN
-        const drawer = screen.getByRole('dialog', { name: 'Département du Rhône' })
+        const drawer = screen.getByRole('dialog', { hidden: false, name: 'Département du Rhône' })
         const contactTechniqueIntitule = within(drawer).queryByText('Contact technique')
         expect(contactTechniqueIntitule).not.toBeInTheDocument()
       })

--- a/src/components/Gouvernance/Membre/MembreRempli.tsx
+++ b/src/components/Gouvernance/Membre/MembreRempli.tsx
@@ -12,8 +12,8 @@ export default function MembreRempli({ coporteurs }: Props): ReactElement {
   // Stryker disable next-line BooleanLiteral
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
   const [membreDetails, setMembreDetails] = useState<MembreDetailsViewModel>(coporteurs[0])
-  const drawerMembreId = 'drawerMembreId'
-  const labelMembreId = useId()
+  const drawerId = 'drawerMembreId'
+  const labelId = useId()
 
   return (
     <>
@@ -33,7 +33,7 @@ export default function MembreRempli({ coporteurs }: Props): ReactElement {
               </td>
               <td>
                 <button
-                  aria-controls={drawerMembreId}
+                  aria-controls={drawerId}
                   className="primary font-weight-700 fr-px-0 no-hover d-block"
                   data-fr-opened="false"
                   onClick={() => {
@@ -67,15 +67,15 @@ export default function MembreRempli({ coporteurs }: Props): ReactElement {
         closeDrawer={() => {
           setIsDrawerOpen(false)
         }}
-        id={drawerMembreId}
+        id={drawerId}
         // Stryker disable next-line BooleanLiteral
         isFixedWidth={false}
         isOpen={isDrawerOpen}
-        labelId={labelMembreId}
+        labelId={labelId}
       >
         <Membre
           details={membreDetails.details}
-          labelId={labelMembreId}
+          labelId={labelId}
           membreDetails={membreDetails}
         />
       </Drawer>

--- a/src/components/Gouvernance/NoteDeContexte/NoteDeContexte.test.tsx
+++ b/src/components/Gouvernance/NoteDeContexte/NoteDeContexte.test.tsx
@@ -138,7 +138,7 @@ describe('note de contexte', () => {
 
       // WHEN
       jOuvreLeFormulairePourModifierUneNoteDeContexte()
-      const drawer = screen.getByRole('dialog', { name: 'Ajouter un comité' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Ajouter un comité' })
       const fermer = jeFermeLeFormulairePourModifierUneNoteDeContexte()
 
       // THEN
@@ -254,11 +254,11 @@ function jEnregistreLaNoteDeContexte(): HTMLElement {
 }
 
 function ajouterUneNoteDeContextDrawer(): HTMLElement {
-  return screen.getByRole('dialog', { name: 'Note de contexte' })
+  return screen.getByRole('dialog', { hidden: false, name: 'Note de contexte' })
 }
 
 function modifierUneNoteDeContexteDrawer(): HTMLElement {
-  return screen.getByRole('dialog', { name: 'Note de contexte' })
+  return screen.getByRole('dialog', { hidden: false, name: 'Note de contexte' })
 }
 
 function jeFermeLeFormulairePourModifierUneNoteDeContexte(): HTMLElement {

--- a/src/components/Gouvernance/NotePrivee/NotePrivee.test.tsx
+++ b/src/components/Gouvernance/NotePrivee/NotePrivee.test.tsx
@@ -41,9 +41,9 @@ describe('note privée', () => {
       jouvreLeFormulairePourAjouterUneNotePrivee()
 
       // THEN
-      const ajouterUneNotePriveeDrawer = screen.getByRole('dialog', { name: 'Note privée' })
-      expect(ajouterUneNotePriveeDrawer).toHaveAttribute('id', 'drawerAjouterNotePriveeId')
-      const formulaire = within(ajouterUneNotePriveeDrawer).getByRole('form', { name: 'Note privée' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Note privée' })
+      expect(drawer).toHaveAttribute('id', 'drawerAjouterNotePriveeId')
+      const formulaire = within(drawer).getByRole('form', { name: 'Note privée' })
       const titre = within(formulaire).getByRole('heading', { level: 1, name: 'Note privée' })
       expect(titre).toBeInTheDocument()
       const sousTitre = within(formulaire).getByText('Uniquement accessibles par vous et votre équipe interne.', { selector: 'p' })
@@ -61,7 +61,7 @@ describe('note privée', () => {
 
       // WHEN
       jouvreLeFormulairePourAjouterUneNotePrivee()
-      const drawer = screen.getByRole('dialog', { name: 'Note privée' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Note privée' })
       const fermer = jeFermeLeFormulairePourAjouterUneNotePrivee()
 
       // THEN
@@ -76,7 +76,7 @@ describe('note privée', () => {
 
       // WHEN
       jouvreLeFormulairePourAjouterUneNotePrivee()
-      const ajouterUneNotePriveeDrawer = screen.getByRole('dialog', { name: 'Note privée' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Note privée' })
       jeTapeUneNotePrivee('un exemple de contenu de note privée')
       const enregistrer = jEnregistreLaNotePrivee()
 
@@ -90,7 +90,7 @@ describe('note privée', () => {
       })
       const notification = await screen.findByRole('alert')
       expect(notification.textContent).toBe('Note privée ajoutée')
-      expect(ajouterUneNotePriveeDrawer).not.toBeVisible()
+      expect(drawer).not.toBeVisible()
       expect(enregistrer).toHaveAccessibleName('Enregistrer')
       expect(enregistrer).toBeEnabled()
     })
@@ -127,9 +127,9 @@ describe('note privée', () => {
       jouvreLeFormulairePourModifierUneNotePrivee()
 
       // THEN
-      const ajouterUneNotePriveeDrawer = screen.getByRole('dialog', { name: 'Note privée' })
-      expect(ajouterUneNotePriveeDrawer).toHaveAttribute('id', 'drawerAjouterNotePriveeId')
-      const formulaire = within(ajouterUneNotePriveeDrawer).getByRole('form', { name: 'Note privée' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Note privée' })
+      expect(drawer).toHaveAttribute('id', 'drawerAjouterNotePriveeId')
+      const formulaire = within(drawer).getByRole('form', { name: 'Note privée' })
       const titre = within(formulaire).getByRole('heading', { level: 1, name: 'Note privée' })
       expect(titre).toBeInTheDocument()
       const sousTitre = within(formulaire).getByText('Uniquement accessibles par vous et votre équipe interne.', { selector: 'p' })
@@ -153,7 +153,7 @@ describe('note privée', () => {
 
       // WHEN
       jouvreLeFormulairePourModifierUneNotePrivee()
-      const drawer = screen.getByRole('dialog', { name: 'Note privée' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Note privée' })
       const fermer = jeFermeLeFormulairePourModifierUneNotePrivee()
 
       // THEN
@@ -168,7 +168,7 @@ describe('note privée', () => {
 
       // WHEN
       jouvreLeFormulairePourModifierUneNotePrivee()
-      const ajouterUneNotePriveeDrawer = screen.getByRole('dialog', { name: 'Note privée' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Note privée' })
       jeTapeUneNotePrivee('modification de la note privée')
       const enregistrer = jEnregistreLaNotePrivee()
 
@@ -182,7 +182,7 @@ describe('note privée', () => {
       })
       const notification = await screen.findByRole('alert')
       expect(notification.textContent).toBe('Note privée modifiée')
-      expect(ajouterUneNotePriveeDrawer).not.toBeVisible()
+      expect(drawer).not.toBeVisible()
       expect(enregistrer).toHaveAccessibleName('Enregistrer')
       expect(enregistrer).toBeEnabled()
     })
@@ -208,8 +208,8 @@ describe('note privée', () => {
 
       // WHEN
       jouvreLeFormulairePourModifierUneNotePrivee()
-      const ajouterUneNotePriveeDrawer = screen.getByRole('dialog', { name: 'Note privée' })
-      jEffaceLaNotePrivee(ajouterUneNotePriveeDrawer)
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Note privée' })
+      jEffaceLaNotePrivee(drawer)
       const enregistrer = jEnregistreLaNotePrivee()
 
       // THEN
@@ -221,7 +221,7 @@ describe('note privée', () => {
       })
       const notification = await screen.findByRole('alert')
       expect(notification.textContent).toBe('Note privée supprimée')
-      expect(ajouterUneNotePriveeDrawer).not.toBeVisible()
+      expect(drawer).not.toBeVisible()
       expect(enregistrer).toHaveAccessibleName('Enregistrer')
       expect(enregistrer).toBeEnabled()
     })
@@ -233,8 +233,8 @@ describe('note privée', () => {
 
       // WHEN
       jouvreLeFormulairePourModifierUneNotePrivee()
-      const ajouterUneNotePriveeDrawer = screen.getByRole('dialog', { name: 'Note privée' })
-      jEffaceLaNotePrivee(ajouterUneNotePriveeDrawer)
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Note privée' })
+      jEffaceLaNotePrivee(drawer)
       jEnregistreLaNotePrivee()
 
       // THEN

--- a/src/components/MesInformationsPersonnelles/MesInformationsPersonnelles.test.tsx
+++ b/src/components/MesInformationsPersonnelles/MesInformationsPersonnelles.test.tsx
@@ -160,7 +160,7 @@ describe('mes informations personnelles : en tant qu’utilisateur authentifié'
       jOuvreLeFormulairePourSupprimerMonCompte()
 
       // THEN
-      const modal = screen.getByRole('dialog', { name: 'Supprimer mon compte' })
+      const modal = screen.getByRole('dialog', { hidden: false, name: 'Supprimer mon compte' })
       expect(modal).toBeVisible()
 
       const titre = within(modal).getByRole('heading', { level: 1, name: 'Supprimer mon compte' })
@@ -191,11 +191,11 @@ describe('mes informations personnelles : en tant qu’utilisateur authentifié'
 
       // WHEN
       jOuvreLeFormulairePourSupprimerMonCompte()
-      const supprimerMonCompteModal = screen.getByRole('dialog', { name: 'Supprimer mon compte' })
+      const modal = screen.getByRole('dialog', { hidden: false, name: 'Supprimer mon compte' })
       jAnnuleLaSuppressionDeMonCompte()
 
       // THEN
-      expect(supprimerMonCompteModal).not.toBeVisible()
+      expect(modal).not.toBeVisible()
     })
 
     it('et que je clique sur fermer alors la modale se ferme', () => {
@@ -204,11 +204,11 @@ describe('mes informations personnelles : en tant qu’utilisateur authentifié'
 
       // WHEN
       jOuvreLeFormulairePourSupprimerMonCompte()
-      const supprimerMonCompteModal = screen.getByRole('dialog', { name: 'Supprimer mon compte' })
+      const modal = screen.getByRole('dialog', { hidden: false, name: 'Supprimer mon compte' })
       jeFermeLaSuppressionDeMonCompte()
 
       // THEN
-      expect(supprimerMonCompteModal).not.toBeVisible()
+      expect(modal).not.toBeVisible()
     })
 
     describe('je ne peux supprimer mon compte, le bouton étant désactivé si', () => {
@@ -323,16 +323,16 @@ describe('mes informations personnelles : en tant qu’utilisateur authentifié'
       jOuvreMesInformationsPersonnelles()
 
       // THEN
-      const modifierMesInfosPersosDrawer = screen.getByRole('dialog', { name: 'Mes informations personnelles' })
-      expect(modifierMesInfosPersosDrawer).toBeVisible()
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Mes informations personnelles' })
+      expect(drawer).toBeVisible()
 
-      const titre = within(modifierMesInfosPersosDrawer).getByRole('heading', { level: 1, name: 'Mes informations personnelles' })
+      const titre = within(drawer).getByRole('heading', { level: 1, name: 'Mes informations personnelles' })
       expect(titre).toBeInTheDocument()
 
-      const champsObligatoires = within(modifierMesInfosPersosDrawer).getByText(matchWithoutMarkup('Les champs avec * sont obligatoires.'), { selector: 'p' })
+      const champsObligatoires = within(drawer).getByText(matchWithoutMarkup('Les champs avec * sont obligatoires.'), { selector: 'p' })
       expect(champsObligatoires).toBeInTheDocument()
 
-      const formulaire = within(modifierMesInfosPersosDrawer).getByRole('form', { name: 'Modifier' })
+      const formulaire = within(drawer).getByRole('form', { name: 'Modifier' })
       expect(formulaire).toHaveAttribute('method', 'dialog')
       const nom = within(formulaire).getByLabelText('Nom *')
       expect(nom).toBeRequired()
@@ -359,12 +359,12 @@ describe('mes informations personnelles : en tant qu’utilisateur authentifié'
 
       const annuler = within(formulaire).getByRole('button', { name: 'Annuler' })
       expect(annuler).toHaveAttribute('type', 'reset')
-      expect(annuler).toHaveAttribute('aria-controls', 'drawer-modifier-mon-compte')
+      expect(annuler).toHaveAttribute('aria-controls', 'drawerMesInformationsPersonnellesId')
 
       const enregistrer = within(formulaire).getByRole('button', { name: 'Enregistrer' })
       expect(enregistrer).toBeEnabled()
       expect(enregistrer).toHaveAttribute('type', 'submit')
-      expect(enregistrer).toHaveAttribute('aria-controls', 'drawer-modifier-mon-compte')
+      expect(enregistrer).toHaveAttribute('aria-controls', 'drawerMesInformationsPersonnellesId')
     })
 
     it('alors le téléphone n’est pas rempli s’il est non renseigné', () => {
@@ -385,11 +385,11 @@ describe('mes informations personnelles : en tant qu’utilisateur authentifié'
 
       // WHEN
       jOuvreMesInformationsPersonnelles()
-      const modifierMesInfosPersosDrawer = screen.getByRole('dialog', { name: 'Mes informations personnelles' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Mes informations personnelles' })
       jAnnuleMesInformationsPersonnelles()
 
       // THEN
-      expect(modifierMesInfosPersosDrawer).not.toBeVisible()
+      expect(drawer).not.toBeVisible()
     })
 
     it('et que je clique sur fermer alors la modale se ferme', () => {
@@ -398,11 +398,11 @@ describe('mes informations personnelles : en tant qu’utilisateur authentifié'
 
       // WHEN
       jOuvreMesInformationsPersonnelles()
-      const modifierMesInfosPersosDrawer = screen.getByRole('dialog', { name: 'Mes informations personnelles' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Mes informations personnelles' })
       jeFermeMesInformationsPersonnelles()
 
       // THEN
-      expect(modifierMesInfosPersosDrawer).not.toBeVisible()
+      expect(drawer).not.toBeVisible()
     })
 
     it('quand je modifie mes informations personnelles, alors le drawer se ferme, une notification s’affiche et mes informations personnelles sont mises à jour', async () => {
@@ -412,7 +412,7 @@ describe('mes informations personnelles : en tant qu’utilisateur authentifié'
 
       // WHEN
       jOuvreMesInformationsPersonnelles()
-      const modifierMesInfosPersosDrawer = screen.getByRole('dialog', { name: 'Mes informations personnelles' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Mes informations personnelles' })
       jeTapeMonNom('Tartempion')
       jeTapeMonPrenom('Martin')
       jeTapeMonEMail('martin.tartempion@example.com')
@@ -431,7 +431,7 @@ describe('mes informations personnelles : en tant qu’utilisateur authentifié'
       })
       const notification = await screen.findByRole('alert')
       expect(notification.textContent).toBe('Informations personnelles modifiées')
-      expect(modifierMesInfosPersosDrawer).not.toBeVisible()
+      expect(drawer).not.toBeVisible()
       expect(enregistrer).toHaveAccessibleName('Enregistrer')
       expect(enregistrer).toBeEnabled()
     })

--- a/src/components/MesInformationsPersonnelles/MesInformationsPersonnelles.tsx
+++ b/src/components/MesInformationsPersonnelles/MesInformationsPersonnelles.tsx
@@ -17,8 +17,8 @@ export default function MesInformationsPersonnelles({ mesInformationsPersonnelle
   const supprimerMonCompteModalId = 'supprimer-mon-compte'
   // Stryker disable next-line BooleanLiteral
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
-  const drawerModifierMonCompteRef = useRef<HTMLDialogElement>(null)
-  const drawerId = 'drawer-modifier-mon-compte'
+  const drawerRef = useRef<HTMLDialogElement>(null)
+  const drawerId = 'drawerMesInformationsPersonnellesId'
   const labelId = useId()
 
   return (
@@ -212,7 +212,7 @@ export default function MesInformationsPersonnelles({ mesInformationsPersonnelle
         isFixedWidth={false}
         isOpen={isDrawerOpen}
         labelId={labelId}
-        ref={drawerModifierMonCompteRef}
+        ref={drawerRef}
       >
         <ModifierMonCompte
           closeDrawer={() => {

--- a/src/components/MesMembres/MesMembres.test.tsx
+++ b/src/components/MesMembres/MesMembres.test.tsx
@@ -24,15 +24,15 @@ describe('membres gouvernance', () => {
       jOuvreLeFormulairePourAjouterUnMembre()
 
       // THEN
-      const ajouterUnMembreDrawer = screen.getByRole('dialog', { name: 'Ajouter un membre à la gouvernance' })
-      expect(ajouterUnMembreDrawer).toBeVisible()
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Ajouter un membre à la gouvernance' })
+      expect(drawer).toBeVisible()
 
-      const titre = within(ajouterUnMembreDrawer).getByRole('heading', { level: 1, name: 'Ajouter un membre à la gouvernance' })
+      const titre = within(drawer).getByRole('heading', { level: 1, name: 'Ajouter un membre à la gouvernance' })
       expect(titre).toBeInTheDocument()
-      const sousTitre = within(ajouterUnMembreDrawer).getByText('Sélectionnez une collectivité ou une structure parmi la liste des volontaires.', { selector: 'p' })
+      const sousTitre = within(drawer).getByText('Sélectionnez une collectivité ou une structure parmi la liste des volontaires.', { selector: 'p' })
       expect(sousTitre).toBeInTheDocument()
 
-      const formulaire = within(ajouterUnMembreDrawer).getByRole('form', { name: 'Ajouter un membre à la gouvernance' })
+      const formulaire = within(drawer).getByRole('form', { name: 'Ajouter un membre à la gouvernance' })
       expect(formulaire).toHaveAttribute('method', 'dialog')
       const fieldset = within(formulaire).getByRole('group', { name: 'Sélectionner un membre' })
       const candidatOuSuggere = within(fieldset).getByRole('combobox', { name: 'Membre candidat ou suggéré' })
@@ -60,11 +60,11 @@ describe('membres gouvernance', () => {
 
       // WHEN
       jOuvreLeFormulairePourAjouterUnMembre()
-      const supprimerMonCompteModal = screen.getByRole('dialog', { name: 'Ajouter un membre à la gouvernance' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Ajouter un membre à la gouvernance' })
       jeFermeLeFormulairePourAjouterUnMembre()
 
       // THEN
-      expect(supprimerMonCompteModal).not.toBeVisible()
+      expect(drawer).not.toBeVisible()
     })
 
     it('puis que je sélectionne un membre alors ses informations s’affichent en entier', () => {
@@ -73,11 +73,11 @@ describe('membres gouvernance', () => {
 
       // WHEN
       jOuvreLeFormulairePourAjouterUnMembre()
-      const ajouterUnMembreDrawer = screen.getByRole('dialog', { name: 'Ajouter un membre à la gouvernance' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Ajouter un membre à la gouvernance' })
       jeSelectionneUnCandidat('structure-99229991601034')
 
       // THEN
-      const formulaire = within(ajouterUnMembreDrawer).getByRole('form', { name: 'Ajouter un membre à la gouvernance' })
+      const formulaire = within(drawer).getByRole('form', { name: 'Ajouter un membre à la gouvernance' })
       const information = within(formulaire).queryByText(matchWithoutMarkup('Vous ne trouvez pas une collectivité/structure dans la liste ? Afin de récupérer leurs informations de contact, invitez les collectivités et structures qui n’ont pas encore manifesté leur souhait de participer à compléter le formulaire disponible via ce lien : https://inclusion-numerique.anct.gouv.fr/gouvernance'), { selector: 'p' })
       expect(information).not.toBeInTheDocument()
 
@@ -116,11 +116,11 @@ describe('membres gouvernance', () => {
 
       // WHEN
       jOuvreLeFormulairePourAjouterUnMembre()
-      const ajouterUnMembreDrawer = screen.getByRole('dialog', { name: 'Ajouter un membre à la gouvernance' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Ajouter un membre à la gouvernance' })
       jeSelectionneUnCandidat('structure-99339991601034')
 
       // THEN
-      const formulaire = within(ajouterUnMembreDrawer).getByRole('form', { name: 'Ajouter un membre à la gouvernance' })
+      const formulaire = within(drawer).getByRole('form', { name: 'Ajouter un membre à la gouvernance' })
       const informationsMembre = within(formulaire).getAllByRole('group')[1]
       const donneesNonFournies = within(informationsMembre).getAllByText('Donnée non fournie')
       expect(donneesNonFournies).toHaveLength(2)
@@ -132,12 +132,12 @@ describe('membres gouvernance', () => {
 
       // WHEN
       jOuvreLeFormulairePourAjouterUnMembre()
-      const ajouterUnMembreDrawer = screen.getByRole('dialog', { name: 'Ajouter un membre à la gouvernance' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Ajouter un membre à la gouvernance' })
       jeSelectionneUnCandidat('structure-99229991601034')
       jeSelectionneUnCandidat('')
 
       // THEN
-      const formulaire = within(ajouterUnMembreDrawer).getByRole('form', { name: 'Ajouter un membre à la gouvernance' })
+      const formulaire = within(drawer).getByRole('form', { name: 'Ajouter un membre à la gouvernance' })
       const information = within(formulaire).getByText(matchWithoutMarkup('Vous ne trouvez pas une collectivité/structure dans la liste ? Afin de récupérer leurs informations de contact, invitez les collectivités et structures qui n’ont pas encore manifesté leur souhait de participer à compléter le formulaire disponible via ce lien : https://inclusion-numerique.anct.gouv.fr/gouvernance'), { selector: 'p' })
       expect(information).toBeInTheDocument()
       const bouton = within(formulaire).getByRole('button', { name: 'Ajouter' })
@@ -151,7 +151,7 @@ describe('membres gouvernance', () => {
 
       // WHEN
       jOuvreLeFormulairePourAjouterUnMembre()
-      const ajouterUnMembreDrawer = screen.getByRole('dialog', { name: 'Ajouter un membre à la gouvernance' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Ajouter un membre à la gouvernance' })
       const selectionnerUnMembre = screen.getByRole<HTMLOptionElement>('option', { name: 'Sélectionner un membre' })
       jeSelectionneUnCandidat('structure-99229991601034')
       const ajouter = jAjouteUnMembre()
@@ -166,7 +166,7 @@ describe('membres gouvernance', () => {
       })
       const notification = await screen.findByRole('alert')
       expect(notification.textContent).toBe('Membre ajouté')
-      expect(ajouterUnMembreDrawer).not.toBeVisible()
+      expect(drawer).not.toBeVisible()
       expect(selectionnerUnMembre.selected).toBe(true)
       expect(ajouter).toHaveAccessibleName('Ajouter')
       expect(ajouter).toBeDisabled()

--- a/src/components/MesMembres/MesMembres.tsx
+++ b/src/components/MesMembres/MesMembres.tsx
@@ -10,7 +10,7 @@ import { MesMembresViewModel } from '@/presenters/mesMembresPresenter'
 export default function MesMembres({ mesMembresViewModel }: Props): ReactElement {
   // Stryker disable next-line BooleanLiteral
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
-  const drawerId = 'drawerAjouterUnMembre'
+  const drawerId = 'drawerAjouterMembreId'
   const labelId = useId()
 
   return (

--- a/src/components/MesUtilisateurs/FiltrerMesUtilisateurs.test.tsx
+++ b/src/components/MesUtilisateurs/FiltrerMesUtilisateurs.test.tsx
@@ -15,21 +15,21 @@ describe('filtrer mes utilisateurs', () => {
     jOuvreLeFormulairePourFiltrer()
 
     // THEN
-    const drawerFiltrer = screen.getByRole('dialog', { name: 'Filtrer' })
+    const drawer = screen.getByRole('dialog', { hidden: false, name: 'Filtrer' })
 
-    const titre = within(drawerFiltrer).getByRole('heading', { level: 1, name: 'Filtrer' })
+    const titre = within(drawer).getByRole('heading', { level: 1, name: 'Filtrer' })
     expect(titre).toBeInTheDocument()
 
-    const formulaire = within(drawerFiltrer).getByRole('form', { name: 'Filtrer' })
+    const formulaire = within(drawer).getByRole('form', { name: 'Filtrer' })
     expect(formulaire).toHaveAttribute('method', 'dialog')
 
-    const utilisateursActives = within(drawerFiltrer).getByRole('checkbox', { checked: false, name: 'Uniquement les utilisateurs activés' })
+    const utilisateursActives = within(drawer).getByRole('checkbox', { checked: false, name: 'Uniquement les utilisateurs activés' })
     expect(utilisateursActives).toHaveAttribute('name', 'utilisateursActives')
 
-    const zonesGeographiques = within(drawerFiltrer).getByRole('combobox', { name: 'Par zone géographique' })
+    const zonesGeographiques = within(drawer).getByRole('combobox', { name: 'Par zone géographique' })
     expect(zonesGeographiques).toBeInTheDocument()
 
-    const structure = within(drawerFiltrer).getByRole('combobox', { name: 'Par structure' })
+    const structure = within(drawer).getByRole('combobox', { name: 'Par structure' })
     expect(structure).toBeInTheDocument()
 
     const administrateurDispositif = within(formulaire).getByRole('checkbox', { checked: true, name: 'Administrateur dispositif' })
@@ -64,7 +64,7 @@ describe('filtrer mes utilisateurs', () => {
 
     // WHEN
     jOuvreLeFormulairePourFiltrer()
-    const drawer = screen.getByRole('dialog', { name: 'Filtrer' })
+    const drawer = screen.getByRole('dialog', { hidden: false, name: 'Filtrer' })
     const fermer = jeFermeLeFormulairePourFiltrer()
 
     // THEN
@@ -141,7 +141,7 @@ describe('filtrer mes utilisateurs', () => {
 
       // WHEN
       jOuvreLeFormulairePourFiltrer()
-      const drawer = screen.getByRole('dialog', { name: 'Filtrer' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Filtrer' })
       jeSelectionneUniquementLesUtilisateursActives()
       jeFiltreLesUtilisateurs()
 

--- a/src/components/MesUtilisateurs/InviterUnUtilisateur.test.tsx
+++ b/src/components/MesUtilisateurs/InviterUnUtilisateur.test.tsx
@@ -15,11 +15,11 @@ describe('inviter un utilisateur', () => {
     jOuvreLeFormulairePourInviterUnUtilisateur()
 
     // THEN
-    const drawerInvitation = screen.getByRole('dialog', { name: 'Invitez un utilisateur à rejoindre l’espace de gestion' })
-    const titre = await within(drawerInvitation).findByRole('heading', { level: 1, name: 'Invitez un utilisateur à rejoindre l’espace de gestion' })
+    const drawer = screen.getByRole('dialog', { hidden: false, name: 'Invitez un utilisateur à rejoindre l’espace de gestion' })
+    const titre = await within(drawer).findByRole('heading', { level: 1, name: 'Invitez un utilisateur à rejoindre l’espace de gestion' })
     expect(titre).toBeInTheDocument()
 
-    const champsObligatoires = within(drawerInvitation).getByText(
+    const champsObligatoires = within(drawer).getByText(
       matchWithoutMarkup('Les champs avec * sont obligatoires.'),
       { selector: 'p' }
     )
@@ -201,46 +201,46 @@ describe('inviter un utilisateur', () => {
     jOuvreLeFormulairePourInviterUnUtilisateur()
 
     // THEN
-    const formulaireInvitation = screen.getByRole('dialog', { name: 'Invitez un utilisateur à rejoindre l’espace de gestion' })
-    const titre = await within(formulaireInvitation).findByRole('heading', { level: 1, name: 'Invitez un utilisateur à rejoindre l’espace de gestion' })
+    const drawer = screen.getByRole('dialog', { hidden: false, name: 'Invitez un utilisateur à rejoindre l’espace de gestion' })
+    const titre = await within(drawer).findByRole('heading', { level: 1, name: 'Invitez un utilisateur à rejoindre l’espace de gestion' })
     expect(titre).toBeInTheDocument()
 
-    const champsObligatoires = within(formulaireInvitation).getByText(
+    const champsObligatoires = within(drawer).getByText(
       matchWithoutMarkup('Les champs avec * sont obligatoires.'),
       { selector: 'p' }
     )
     expect(champsObligatoires).toBeInTheDocument()
 
-    const nom = within(formulaireInvitation).getByLabelText('Nom *')
+    const nom = within(drawer).getByLabelText('Nom *')
     expect(nom).toBeRequired()
     expect(nom).toHaveAttribute('name', 'nom')
     expect(nom).toHaveAttribute('type', 'text')
 
-    const prenom = within(formulaireInvitation).getByLabelText('Prénom *')
+    const prenom = within(drawer).getByLabelText('Prénom *')
     expect(prenom).toBeRequired()
     expect(prenom).toHaveAttribute('name', 'prenom')
     expect(prenom).toHaveAttribute('type', 'text')
 
-    const email = within(formulaireInvitation).getByLabelText('Adresse électronique *Une invitation lui sera envoyée par e-mail')
+    const email = within(drawer).getByLabelText('Adresse électronique *Une invitation lui sera envoyée par e-mail')
     expect(email).toBeRequired()
     expect(email).toHaveAttribute('name', 'email')
     expect(email).toHaveAttribute('pattern', '^\\S+@\\S+\\.\\S+$')
     expect(email).toHaveAttribute('type', 'email')
     expect(email).toHaveAttribute('aria-describedby', 'text-input-error-desc-error')
 
-    const roleQuestion = within(formulaireInvitation).getByText(
+    const roleQuestion = within(drawer).getByText(
       matchWithoutMarkup('Rôle attribué à cet utilisateur :'),
       { selector: 'p' }
     )
     expect(roleQuestion).toBeInTheDocument()
 
-    const role = within(formulaireInvitation).getByText(
+    const role = within(drawer).getByText(
       matchWithoutMarkup('Gestionnaire département'),
       { selector: 'p' }
     )
     expect(role).toBeInTheDocument()
 
-    const envoyerInvitation = within(formulaireInvitation).getByRole('button', { name: 'Envoyer l’invitation' })
+    const envoyerInvitation = within(drawer).getByRole('button', { name: 'Envoyer l’invitation' })
     expect(envoyerInvitation).toHaveAttribute('type', 'submit')
     expect(envoyerInvitation).toBeEnabled()
   })
@@ -254,7 +254,7 @@ describe('inviter un utilisateur', () => {
 
     // WHEN
     jOuvreLeFormulairePourInviterUnUtilisateur()
-    const drawerInvitation = jOuvreLeFormulaireDInvitation()
+    const drawer = jOuvreLeFormulaireDInvitation()
     const roleRadios = screen.getAllByRole('radio')
     const nom = jeTapeSonNom('Tartempion')
     const prenom = jeTapeSonPrenom('Martin')
@@ -277,7 +277,7 @@ describe('inviter un utilisateur', () => {
     })
     const notification = await screen.findByRole('alert')
     expect(notification.textContent).toBe('Invitation envoyée à martin.tartempion@example.com')
-    expect(drawerInvitation).not.toBeVisible()
+    expect(drawer).not.toBeVisible()
     expect(nom).toHaveValue('')
     expect(prenom).toHaveValue('')
     expect(email).toHaveValue('')
@@ -304,7 +304,7 @@ describe('inviter un utilisateur', () => {
 
     // WHEN
     jOuvreLeFormulairePourInviterUnUtilisateur()
-    const drawerInvitation = jOuvreLeFormulaireDInvitation()
+    const drawer = jOuvreLeFormulaireDInvitation()
     const roleRadios = screen.getAllByRole('radio')
     const nom = jeTapeSonNom('Tartempion')
     const prenom = jeTapeSonPrenom('Martin')
@@ -321,7 +321,7 @@ describe('inviter un utilisateur', () => {
     expect(absenceMessageDErreur).not.toBeInTheDocument()
     const notification = await screen.findByRole('alert')
     expect(notification).toHaveTextContent('Invitation envoyée à martin.tartempion@example.com')
-    expect(drawerInvitation).not.toBeVisible()
+    expect(drawer).not.toBeVisible()
     expect(nom).toHaveValue('')
     expect(prenom).toHaveValue('')
     expect(email).toHaveValue('')
@@ -329,7 +329,7 @@ describe('inviter un utilisateur', () => {
       expect(roleRadio).not.toBeChecked()
     })
     Object.values(roleGestionnaireLabelSelectionMapping).forEach((labelChampSelection) => {
-      const champSelection = within(drawerInvitation).queryByLabelText(`${labelChampSelection} *`)
+      const champSelection = within(drawer).queryByLabelText(`${labelChampSelection} *`)
       expect(champSelection).not.toBeInTheDocument()
     })
   })
@@ -360,7 +360,7 @@ describe('inviter un utilisateur', () => {
 
     // WHEN
     jOuvreLeFormulairePourInviterUnUtilisateur()
-    const drawerInvitation = jOuvreLeFormulaireDInvitation()
+    const drawer = jOuvreLeFormulaireDInvitation()
     jeTapeSonNom('Tartempion')
     jeTapeSonPrenom('Martin')
     jeTapeSonAdresseElectronique('martin.tartempion@example.com')
@@ -368,9 +368,9 @@ describe('inviter un utilisateur', () => {
     jEnvoieLInvitation()
 
     // THEN
-    const erreurEmailDejaExistant = await within(drawerInvitation).findByText('Cet utilisateur dispose déjà d’un compte', { selector: 'p' })
+    const erreurEmailDejaExistant = await within(drawer).findByText('Cet utilisateur dispose déjà d’un compte', { selector: 'p' })
     expect(erreurEmailDejaExistant).toBeInTheDocument()
-    expect(drawerInvitation).toBeVisible()
+    expect(drawer).toBeVisible()
   })
 
   it('dans le drawer d’invitation, quand je remplis correctement le formulaire mais que l’invitation ne peut pas se faire, alors le drawer se ferme', async () => {
@@ -381,8 +381,8 @@ describe('inviter un utilisateur', () => {
 
     // WHEN
     jOuvreLeFormulairePourInviterUnUtilisateur()
-    const drawerInvitation = jOuvreLeFormulaireDInvitation()
-    const roleRadios = within(drawerInvitation).getAllByRole('radio')
+    const drawer = jOuvreLeFormulaireDInvitation()
+    const roleRadios = within(drawer).getAllByRole('radio')
     const nom = jeTapeSonNom('Tartempion')
     const prenom = jeTapeSonPrenom('Martin')
     const email = jeTapeSonAdresseElectronique('martin.tartempion@example.com')
@@ -390,10 +390,10 @@ describe('inviter un utilisateur', () => {
     jEnvoieLInvitation()
 
     // THEN
-    const absenceDeMessageDErreur = within(drawerInvitation).queryByText('Cet utilisateur dispose déjà d’un compte', { selector: 'p' })
+    const absenceDeMessageDErreur = within(drawer).queryByText('Cet utilisateur dispose déjà d’un compte', { selector: 'p' })
     expect(absenceDeMessageDErreur).not.toBeInTheDocument()
     await waitFor(() => {
-      expect(drawerInvitation).not.toBeVisible()
+      expect(drawer).not.toBeVisible()
     })
     expect(nom).toHaveValue('')
     expect(prenom).toHaveValue('')
@@ -456,7 +456,7 @@ describe('inviter un utilisateur', () => {
   }
 
   function jOuvreLeFormulaireDInvitation(): HTMLElement {
-    return screen.getByRole('dialog', { name: 'Invitez un utilisateur à rejoindre l’espace de gestion' })
+    return screen.getByRole('dialog', { hidden: false, name: 'Invitez un utilisateur à rejoindre l’espace de gestion' })
   }
 
   function afficherMesUtilisateurs(options?: Partial<Parameters<typeof renderComponent>[1]>): void {

--- a/src/components/MesUtilisateurs/MesUtilisateurs.test.tsx
+++ b/src/components/MesUtilisateurs/MesUtilisateurs.test.tsx
@@ -204,32 +204,32 @@ describe('mes utilisateurs', () => {
     jOuvreLesDetailsDunUtilisateur('Martin Tartempion')
 
     // THEN
-    const drawerDetailsUtilisateur = screen.getByRole('dialog', { name: 'Martin Tartempion' })
-    const prenomEtNom = within(drawerDetailsUtilisateur).getByRole('heading', { level: 1, name: 'Martin Tartempion' })
+    const drawer = screen.getByRole('dialog', { hidden: false, name: 'Martin Tartempion' })
+    const prenomEtNom = within(drawer).getByRole('heading', { level: 1, name: 'Martin Tartempion' })
     expect(prenomEtNom).toBeInTheDocument()
-    const roleAttribueLabel = within(drawerDetailsUtilisateur).getByText('Rôle attribué')
+    const roleAttribueLabel = within(drawer).getByText('Rôle attribué')
     expect(roleAttribueLabel).toBeInTheDocument()
-    const roleAttribue = within(drawerDetailsUtilisateur).getByText('Administrateur dispositif')
+    const roleAttribue = within(drawer).getByText('Administrateur dispositif')
     expect(roleAttribue).toBeInTheDocument()
 
-    const emailLabel = within(drawerDetailsUtilisateur).getByText('Adresse électronique')
+    const emailLabel = within(drawer).getByText('Adresse électronique')
     expect(emailLabel).toBeInTheDocument()
-    const email = within(drawerDetailsUtilisateur).getByText('martin.tartempion@example.net')
+    const email = within(drawer).getByText('martin.tartempion@example.net')
     expect(email).toBeInTheDocument()
 
-    const telephoneLabel = within(drawerDetailsUtilisateur).getByText('Téléphone professionnel')
+    const telephoneLabel = within(drawer).getByText('Téléphone professionnel')
     expect(telephoneLabel).toBeInTheDocument()
-    const telephone = within(drawerDetailsUtilisateur).getByText('0102030405')
+    const telephone = within(drawer).getByText('0102030405')
     expect(telephone).toBeInTheDocument()
 
-    const derniereConnexionLabel = within(drawerDetailsUtilisateur).getByText('Dernière connexion')
+    const derniereConnexionLabel = within(drawer).getByText('Dernière connexion')
     expect(derniereConnexionLabel).toBeInTheDocument()
-    const derniereConnexion = within(drawerDetailsUtilisateur).getByText('02/01/1970')
+    const derniereConnexion = within(drawer).getByText('02/01/1970')
     expect(derniereConnexion).toBeInTheDocument()
 
-    const structureLabel = within(drawerDetailsUtilisateur).getByText('Structure ou collectivité')
+    const structureLabel = within(drawer).getByText('Structure ou collectivité')
     expect(structureLabel).toBeInTheDocument()
-    const structure = within(drawerDetailsUtilisateur).getByText('Préfecture du Rhône')
+    const structure = within(drawer).getByText('Préfecture du Rhône')
     expect(structure).toBeInTheDocument()
   })
 
@@ -239,7 +239,7 @@ describe('mes utilisateurs', () => {
 
     // WHEN
     jOuvreLesDetailsDunUtilisateur('Martin Tartempion')
-    const drawer = screen.getByRole('dialog', { name: 'Martin Tartempion' })
+    const drawer = screen.getByRole('dialog', { hidden: false, name: 'Martin Tartempion' })
     const fermer = jeFermeLesDetailsDunUtilisateur()
 
     // THEN
@@ -256,13 +256,13 @@ describe('mes utilisateurs', () => {
       jOuvreLesDetailsDunUtilisateur('Julien Deschamps')
 
       // THEN
-      const drawerRenvoyerInvitation = screen.getByRole('dialog', { name: 'Invitation envoyée le 30/12/1969' })
-      const titre = within(drawerRenvoyerInvitation).getByRole('heading', { level: 1, name: 'Invitation envoyée le 30/12/1969' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Invitation envoyée le 30/12/1969' })
+      const titre = within(drawer).getByRole('heading', { level: 1, name: 'Invitation envoyée le 30/12/1969' })
       expect(titre).toBeInTheDocument()
 
-      const emailLabel = within(drawerRenvoyerInvitation).getByText('Adresse électronique')
+      const emailLabel = within(drawer).getByText('Adresse électronique')
       expect(emailLabel).toBeInTheDocument()
-      const email = within(drawerRenvoyerInvitation).getByText('julien.deschamps@example.com')
+      const email = within(drawer).getByText('julien.deschamps@example.com')
       expect(email).toBeInTheDocument()
 
       const renvoyerCetteInvitation = screen.getByRole('button', { name: 'Renvoyer cette invitation' })
@@ -277,7 +277,7 @@ describe('mes utilisateurs', () => {
 
       // WHEN
       jOuvreLaReinvitation('Stephane Raymond')
-      const drawer = screen.getByRole('dialog', { name: 'Invitation envoyée hier' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Invitation envoyée hier' })
       const fermer = jeFermeLaReinvitation()
 
       // THEN
@@ -292,7 +292,7 @@ describe('mes utilisateurs', () => {
 
       // WHEN
       jOuvreLesDetailsDunUtilisateur('Julien Deschamps')
-      const drawer = screen.getByRole('dialog', { name: 'Invitation envoyée le 30/12/1969' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Invitation envoyée le 30/12/1969' })
       const envoyer = jeRenvoieLInvitation()
 
       // THEN
@@ -328,8 +328,8 @@ describe('mes utilisateurs', () => {
       jOuvreLaReinvitation('Sebastien Palat')
 
       // THEN
-      const drawerRenvoyerInvitation = screen.getByRole('dialog', { name: 'Invitation envoyée aujourd’hui' })
-      const titre = within(drawerRenvoyerInvitation).getByRole('heading', { level: 1, name: 'Invitation envoyée aujourd’hui' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Invitation envoyée aujourd’hui' })
+      const titre = within(drawer).getByRole('heading', { level: 1, name: 'Invitation envoyée aujourd’hui' })
       expect(titre).toBeInTheDocument()
     })
 
@@ -341,8 +341,8 @@ describe('mes utilisateurs', () => {
       jOuvreLaReinvitation('Stephane Raymond')
 
       // THEN
-      const drawerRenvoyerInvitation = screen.getByRole('dialog', { name: 'Invitation envoyée hier' })
-      const titre = within(drawerRenvoyerInvitation).getByRole('heading', { level: 1, name: 'Invitation envoyée hier' })
+      const drawer = screen.getByRole('dialog', { hidden: false, name: 'Invitation envoyée hier' })
+      const titre = within(drawer).getByRole('heading', { level: 1, name: 'Invitation envoyée hier' })
       expect(titre).toBeInTheDocument()
     })
   })
@@ -355,32 +355,32 @@ describe('mes utilisateurs', () => {
     jOuvreLesDetailsDunUtilisateur('Paul Provost')
 
     // THEN
-    const drawerDetailsUtilisateur = screen.getByRole('dialog', { name: 'Paul Provost' })
-    const prenomEtNom = within(drawerDetailsUtilisateur).getByRole('heading', { level: 1, name: 'Paul Provost' })
+    const drawer = screen.getByRole('dialog', { hidden: false, name: 'Paul Provost' })
+    const prenomEtNom = within(drawer).getByRole('heading', { level: 1, name: 'Paul Provost' })
     expect(prenomEtNom).toBeInTheDocument()
-    const roleAttribueLabel = within(drawerDetailsUtilisateur).getByText('Rôle attribué')
+    const roleAttribueLabel = within(drawer).getByText('Rôle attribué')
     expect(roleAttribueLabel).toBeInTheDocument()
-    const roleAttribue = within(drawerDetailsUtilisateur).getByText('Administrateur dispositif')
+    const roleAttribue = within(drawer).getByText('Administrateur dispositif')
     expect(roleAttribue).toBeInTheDocument()
 
-    const emailLabel = within(drawerDetailsUtilisateur).getByText('Adresse électronique')
+    const emailLabel = within(drawer).getByText('Adresse électronique')
     expect(emailLabel).toBeInTheDocument()
-    const email = within(drawerDetailsUtilisateur).getByText('paul.provost@example.net')
+    const email = within(drawer).getByText('paul.provost@example.net')
     expect(email).toBeInTheDocument()
 
-    const telephoneLabel = within(drawerDetailsUtilisateur).getByText('Téléphone professionnel')
+    const telephoneLabel = within(drawer).getByText('Téléphone professionnel')
     expect(telephoneLabel).toBeInTheDocument()
-    const telephone = within(drawerDetailsUtilisateur).getByText('Non renseigné')
+    const telephone = within(drawer).getByText('Non renseigné')
     expect(telephone).toBeInTheDocument()
 
-    const derniereConnexionLabel = within(drawerDetailsUtilisateur).getByText('Dernière connexion')
+    const derniereConnexionLabel = within(drawer).getByText('Dernière connexion')
     expect(derniereConnexionLabel).toBeInTheDocument()
-    const derniereConnexion = within(drawerDetailsUtilisateur).getByText('31/12/1969')
+    const derniereConnexion = within(drawer).getByText('31/12/1969')
     expect(derniereConnexion).toBeInTheDocument()
 
-    const structureLabel = within(drawerDetailsUtilisateur).getByText('Structure ou collectivité')
+    const structureLabel = within(drawer).getByText('Structure ou collectivité')
     expect(structureLabel).toBeInTheDocument()
-    const structureOuCollectivite = within(drawerDetailsUtilisateur).getByText('Préfecture du Rhône')
+    const structureOuCollectivite = within(drawer).getByText('Préfecture du Rhône')
     expect(structureOuCollectivite).toBeInTheDocument()
   })
 
@@ -393,18 +393,18 @@ describe('mes utilisateurs', () => {
       jOuvreLaSuppressionDUnUtilisateur()
 
       // THEN
-      const supprimerUnUtilisateurModal = screen.getByRole('dialog')
-      expect(supprimerUnUtilisateurModal).toBeVisible()
+      const modal = screen.getByRole('dialog', { hidden: false })
+      expect(modal).toBeVisible()
 
-      const titre = within(supprimerUnUtilisateurModal)
+      const titre = within(modal)
         .getByRole('heading', { level: 1, name: 'Retirer Julien Deschamps de mon équipe d’utilisateurs ?' })
       expect(titre).toBeInTheDocument()
 
-      const annuler = within(supprimerUnUtilisateurModal).getByRole('button', { name: 'Annuler' })
+      const annuler = within(modal).getByRole('button', { name: 'Annuler' })
       expect(annuler).toHaveAttribute('type', 'button')
       expect(annuler).toHaveAttribute('aria-controls', 'supprimer-un-utilisateur')
 
-      const confirmer = within(supprimerUnUtilisateurModal).getByRole('button', { name: 'Confirmer' })
+      const confirmer = within(modal).getByRole('button', { name: 'Confirmer' })
       expect(confirmer).toHaveAttribute('type', 'button')
     })
 
@@ -418,7 +418,7 @@ describe('mes utilisateurs', () => {
 
       // WHEN
       jOuvreLaSuppressionDUnUtilisateur()
-      const supprimerMonCompteModal = screen.getByRole('dialog', { name: 'Retirer Julien Deschamps de mon équipe d’utilisateurs ?' })
+      const modal = screen.getByRole('dialog', { hidden: false, name: 'Retirer Julien Deschamps de mon équipe d’utilisateurs ?' })
       const supprimer = jeSupprimeUnUtilisateur()
 
       // THEN
@@ -427,7 +427,7 @@ describe('mes utilisateurs', () => {
       expect(supprimerUnUtilisateurAction).toHaveBeenCalledWith({ path: '/mes-utilisateurs', uidUtilisateurASupprimer: '123456' })
       const notification = await screen.findByRole('alert')
       expect(notification.textContent).toBe('Utilisateur supprimé')
-      expect(supprimerMonCompteModal).not.toBeVisible()
+      expect(modal).not.toBeVisible()
       expect(supprimer).toHaveAccessibleName('Confirmer')
       expect(supprimer).toBeEnabled()
     })
@@ -455,11 +455,11 @@ describe('mes utilisateurs', () => {
 
       // WHEN
       jOuvreLaSuppressionDUnUtilisateur()
-      const supprimerMonCompteModal = screen.getByRole('dialog', { name: 'Retirer Julien Deschamps de mon équipe d’utilisateurs ?' })
+      const modal = screen.getByRole('dialog', { hidden: false, name: 'Retirer Julien Deschamps de mon équipe d’utilisateurs ?' })
       jeFermeLaSuppressionDUnUtilisateur()
 
       // THEN
-      expect(supprimerMonCompteModal).not.toBeVisible()
+      expect(modal).not.toBeVisible()
     })
   })
 

--- a/src/components/transverse/EnTete/EnTete.test.tsx
+++ b/src/components/transverse/EnTete/EnTete.test.tsx
@@ -28,7 +28,7 @@ describe('en-tête : en tant qu’utilisateur authentifié', () => {
     expect(notifications).toHaveAttribute('href', '/notifications')
 
     const monCompte = within(menuItems[3]).getByRole('button', { name: 'Martin Tartempion' })
-    expect(monCompte).toHaveAttribute('aria-controls', 'drawer-menu-utilisateur')
+    expect(monCompte).toHaveAttribute('aria-controls', 'drawerMenuUtilisateurId')
     expect(monCompte).toHaveAttribute('type', 'button')
   })
 
@@ -40,53 +40,53 @@ describe('en-tête : en tant qu’utilisateur authentifié', () => {
     jOuvreLeMenuUtilisateur()
 
     // THEN
-    const menuUtilisateur = screen.getByRole('dialog')
+    const drawer = screen.getByRole('dialog', { hidden: false })
 
-    const deconnexion = within(menuUtilisateur).getByRole('button', { name: 'Se déconnecter' })
+    const deconnexion = within(drawer).getByRole('button', { name: 'Se déconnecter' })
     expect(deconnexion).toHaveAttribute('name', 'deconnexion')
     expect(deconnexion).toHaveAttribute('type', 'button')
 
-    expect(within(menuUtilisateur).getByRole('presentation')).toHaveAttribute('alt', '')
+    expect(within(drawer).getByRole('presentation')).toHaveAttribute('alt', '')
 
-    const prenom = within(menuUtilisateur).getByText('Martin')
+    const prenom = within(drawer).getByText('Martin')
     expect(prenom).toBeInTheDocument()
 
-    const nom = within(menuUtilisateur).getByText('Tartempion')
+    const nom = within(drawer).getByText('Tartempion')
     expect(nom).toBeInTheDocument()
 
-    const email = within(menuUtilisateur).getByText('martin.tartempion@example.net')
+    const email = within(drawer).getByText('martin.tartempion@example.net')
     expect(email).toBeInTheDocument()
 
-    const liens = within(within(menuUtilisateur).getByRole('list', { name: 'liens-menu' })).getAllByRole('listitem')
+    const liens = within(within(drawer).getByRole('list', { name: 'liens-menu' })).getAllByRole('listitem')
     expect(liens).toHaveLength(3)
 
     const mesInformations = within(liens[0]).getByRole('link', { name: 'Mes informations' })
     expect(mesInformations).toHaveAttribute('href', '/mes-informations-personnelles')
-    expect(mesInformations).toHaveAttribute('aria-controls', 'drawer-menu-utilisateur')
+    expect(mesInformations).toHaveAttribute('aria-controls', 'drawerMenuUtilisateurId')
 
     const mesParametres = within(liens[1]).getByRole('link', { name: 'Mes paramètres' })
     expect(mesParametres).toHaveAttribute('href', '/mes-parametres')
-    expect(mesParametres).toHaveAttribute('aria-controls', 'drawer-menu-utilisateur')
+    expect(mesParametres).toHaveAttribute('aria-controls', 'drawerMenuUtilisateurId')
 
     const mesUtilisateurs = within(liens[2]).getByRole('link', { name: 'Mes utilisateurs' })
     expect(mesUtilisateurs).toHaveAttribute('href', '/mes-utilisateurs')
-    expect(mesUtilisateurs).toHaveAttribute('aria-controls', 'drawer-menu-utilisateur')
+    expect(mesUtilisateurs).toHaveAttribute('aria-controls', 'drawerMenuUtilisateurId')
 
-    const roles = within(menuUtilisateur).getByRole('combobox', { name: 'Rôle' })
+    const roles = within(drawer).getByRole('combobox', { name: 'Rôle' })
     const admin = within(roles).getByRole('option', { name: 'Administrateur dispositif' })
-    expect(admin).toHaveAttribute('aria-controls', 'drawer-menu-utilisateur')
+    expect(admin).toHaveAttribute('aria-controls', 'drawerMenuUtilisateurId')
     const gestionnaireDepartement = within(roles).getByRole('option', { name: 'Gestionnaire département' })
-    expect(gestionnaireDepartement).toHaveAttribute('aria-controls', 'drawer-menu-utilisateur')
+    expect(gestionnaireDepartement).toHaveAttribute('aria-controls', 'drawerMenuUtilisateurId')
     const gestionnaireGroupement = within(roles).getByRole('option', { name: 'Gestionnaire groupement' })
-    expect(gestionnaireGroupement).toHaveAttribute('aria-controls', 'drawer-menu-utilisateur')
+    expect(gestionnaireGroupement).toHaveAttribute('aria-controls', 'drawerMenuUtilisateurId')
     const gestionnaireRegion = within(roles).getByRole('option', { name: 'Gestionnaire région' })
-    expect(gestionnaireRegion).toHaveAttribute('aria-controls', 'drawer-menu-utilisateur')
+    expect(gestionnaireRegion).toHaveAttribute('aria-controls', 'drawerMenuUtilisateurId')
     const gestionnaireStructure = within(roles).getByRole('option', { name: 'Gestionnaire structure' })
-    expect(gestionnaireStructure).toHaveAttribute('aria-controls', 'drawer-menu-utilisateur')
+    expect(gestionnaireStructure).toHaveAttribute('aria-controls', 'drawerMenuUtilisateurId')
     const instructeur = within(roles).getByRole('option', { name: 'Instructeur' })
-    expect(instructeur).toHaveAttribute('aria-controls', 'drawer-menu-utilisateur')
+    expect(instructeur).toHaveAttribute('aria-controls', 'drawerMenuUtilisateurId')
     const pilotePolitiquePublique = within(roles).getByRole('option', { name: 'Pilote politique publique' })
-    expect(pilotePolitiquePublique).toHaveAttribute('aria-controls', 'drawer-menu-utilisateur')
+    expect(pilotePolitiquePublique).toHaveAttribute('aria-controls', 'drawerMenuUtilisateurId')
     const supportAnimation = within(roles).getByRole('option', { name: 'Support animation', selected: true })
     expect(supportAnimation).toBeInTheDocument()
   })
@@ -126,11 +126,11 @@ describe('en-tête : en tant qu’utilisateur authentifié', () => {
 
       // WHEN
       jOuvreLeMenuUtilisateur()
-      const drawer = screen.getByRole('dialog')
+      const drawer = screen.getByRole('dialog', { hidden: false })
       const fermer = jeFermeLeMenuUtilisateur()
 
       // THEN
-      expect(fermer).toHaveAttribute('aria-controls', 'drawer-menu-utilisateur')
+      expect(fermer).toHaveAttribute('aria-controls', 'drawerMenuUtilisateurId')
       expect(drawer).not.toBeVisible()
     })
   })

--- a/src/components/transverse/EnTete/EnTete.tsx
+++ b/src/components/transverse/EnTete/EnTete.tsx
@@ -12,7 +12,7 @@ export default function EnTete(): ReactElement {
   const { sessionUtilisateurViewModel } = useContext(clientContext)
   // Stryker disable next-line BooleanLiteral
   const [isOpen, setIsOpen] = useState(false)
-  const drawerId = 'drawer-menu-utilisateur'
+  const drawerId = 'drawerMenuUtilisateurId'
   const labelId = useId()
 
   return (


### PR DESCRIPTION
Au final, je m'aperçois que personnalisé ce genre d'ID ne sert à rien et coute du temps quand on copie colle donc autant avoir tout le temps le même quand cela est possible.

# Contrat du dev

## Qualité

- [x] Relire le code

> **Et n'oublie pas de vérifier ce que tu as fait en production !**
