### PR TITLE
Suppression du mock dans les tests du TextEditor

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -259,6 +259,10 @@
           {
             "message": "Utiliser waitFor() ou findByXXX()",
             "selector": "Identifier[name='act']"
+          },
+          {
+            "message": "Tu es trop couplé à cette lib, mieux vaut l'injecter",
+            "selector": "CallExpression[callee.object.name='vi'][callee.property.name='mock']"
           }
         ],
         "no-undef": "off",

--- a/src/components/Gouvernance/NoteDeContexte/ModifierNoteDeContexte.tsx
+++ b/src/components/Gouvernance/NoteDeContexte/ModifierNoteDeContexte.tsx
@@ -6,7 +6,7 @@ import { clientContext } from '@/components/shared/ClientContext'
 import DrawerTitle from '@/components/shared/DrawerTitle/DrawerTitle'
 import { Notification } from '@/components/shared/Notification/Notification'
 import { useRichTextEditor } from '@/components/shared/RichTextEditor/hooks/useRichTextEditor'
-import EditeurDeTexte from '@/components/shared/RichTextEditor/TextEditor'
+import TextEditor from '@/components/shared/RichTextEditor/TextEditor'
 import SubmitButton from '@/components/shared/SubmitButton/SubmitButton'
 
 export default function ModifierNoteDeContexte({
@@ -21,7 +21,7 @@ export default function ModifierNoteDeContexte({
   const { modifierUneNoteDeContexteAction, supprimerUneNoteDeContexteAction, pathname } = useContext(clientContext)
   const [isDisabled, setIsDisabled] = useState(false)
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  const { contenu, gererLeChangementDeContenu, viderLeContenu } = useRichTextEditor()
+  const { contenu, gererLeChangementDeContenu, viderLeContenu } = useRichTextEditor(texte)
 
   return (
     <>
@@ -40,8 +40,8 @@ export default function ModifierNoteDeContexte({
             ou tout autre élément que vous souhaitez porter à notre connaissance
           </div>
         </div>
-        <EditeurDeTexte
-          contenu={texte}
+        <TextEditor
+          contenu={contenu}
           onChange={gererLeChangementDeContenu}
         />
         <ul className="fr-btns-group fr-mt-2w">

--- a/src/components/shared/RichTextEditor/MenuBar.tsx
+++ b/src/components/shared/RichTextEditor/MenuBar.tsx
@@ -1,18 +1,12 @@
 // Stryker disable all
-'use client'
-
 import { Editor } from '@tiptap/react'
 import { ReactElement } from 'react'
 
 import { MenuButton } from './MenuButton'
 import styles from './RichTextEditor.module.css'
 
-type BarreDeMenuProps = Readonly<{
-  editor: Editor | null
-}>
-
 // istanbul ignore next @preserve
-export function BarreDeMenuEditeurDeTexte({ editor }: BarreDeMenuProps): ReactElement | null {
+export function BarreDeMenuEditeurDeTexte({ editor }: Props): ReactElement | null {
   if (!editor) {
     return null
   }
@@ -26,7 +20,7 @@ export function BarreDeMenuEditeurDeTexte({ editor }: BarreDeMenuProps): ReactEl
       return
     }
 
-    // eslint-disable-next-line no-alert, no-restricted-syntax
+    // eslint-disable-next-line no-alert
     const url = window.prompt('URL du lien :')
 
     if (url === null || url === '') {
@@ -106,3 +100,7 @@ export function BarreDeMenuEditeurDeTexte({ editor }: BarreDeMenuProps): ReactEl
     </div>
   )
 }
+
+type Props = Readonly<{
+  editor: Editor | null
+}>

--- a/src/components/shared/RichTextEditor/MenuButton.tsx
+++ b/src/components/shared/RichTextEditor/MenuButton.tsx
@@ -3,19 +3,13 @@ import { MouseEventHandler, ReactElement } from 'react'
 
 import styles from './RichTextEditor.module.css'
 
-type MenuButtonProps = Readonly<{
-  title: string
-  icon: string
-  onClick: MouseEventHandler<HTMLButtonElement>
-  isActive: boolean
-}>
-// istanbul ignore next @preserve
 export function MenuButton({
   title,
   icon,
   onClick,
   isActive,
-}: MenuButtonProps): ReactElement {
+}: Props): ReactElement {
+  // istanbul ignore next @preserve
   function handleClick(event: React.MouseEvent<HTMLButtonElement>): void {
     event.preventDefault()
     event.stopPropagation()
@@ -34,3 +28,10 @@ export function MenuButton({
     />
   )
 }
+
+type Props = Readonly<{
+  title: string
+  icon: string
+  onClick: MouseEventHandler<HTMLButtonElement>
+  isActive: boolean
+}>

--- a/src/components/shared/RichTextEditor/TextEditor.tsx
+++ b/src/components/shared/RichTextEditor/TextEditor.tsx
@@ -1,4 +1,3 @@
-// Stryker disable all
 'use client'
 
 import { Link } from '@tiptap/extension-link'
@@ -8,12 +7,6 @@ import { ReactElement } from 'react'
 
 import { BarreDeMenuEditeurDeTexte } from './MenuBar'
 
-type Props = Readonly<{
-  contenu: string
-  onChange(content: string): void
-}>
-
-// istanbul ignore next @preserve
 export default function TextEditor({ contenu, onChange }: Props): ReactElement {
   const editor = useEditor({
     content: contenu,
@@ -35,10 +28,8 @@ export default function TextEditor({ contenu, onChange }: Props): ReactElement {
     ],
     immediatelyRender: false,
     onCreate: ({ editor }) => {
-      // eslint-disable-next-line no-restricted-syntax
       window.dispatchEvent(new CustomEvent('editorReady', { detail: editor }))
     },
-
     onUpdate: ({ editor }) => {
       const content = editor.getHTML()
       const isEmptyContent = content === '<p></p>'
@@ -53,3 +44,8 @@ export default function TextEditor({ contenu, onChange }: Props): ReactElement {
     </>
   )
 }
+
+type Props = Readonly<{
+  contenu: string
+  onChange(content: string): void
+}>

--- a/src/components/shared/RichTextEditor/hooks/useRichTextEditor.ts
+++ b/src/components/shared/RichTextEditor/hooks/useRichTextEditor.ts
@@ -4,10 +4,6 @@ import { useState, useEffect } from 'react'
 
 import type { Editor } from '@tiptap/react'
 
-type EditorReadyEvent = {
-  detail: Editor
-} & CustomEvent
-// istanbul ignore next @preserve
 export function useRichTextEditor(contenuInitial = ''): {
   contenu: string
   editeur: Editor | null
@@ -22,23 +18,20 @@ export function useRichTextEditor(contenuInitial = ''): {
   }
 
   function gererEditeurPret(evenement: Event): void {
-    const evenementPersonnalise = evenement as EditorReadyEvent
-    setEditeur(evenementPersonnalise.detail as Editor)
+    setEditeur((evenement as EditorReadyEvent).detail as Editor)
   }
 
   function viderLeContenu(): void {
     setContenu('')
     if (editeur) {
-      editeur.commands.setContent('')
+      editeur.commands.clearContent(true)
     }
   }
 
   useEffect((): () => void => {
-    // eslint-disable-next-line no-restricted-syntax
     window.addEventListener('editorReady', gererEditeurPret)
 
     return (): void => {
-      // eslint-disable-next-line no-restricted-syntax
       window.removeEventListener('editorReady', gererEditeurPret)
     }
   }, [])
@@ -50,3 +43,7 @@ export function useRichTextEditor(contenuInitial = ''): {
     viderLeContenu,
   }
 }
+
+type EditorReadyEvent = {
+  detail: Editor
+} & CustomEvent


### PR DESCRIPTION
- Plus besoin de doubler le textEditor, on écrit nos tests comme d'habitude et il faut insérer via `innerHTML` plutôt que `value` et ajouter un await juste après pour que cela fonctionne correctement
- Suppression de commentaire eslint inutile
- coverage augmenté
- ajout de la règle eslint pour interdire le vi.mock

# Contrat du dev

## Qualité

- [x] Relire le code
- [x] Vérifier le coverage

> **Et n'oublie pas de vérifier ce que tu as fait en production !**
