### PR TITLE
Suppression d'un niveau d'abstraction pour les fonctions helpers et plutôt mise en snippet

### DIFF
--- a/.vscode/typescriptreact.code-snippets
+++ b/.vscode/typescriptreact.code-snippets
@@ -468,7 +468,7 @@
       "expect(XXX).toHaveValue('XXX')",
     ],
   },
-  "getByText": {
+  "rechercher par un texte": {
     "prefix": "_getByText",
     "scope": "typescriptreact",
     "description": "Tester une chaîne de caractères",
@@ -476,6 +476,50 @@
       "const XXX = screen.getByText('XXX', { selector: 'p' })",
       "expect(XXX).toBeInTheDocument()",
     ],
+  },
+  "presser le bouton": {
+    "prefix": "_presserLeBouton",
+    "scope": "typescriptreact",
+    "description": "Presser le bouton",
+    "body": [
+      "const button = screen.getByRole('button', { description: 'XXX', name: 'XXX' })",
+      "fireEvent.click(button)",
+      "return button",
+    ],
+  },
+  "cocher la case": {
+    "prefix": "_cocherLaCase",
+    "scope": "typescriptreact",
+    "description": "Cocher la case",
+    "body": ["fireEvent.click(screen.getByRole('checkbox', { name: 'XXX' }))"],
+  },
+  "presser le bouton radio": {
+    "prefix": "_presserLeBoutonRadio",
+    "scope": "typescriptreact",
+    "description": "Presser le bouton radio",
+    "body": ["fireEvent.click(screen.getByRole('radio', { name: 'XXX' }))"],
+  },
+  "saisir le texte": {
+    "prefix": "_saisirLeTexte",
+    "scope": "typescriptreact",
+    "description": "Saisir le texte",
+    "body": [
+      "const input = screen.getByLabelText('XXX')",
+      "fireEvent.change(input, { target: { value: 'XXX' } })",
+      "return input",
+    ],
+  },
+  "sélectionner l'élement": {
+    "prefix": "_selectionnerLElement",
+    "scope": "typescriptreact",
+    "description": "Sélectionner l'élement",
+    "body": ["await select('XXX', 'XXX')"],
+  },
+  "doublure de conceal": {
+    "prefix": "_stubbedConceal",
+    "scope": "typescriptreact",
+    "description": "La doublure de la fonction DSFR conceal pour fermer le drawer",
+    "body": ["vi.stubGlobal('dsfr', stubbedConceal())"],
   },
   "it fermer drawer": {
     "prefix": "_itFermerDrawer",

--- a/src/components/Action/Action.test.tsx
+++ b/src/components/Action/Action.test.tsx
@@ -7,7 +7,7 @@ import { FormulaireAction } from './FormulaireAction'
 import MenuLateral from './MenuLateral'
 import ModifierUneAction from './ModifierUneAction'
 import SubmitButton from '../shared/SubmitButton/SubmitButton'
-import { matchWithoutMarkup, presserLeBoutonDans, presserLeBoutonRadio, renderComponent, stubbedServerAction } from '../testHelper'
+import { matchWithoutMarkup, renderComponent, stubbedServerAction } from '../testHelper'
 import { actionVideViewModelFactory, actionViewModelFactory } from '@/presenters/testHelper'
 import { epochTime } from '@/shared/testHelper'
 
@@ -281,7 +281,7 @@ describe('formulaire d‘ajout d‘une action', () => {
       fireEvent.change(nomDeLAction, { target: { value: 'Structurer une filière de reconditionnement locale 2' } })
       jeTapeLeContexteDeLaction(formulaire)
       jeTapeLaDescriptionDeLaction(formulaire)
-      presserLeBoutonRadio('Pluriannuelle')
+      fireEvent.click(screen.getByRole('radio', { name: 'Pluriannuelle' }))
       jeSelectionneLAnneeDeDebut('2026')
       jeSelectionneLAnneeDeFin('2028')
       jeTapeLeBudgetGlobalDeLAction(formulaire)
@@ -310,7 +310,7 @@ describe('formulaire d‘ajout d‘une action', () => {
       afficherFormulaireDeCreationAction()
 
       // WHEN
-      presserLeBoutonRadio('Annuelle')
+      fireEvent.click(screen.getByRole('radio', { name: 'Annuelle' }))
 
       // THEN
       const optionAnnuelle = screen.getByRole('radio', { name: 'Annuelle' })
@@ -389,10 +389,10 @@ describe('formulaire d‘ajout d‘une action', () => {
     it('étant un utilisateur, quand je change la temporalite à annuelle, la temporalite est mise à jour', () => {
       // GIVEN
       afficherFormulaireDeCreationAction()
-      presserLeBoutonRadio('Pluriannuelle')
+      fireEvent.click(screen.getByRole('radio', { name: 'Pluriannuelle' }))
 
       // WHEN
-      presserLeBoutonRadio('Annuelle')
+      fireEvent.click(screen.getByRole('radio', { name: 'Annuelle' }))
 
       // THEN
       const radioAnnuelle = screen.getByRole('radio', { name: 'Annuelle' })
@@ -545,12 +545,16 @@ function jeSelectionneLAnneeDeFin(annee: string): void {
 
 function jeValideLeFormulaireDAjout(): HTMLElement {
   const form = screen.getByRole('form', { name: 'Ajouter une action à la feuille de route' })
-  return presserLeBoutonDans(form, 'Valider et envoyer')
+  const button = within(form).getByRole('button', { name: 'Valider et envoyer' })
+  fireEvent.click(button)
+  return button
 }
 
 function jeValideLeFormulaireDeModification(): HTMLElement {
   const form = screen.getByRole('form', { name: 'Modifier une action' })
-  return presserLeBoutonDans(form, 'Valider et envoyer')
+  const button = within(form).getByRole('button', { name: 'Valider et envoyer' })
+  fireEvent.click(button)
+  return button
 }
 
 function jeTapeLeContexteDeLaction(formulaire: HTMLElement): void {

--- a/src/components/Action/AjouterDesBeneficiaires.test.tsx
+++ b/src/components/Action/AjouterDesBeneficiaires.test.tsx
@@ -1,6 +1,6 @@
-import { screen, within } from '@testing-library/react'
+import { fireEvent, screen, within } from '@testing-library/react'
 
-import { matchWithoutMarkup, presserLeBouton, renderComponent } from '../testHelper'
+import { matchWithoutMarkup, renderComponent } from '../testHelper'
 import { FormulaireAction } from './FormulaireAction'
 import { ActionViewModel } from '@/presenters/actionPresenter'
 import { actionViewModelFactory } from '@/presenters/testHelper'
@@ -80,6 +80,12 @@ describe('ajout des bénéficiaires', () => {
       })
     })
   })
+
+  function presserLeBouton(name: string, description?: string): HTMLElement {
+    const button = screen.getByRole('button', { description, name })
+    fireEvent.click(button)
+    return button
+  }
 
   function afficherLeFormulaireAction(overrides: Partial<ActionViewModel> = {}): void {
     renderComponent(

--- a/src/components/Action/AjouterDesBesoins.test.tsx
+++ b/src/components/Action/AjouterDesBesoins.test.tsx
@@ -1,6 +1,6 @@
-import { screen, within } from '@testing-library/react'
+import { fireEvent, screen, within } from '@testing-library/react'
 
-import { presserLeBouton, renderComponent } from '../testHelper'
+import { renderComponent } from '../testHelper'
 import { FormulaireAction } from './FormulaireAction'
 import { actionViewModelFactory } from '@/presenters/testHelper'
 
@@ -103,6 +103,12 @@ describe('ajouter des besoins', () => {
 
   function jeFermeLeFormulairePourAjouterDesBesoins(): HTMLElement {
     return presserLeBouton('Fermer l’ajout des besoins')
+  }
+
+  function presserLeBouton(name: string, description?: string): HTMLElement {
+    const button = screen.getByRole('button', { description, name })
+    fireEvent.click(button)
+    return button
   }
 
   function afficherLeFormulaireAction(): void {

--- a/src/components/Action/AjouterDesPorteurs.test.tsx
+++ b/src/components/Action/AjouterDesPorteurs.test.tsx
@@ -1,6 +1,6 @@
-import { screen, within } from '@testing-library/react'
+import { fireEvent, screen, within } from '@testing-library/react'
 
-import { matchWithoutMarkup, presserLeBouton, renderComponent } from '../testHelper'
+import { matchWithoutMarkup, renderComponent } from '../testHelper'
 import { FormulaireAction } from './FormulaireAction'
 import { ActionViewModel } from '@/presenters/actionPresenter'
 import { actionViewModelFactory } from '@/presenters/testHelper'
@@ -80,6 +80,12 @@ describe('ajout des porteurs', () => {
       })
     })
   })
+
+  function presserLeBouton(name: string, description?: string): HTMLElement {
+    const button = screen.getByRole('button', { description, name })
+    fireEvent.click(button)
+    return button
+  }
 
   function afficherLeFormulaireAction(overrides: Partial<ActionViewModel> = {}): void {
     renderComponent(

--- a/src/components/Connexion/Connexion.test.tsx
+++ b/src/components/Connexion/Connexion.test.tsx
@@ -1,8 +1,7 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import * as nextAuth from 'next-auth/react'
 
 import Connexion from './Connexion'
-import { presserLeBouton } from '../testHelper'
 
 describe('connexion : en tant qu’utilisateur non authentifié', () => {
   it('quand je me rend sur la page de connexion alors elle s’affiche', () => {
@@ -28,7 +27,8 @@ describe('connexion : en tant qu’utilisateur non authentifié', () => {
     render(<Connexion idProvider="pro-connect" />)
 
     // WHEN
-    presserLeBouton('S’identifier avec ProConnect')
+    const button = screen.getByRole('button', { name: 'S’identifier avec ProConnect' })
+    fireEvent.click(button)
 
     // THEN
     expect(nextAuth.signIn).toHaveBeenCalledWith('pro-connect', { callbackUrl: '/' })

--- a/src/components/FeuilleDeRoute/ModifierUneFeuilleDeRoute.test.tsx
+++ b/src/components/FeuilleDeRoute/ModifierUneFeuilleDeRoute.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, screen, within } from '@testing-library/react'
 
-import { matchWithoutMarkup, presserLeBouton, presserLeBoutonRadio, renderComponent, stubbedConceal, stubbedServerAction } from '../testHelper'
 import FeuilleDeRoute from './FeuilleDeRoute'
+import { matchWithoutMarkup, renderComponent, stubbedConceal, stubbedServerAction } from '../testHelper'
 import { feuilleDeRoutePresenter } from '@/presenters/feuilleDeRoutePresenter'
 
 describe('modifier une feuille de route', () => {
@@ -141,11 +141,11 @@ describe('modifier une feuille de route', () => {
   }
 
   function jeSelectionneUnPerimetre(name: string): void {
-    presserLeBoutonRadio(name)
+    fireEvent.click(screen.getByRole('radio', { name }))
   }
 
   function jeSelectionneUnContrat(name: string): void {
-    presserLeBoutonRadio(name)
+    fireEvent.click(screen.getByRole('radio', { name }))
   }
 
   function jEnregistreLaFeuilleDeRoute(): HTMLElement {
@@ -158,6 +158,12 @@ describe('modifier une feuille de route', () => {
 
   function jOuvreLeFormulairePourModifierUneFeuilleDeRoute(): void {
     presserLeBouton('Modifier', 'Modifier la feuille de route')
+  }
+
+  function presserLeBouton(name: string, description?: string): HTMLElement {
+    const button = screen.getByRole('button', { description, name })
+    fireEvent.click(button)
+    return button
   }
 
   function afficherUneFeuilleDeRoute(

--- a/src/components/FeuillesDeRoute/AjouterUneFeuilleDeRoute.test.tsx
+++ b/src/components/FeuillesDeRoute/AjouterUneFeuilleDeRoute.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, screen, within } from '@testing-library/react'
 
-import { matchWithoutMarkup, presserLeBouton, presserLeBoutonRadio, renderComponent, stubbedConceal, stubbedServerAction } from '../testHelper'
 import FeuillesDeRoute from './FeuillesDeRoute'
+import { matchWithoutMarkup, renderComponent, stubbedConceal, stubbedServerAction } from '../testHelper'
 import { feuillesDeRoutePresenter } from '@/presenters/feuillesDeRoutePresenter'
 import { feuillesDeRouteReadModelFactory } from '@/use-cases/testHelper'
 
@@ -145,11 +145,11 @@ describe('ajouter une feuille de route', () => {
   }
 
   function jeSelectionneUnPerimetre(name: string): void {
-    presserLeBoutonRadio(name)
+    fireEvent.click(screen.getByRole('radio', { name }))
   }
 
   function jeSelectionneUnContrat(name: string): void {
-    presserLeBoutonRadio(name)
+    fireEvent.click(screen.getByRole('radio', { name }))
   }
 
   function jEnregistreLaFeuilleDeRoute(): HTMLElement {
@@ -162,6 +162,12 @@ describe('ajouter une feuille de route', () => {
 
   function jOuvreLeFormulairePourAjouterUneFeuilleDeRoute(): void {
     presserLeBouton('Ajouter une feuille de route')
+  }
+
+  function presserLeBouton(name: string): HTMLElement {
+    const button = screen.getByRole('button', { name })
+    fireEvent.click(button)
+    return button
   }
 
   function afficherLesFeuillesDeRoute(

--- a/src/components/FeuillesDeRoute/DetailAction.test.tsx
+++ b/src/components/FeuillesDeRoute/DetailAction.test.tsx
@@ -1,6 +1,6 @@
-import { screen, within } from '@testing-library/react'
+import { fireEvent, screen, within } from '@testing-library/react'
 
-import { matchWithoutMarkup, presserLeBouton, renderComponent } from '../testHelper'
+import { matchWithoutMarkup, renderComponent } from '../testHelper'
 import FeuillesDeRoute from './FeuillesDeRoute'
 import { feuillesDeRoutePresenter } from '@/presenters/feuillesDeRoutePresenter'
 import { feuillesDeRouteReadModelFactory } from '@/use-cases/testHelper'
@@ -98,6 +98,12 @@ describe('détail d’une action', () => {
 
   function jeFermeLAction(): HTMLElement {
     return presserLeBouton('Fermer le détail de Structurer une filière de reconditionnement locale 2')
+  }
+
+  function presserLeBouton(name: string): HTMLElement {
+    const button = screen.getByRole('button', { name })
+    fireEvent.click(button)
+    return button
   }
 
   function afficherLesFeuillesDeRoute(

--- a/src/components/GestionMembresGouvernance/AjouterUnMembre.test.tsx
+++ b/src/components/GestionMembresGouvernance/AjouterUnMembre.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, screen, within } from '@testing-library/react'
 
-import { matchWithoutMarkup, presserLeBouton, renderComponent, stubbedServerAction } from '../testHelper'
 import GestionMembres from './GestionMembres'
+import { matchWithoutMarkup, renderComponent, stubbedServerAction } from '../testHelper'
 import { membresPresenter } from '@/presenters/membresPresenter'
 import { membresReadModelFactory } from '@/use-cases/testHelper'
 
@@ -203,6 +203,12 @@ describe('membres gouvernance', () => {
 
   function jAjouteUnMembre(): HTMLElement {
     return presserLeBouton('Ajouter')
+  }
+
+  function presserLeBouton(name: string): HTMLElement {
+    const button = screen.getByRole('button', { name })
+    fireEvent.click(button)
+    return button
   }
 })
 

--- a/src/components/Gouvernance/Comitologie/Comitologie.test.tsx
+++ b/src/components/Gouvernance/Comitologie/Comitologie.test.tsx
@@ -1,7 +1,7 @@
 import { within, screen, fireEvent, waitFor } from '@testing-library/react'
 
 import Gouvernance from '../Gouvernance'
-import { presserLeBouton, presserLeBoutonRadio, matchWithoutMarkup, renderComponent, stubbedServerAction } from '@/components/testHelper'
+import { matchWithoutMarkup, renderComponent, stubbedServerAction } from '@/components/testHelper'
 import { gouvernancePresenter } from '@/presenters/gouvernancePresenter'
 import { epochTimePlusOneDay } from '@/shared/testHelper'
 import { gouvernanceReadModelFactory } from '@/use-cases/testHelper'
@@ -368,11 +368,11 @@ describe('comitologie', () => {
   }
 
   function jeSelectionneUnType(name: string): void {
-    presserLeBoutonRadio(name)
+    fireEvent.click(screen.getByRole('radio', { name }))
   }
 
   function jeSelectionneUneFrequence(name: string): void {
-    presserLeBoutonRadio(name)
+    fireEvent.click(screen.getByRole('radio', { name }))
   }
 
   function jeChoisisUneDate(container: HTMLElement, value: string): HTMLElement {
@@ -398,5 +398,11 @@ describe('comitologie', () => {
   function afficherUneGouvernance(options?: Partial<Parameters<typeof renderComponent>[1]>): void {
     const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModelFactory(), epochTimePlusOneDay)
     renderComponent(<Gouvernance />, options, gouvernanceViewModel)
+  }
+
+  function presserLeBouton(name: string): HTMLElement {
+    const button = screen.getByRole('button', { name })
+    fireEvent.click(button)
+    return button
   }
 })

--- a/src/components/Gouvernance/FeuilleDeRoute/FeuilleDeRoute.test.tsx
+++ b/src/components/Gouvernance/FeuilleDeRoute/FeuilleDeRoute.test.tsx
@@ -1,7 +1,7 @@
-import { within, screen } from '@testing-library/react'
+import { within, screen, fireEvent } from '@testing-library/react'
 
 import Gouvernance from '../Gouvernance'
-import { presserLeBouton, renderComponent } from '@/components/testHelper'
+import { renderComponent } from '@/components/testHelper'
 import { gouvernancePresenter } from '@/presenters/gouvernancePresenter'
 import { epochTime } from '@/shared/testHelper'
 import { gouvernanceReadModelFactory } from '@/use-cases/testHelper'
@@ -134,5 +134,11 @@ describe('feuille de route', () => {
   function afficherUneGouvernance(override?: Partial<Parameters<typeof gouvernanceReadModelFactory>[0]>): void {
     const gouvernanceViewModel = gouvernancePresenter(gouvernanceReadModelFactory(override), epochTime)
     renderComponent(<Gouvernance />, undefined, gouvernanceViewModel)
+  }
+
+  function presserLeBouton(name: string): HTMLElement {
+    const button = screen.getByRole('button', { name })
+    fireEvent.click(button)
+    return button
   }
 })

--- a/src/components/Gouvernance/Gouvernance.test.tsx
+++ b/src/components/Gouvernance/Gouvernance.test.tsx
@@ -1,7 +1,7 @@
-import { screen, within } from '@testing-library/react'
+import { fireEvent, screen, within } from '@testing-library/react'
 
 import Gouvernance from './Gouvernance'
-import { matchWithoutMarkup, presserLeBouton, renderComponent } from '../testHelper'
+import { matchWithoutMarkup, renderComponent } from '../testHelper'
 import { gouvernancePresenter } from '@/presenters/gouvernancePresenter'
 import { epochTime, epochTimePlusOneDay } from '@/shared/testHelper'
 import { gouvernanceReadModelFactory } from '@/use-cases/testHelper'
@@ -597,5 +597,11 @@ describe('gouvernance', () => {
 
   function jeDeplieLaNoteDeContexte(): HTMLElement {
     return presserLeBouton('Lire plus')
+  }
+
+  function presserLeBouton(name: string): HTMLElement {
+    const button = screen.getByRole('button', { name })
+    fireEvent.click(button)
+    return button
   }
 })

--- a/src/components/Gouvernance/Membre/Membre.test.tsx
+++ b/src/components/Gouvernance/Membre/Membre.test.tsx
@@ -1,7 +1,7 @@
-import { screen, within } from '@testing-library/react'
+import { fireEvent, screen, within } from '@testing-library/react'
 
 import Gouvernance from '../Gouvernance'
-import { matchWithoutMarkup, presserLeBouton, renderComponent } from '@/components/testHelper'
+import { matchWithoutMarkup, renderComponent } from '@/components/testHelper'
 import { gouvernancePresenter } from '@/presenters/gouvernancePresenter'
 import { epochTime } from '@/shared/testHelper'
 import { gouvernanceReadModelFactory } from '@/use-cases/testHelper'
@@ -562,4 +562,10 @@ function jOuvreLesDetailsDuMembre(nomDuMembre: string): void {
 
 function jeFermeLesDetailsDuMembre(nomDuMembre: string): HTMLElement {
   return presserLeBouton(nomDuMembre)
+}
+
+function presserLeBouton(name: string): HTMLElement {
+  const button = screen.getByRole('button', { name })
+  fireEvent.click(button)
+  return button
 }

--- a/src/components/Gouvernance/NoteDeContexte/NoteDeContexte.test.tsx
+++ b/src/components/Gouvernance/NoteDeContexte/NoteDeContexte.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, screen, waitFor, within } from '@testing-library/react'
 
 import Gouvernance from '../Gouvernance'
-import { presserLeBouton, presserLeBoutonDans, renderComponent, stubbedServerAction } from '@/components/testHelper'
+import { renderComponent, stubbedServerAction } from '@/components/testHelper'
 import { gouvernancePresenter } from '@/presenters/gouvernancePresenter'
 import { epochTime } from '@/shared/testHelper'
 import { gouvernanceReadModelFactory } from '@/use-cases/testHelper'
@@ -270,5 +270,11 @@ function jOuvreLeFormulairePourModifierUneNoteDeContexte(): void {
 }
 
 function jEffaceLaNoteDeContexte(context: HTMLElement): void {
-  presserLeBoutonDans(context, 'Effacer')
+  fireEvent.click(within(context).getByRole('button', { name: 'Effacer' }))
+}
+
+function presserLeBouton(name: string): HTMLElement {
+  const button = screen.getByRole('button', { name })
+  fireEvent.click(button)
+  return button
 }

--- a/src/components/Gouvernance/NotePrivee/NotePrivee.test.tsx
+++ b/src/components/Gouvernance/NotePrivee/NotePrivee.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, screen, within } from '@testing-library/react'
 
 import Gouvernance from '../Gouvernance'
-import { matchWithoutMarkup, presserLeBouton, presserLeBoutonDans, renderComponent, saisirLeTexte, stubbedServerAction } from '@/components/testHelper'
+import { matchWithoutMarkup, renderComponent, stubbedServerAction } from '@/components/testHelper'
 import { gouvernancePresenter } from '@/presenters/gouvernancePresenter'
 import { epochTime } from '@/shared/testHelper'
 import { gouvernanceReadModelFactory } from '@/use-cases/testHelper'
@@ -251,12 +251,12 @@ describe('note privée', () => {
     }
 
     function jEffaceLaNotePrivee(context: HTMLElement): void {
-      presserLeBoutonDans(context, 'Effacer')
+      fireEvent.click(within(context).getByRole('button', { name: 'Effacer' }))
     }
   })
 
   function jeTapeUneNotePrivee(value: string): void {
-    saisirLeTexte('Votre note', value)
+    fireEvent.change(screen.getByLabelText('Votre note'), { target: { value } })
   }
 
   function jEnregistreLaNotePrivee(): HTMLElement {
@@ -281,6 +281,12 @@ describe('note privée', () => {
       },
     }), now)
     renderComponent(<Gouvernance />, options, gouvernanceViewModel)
+  }
+
+  function presserLeBouton(name: string): HTMLElement {
+    const button = screen.getByRole('button', { name })
+    fireEvent.click(button)
+    return button
   }
 
   const now = epochTime

--- a/src/components/MesInformationsPersonnelles/MesInformationsPersonnelles.test.tsx
+++ b/src/components/MesInformationsPersonnelles/MesInformationsPersonnelles.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, screen, within } from '@testing-library/react'
 import * as nextAuth from 'next-auth/react'
 
 import MesInformationsPersonnelles from './MesInformationsPersonnelles'
-import { presserLeBouton, saisirLeTexte, matchWithoutMarkup, renderComponent, stubbedServerAction } from '@/components/testHelper'
+import { matchWithoutMarkup, renderComponent, stubbedServerAction } from '@/components/testHelper'
 import { mesInformationsPersonnellesPresenter } from '@/presenters/mesInformationsPersonnellesPresenter'
 import { mesInformationsPersonnellesReadModelFactory } from '@/use-cases/testHelper'
 
@@ -496,4 +496,16 @@ function afficherMesInformationsPersonnelles(
     />,
     options
   )
+}
+
+function saisirLeTexte(name: string | RegExp, value: string): HTMLElement {
+  const input = screen.getByLabelText(name)
+  fireEvent.change(input, { target: { value } })
+  return input
+}
+
+function presserLeBouton(name: string): HTMLElement {
+  const button = screen.getByRole('button', { name })
+  fireEvent.click(button)
+  return button
 }

--- a/src/components/MesUtilisateurs/FiltrerMesUtilisateurs.test.tsx
+++ b/src/components/MesUtilisateurs/FiltrerMesUtilisateurs.test.tsx
@@ -1,8 +1,8 @@
-import { screen, within } from '@testing-library/react'
-import { clearFirst } from 'react-select-event'
+import { fireEvent, screen, within } from '@testing-library/react'
+import { clearFirst, select } from 'react-select-event'
 
 import MesUtilisateurs from './MesUtilisateurs'
-import { cocherLaCase, presserLeBouton, saisirLeTexte, renderComponent, rolesAvecStructure, structuresFetch, selectionnerLElement } from '@/components/testHelper'
+import { renderComponent, rolesAvecStructure, structuresFetch } from '@/components/testHelper'
 import { mesUtilisateursPresenter } from '@/presenters/mesUtilisateursPresenter'
 import { epochTime } from '@/shared/testHelper'
 
@@ -354,7 +354,7 @@ describe('filtrer mes utilisateurs', () => {
   })
 
   function jeSelectionneUniquementLesUtilisateursActives(): void {
-    cocherLaCase('Uniquement les utilisateurs activés')
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Uniquement les utilisateurs activés' }))
   }
 
   function jeTapeMaRecherche(value: string): HTMLElement {
@@ -362,7 +362,7 @@ describe('filtrer mes utilisateurs', () => {
   }
 
   async function jeSelectionneUneZoneGeographique(zoneGeographique: string): Promise<void> {
-    await selectionnerLElement(screen.getByRole('combobox', { name: 'Par zone géographique' }), zoneGeographique)
+    await select(screen.getByRole('combobox', { name: 'Par zone géographique' }), zoneGeographique)
   }
 
   function jeTapeUneStructure(value: string): HTMLElement {
@@ -370,15 +370,15 @@ describe('filtrer mes utilisateurs', () => {
   }
 
   async function jeSelectionneUneStructure(input: HTMLElement, nomStructure: string): Promise<void> {
-    await selectionnerLElement(input, nomStructure)
+    await select(input, nomStructure)
   }
 
   function jeSelectionneGestionnaireRegion(): void {
-    cocherLaCase('Gestionnaire région')
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Gestionnaire région' }))
   }
 
   function jeSelectionneGestionnaireDepartement(): void {
-    cocherLaCase('Gestionnaire département')
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Gestionnaire département' }))
   }
 
   function jeReinitialiseLesFiltres(): void {
@@ -403,5 +403,17 @@ describe('filtrer mes utilisateurs', () => {
   ): void {
     const mesUtilisateursViewModel = mesUtilisateursPresenter([], 'fooId', totalUtilisateur, rolesAvecStructure, epochTime)
     renderComponent(<MesUtilisateurs mesUtilisateursViewModel={mesUtilisateursViewModel} />, options)
+  }
+
+  function saisirLeTexte(name: string, value: string): HTMLElement {
+    const input = screen.getByLabelText(name)
+    fireEvent.change(input, { target: { value } })
+    return input
+  }
+
+  function presserLeBouton(name: string): HTMLElement {
+    const button = screen.getByRole('button', { name })
+    fireEvent.click(button)
+    return button
   }
 })

--- a/src/components/MesUtilisateurs/InviterUnUtilisateur.test.tsx
+++ b/src/components/MesUtilisateurs/InviterUnUtilisateur.test.tsx
@@ -1,7 +1,8 @@
 import { fireEvent, screen, waitFor, within } from '@testing-library/react'
+import { select } from 'react-select-event'
 
 import MesUtilisateurs from './MesUtilisateurs'
-import { renderComponent, matchWithoutMarkup, structuresFetch, rolesAvecStructure, stubbedConceal, presserLeBouton, saisirLeTexte, selectionnerLElement, stubbedServerAction } from '@/components/testHelper'
+import { renderComponent, matchWithoutMarkup, structuresFetch, rolesAvecStructure, stubbedConceal, stubbedServerAction } from '@/components/testHelper'
 import { mesUtilisateursPresenter } from '@/presenters/mesUtilisateursPresenter'
 import { sessionUtilisateurViewModelFactory } from '@/presenters/testHelper'
 import { epochTime } from '@/shared/testHelper'
@@ -440,11 +441,11 @@ describe('inviter un utilisateur', () => {
   }
 
   async function jeSelectionneSaStructure(input: HTMLElement, nomStructure: string): Promise<void> {
-    await selectionnerLElement(input, nomStructure)
+    await select(input, nomStructure)
   }
 
   async function jeSelectionneSonDepartement(departement: string): Promise<void> {
-    await selectionnerLElement(screen.getByLabelText('Département *'), departement)
+    await select(screen.getByLabelText('Département *'), departement)
   }
 
   function jeSelectionneUnDepartementInexistant(): void {
@@ -482,5 +483,17 @@ describe('inviter un utilisateur', () => {
       }),
       ...options,
     })
+  }
+
+  function saisirLeTexte(name: string | RegExp, value: string): HTMLElement {
+    const input = screen.getByLabelText(name)
+    fireEvent.change(input, { target: { value } })
+    return input
+  }
+
+  function presserLeBouton(name: string): HTMLElement {
+    const button = screen.getByRole('button', { name })
+    fireEvent.click(button)
+    return button
   }
 })

--- a/src/components/MesUtilisateurs/MesUtilisateurs.test.tsx
+++ b/src/components/MesUtilisateurs/MesUtilisateurs.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, screen, within } from '@testing-library/react'
 import { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime'
 
 import MesUtilisateurs from './MesUtilisateurs'
-import { presserLeBouton, saisirLeTexte, renderComponent, rolesAvecStructure, stubbedServerAction } from '@/components/testHelper'
+import { renderComponent, rolesAvecStructure, stubbedServerAction } from '@/components/testHelper'
 import { mesUtilisateursPresenter } from '@/presenters/mesUtilisateursPresenter'
 import { sessionUtilisateurViewModelFactory } from '@/presenters/testHelper'
 import { epochTime, epochTimeMinusOneDay, epochTimeMinusTwoDays, epochTimePlusOneDay } from '@/shared/testHelper'
@@ -520,7 +520,7 @@ describe('mes utilisateurs', () => {
   }
 
   function jeTapeUnNom(value: string): void {
-    saisirLeTexte('Rechercher par nom ou adresse électronique', value)
+    fireEvent.change(screen.getByLabelText('Rechercher par nom ou adresse électronique'), { target: { value } })
   }
 
   function jeRecherche(): void {
@@ -531,6 +531,12 @@ describe('mes utilisateurs', () => {
     presserLeBouton('Reinitialiser')
   }
 })
+
+function presserLeBouton(name: string): HTMLElement {
+  const button = screen.getByRole('button', { name })
+  fireEvent.click(button)
+  return button
+}
 
 function afficherMesUtilisateurs(
   mesUtilisateursReadModel = [utilisateurActifReadModel, utilisateurEnAttenteReadModel],

--- a/src/components/testHelper.tsx
+++ b/src/components/testHelper.tsx
@@ -1,6 +1,5 @@
-import { fireEvent, render, RenderResult, screen, within } from '@testing-library/react'
+import { render, RenderResult } from '@testing-library/react'
 import { ReactElement } from 'react'
-import { select } from 'react-select-event'
 import { ToastContainer } from 'react-toastify'
 import { Mock } from 'vitest'
 
@@ -127,34 +126,4 @@ export function stubbedConceal() {
 
 export function stubbedServerAction(result: ReadonlyArray<string>): Mock<() => Promise<ReadonlyArray<string>>> {
   return vi.fn<() => Promise<ReadonlyArray<string>>>().mockResolvedValueOnce(result)
-}
-
-export function presserLeBouton(name: string, description?: string): HTMLElement {
-  const button = screen.getByRole('button', { description, name })
-  fireEvent.click(button)
-  return button
-}
-
-export function presserLeBoutonDans(context: HTMLElement, name: string): HTMLElement {
-  const button = within(context).getByRole('button', { name })
-  fireEvent.click(button)
-  return button
-}
-
-export function cocherLaCase(name: string): void {
-  fireEvent.click(screen.getByRole('checkbox', { name }))
-}
-
-export function presserLeBoutonRadio(name: string): void {
-  fireEvent.click(screen.getByRole('radio', { name }))
-}
-
-export function saisirLeTexte(name: string | RegExp, value: string): HTMLElement {
-  const input = screen.getByLabelText(name)
-  fireEvent.change(input, { target: { value } })
-  return input
-}
-
-export async function selectionnerLElement(input: HTMLElement, nomStructure: string): Promise<void> {
-  await select(input, nomStructure)
 }

--- a/src/components/transverse/EnTete/EnTete.test.tsx
+++ b/src/components/transverse/EnTete/EnTete.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, screen, waitFor, within } from '@testing-library/react'
 import * as nextAuth from 'next-auth/react'
 
 import EnTete from './EnTete'
-import { presserLeBouton, renderComponent, stubbedServerAction } from '@/components/testHelper'
+import { renderComponent, stubbedServerAction } from '@/components/testHelper'
 import { sessionUtilisateurViewModelFactory } from '@/presenters/testHelper'
 
 describe('en-tête : en tant qu’utilisateur authentifié', () => {
@@ -167,6 +167,12 @@ describe('en-tête : en tant qu’utilisateur authentifié', () => {
         }),
       }
     )
+  }
+
+  function presserLeBouton(name: string): HTMLElement {
+    const button = screen.getByRole('button', { name })
+    fireEvent.click(button)
+    return button
   }
 })
 


### PR DESCRIPTION
Nous avions deux niveaux d'abstraction pour simplifier l'écriture des tests mais à l'utilisation, ça fait un de trop.
Donc suppression du niveau générique et plutôt mise en snippet pour les écrire rapidement au cas par cas selon les tests.

# Contrat du dev

## Qualité

- [x] Relire le code

> **Et n'oublie pas de vérifier ce que tu as fait en production !**
