### PR TITLE
Fix paginatoin sur les lieux

### DIFF
--- a/src/app/(connecte)/(sans-menu)/liste-lieux-inclusion/page.tsx
+++ b/src/app/(connecte)/(sans-menu)/liste-lieux-inclusion/page.tsx
@@ -34,7 +34,7 @@ export default async function ListeLieuxInclusionController({
 
   const searchParamsAwaited = await searchParams
   const pageAwaited = searchParamsAwaited.page
-  const page = isNullishOrEmpty(pageAwaited) ? 0 : Number(pageAwaited)
+  const page = isNullishOrEmpty(pageAwaited) ? 0 : Number(pageAwaited) - 1
   const limite = 10
 
   const listeLieuxInclusionLoader = new PrismaListeLieuxInclusionLoader()

--- a/src/gateways/PrismaListeLieuxInclusionLoader.ts
+++ b/src/gateways/PrismaListeLieuxInclusionLoader.ts
@@ -67,7 +67,7 @@ export class PrismaListeLieuxInclusionLoader implements RecupererLieuxInclusionP
         ) AS nb_accompagnements_ac
       FROM main.structure s
       INNER JOIN main.adresse a ON a.id = s.adresse_id
-      inner join reference.categories_juridiques ref on s.categorie_juridique = ref.code
+      LEFT join reference.categories_juridiques ref on s.categorie_juridique = ref.code
       WHERE s.structure_cartographie_nationale_id IS NOT NULL
       ${codeDepartement ? Prisma.sql`AND a.departement = ${codeDepartement}` : Prisma.empty}
       ORDER BY s.nom ASC


### PR DESCRIPTION
- Avec la refacto sur la pagination et l'uniformisation avec la page, il faut ajuster l'index à demander au loader.
=> cette partie est à refactorer
- La requête sur les lieux ne renvoyait pas ceux qui n'avait pas de référence juridique valide => LEFT JOIN au lieu d'INNER JOIN
