### PR TITLE
Réduction de la taille du container Scalingo

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -2,3 +2,10 @@
 .husky
 .yarn
 src
+node_modules/@babel
+node_modules/@opentelemetry
+node_modules/@gouvfr/dsfr/example
+node_modules/@gouvfr/dsfr/src
+node_modules/@gouvfr/dsfr/dist/component
+node_modules/@gouvfr/dsfr/dist/dsfr
+node_modules/@gouvfr/dsfr/storybook


### PR DESCRIPTION
La limite de taille d'un container Scalingo est de 1,5 Go et on y est presque.
J'ai utilisé la commande suivante pour détecter les gros répertoires pour pouvoir les exclures :
`du -h -d 1 node_modules | sort -h`