### PR TITLE
781 : ne reset pas le perimètre après validation du formulaire

### DIFF
--- a/src/components/FeuillesDeRoute/AjouterUneFeuilleDeRoute.tsx
+++ b/src/components/FeuillesDeRoute/AjouterUneFeuilleDeRoute.tsx
@@ -52,6 +52,7 @@ export default function AjouterUneFeuilleDeRoute({
           membres={membres}
           nom=""
           perimetres={perimetres}
+          resetPerimetre={true}
           validerFormulaire={ajouterUneFeuilleDeRoute}
         >
           <SubmitButton isDisabled={isDisabled}>

--- a/src/components/FeuillesDeRoute/FormulaireFeuilleDeRoute.tsx
+++ b/src/components/FeuillesDeRoute/FormulaireFeuilleDeRoute.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { FormEvent, PropsWithChildren, ReactElement, useId, useState } from 'react'
+import { FormEvent, PropsWithChildren, ReactElement, useEffect, useId, useState } from 'react'
 
 import DrawerTitle from '../shared/DrawerTitle/DrawerTitle'
 import RadioGroup from '../shared/Radio/RadioGroup'
@@ -17,14 +17,21 @@ export default function FormulaireFeuilleDeRoute({
   nom,
   perimetreActuel,
   perimetres,
+  resetPerimetre,
   validerFormulaire,
 }: Props): ReactElement {
   const nomId = useId()
   const [perimetreSelectionne, setPerimetreSelectionne] = useState(perimetreActuel ?? '')
 
+  useEffect(() => {
+    setPerimetreSelectionne(perimetreActuel ?? '')
+  }, [perimetreActuel])
+
   function handleSubmit(event: FormEvent<HTMLFormElement>): void {
     validerFormulaire(event)
-    setPerimetreSelectionne('')
+    if (resetPerimetre === true) {
+      setPerimetreSelectionne('')
+    }
   }
   return (
     <>
@@ -102,5 +109,6 @@ type Props = PropsWithChildren<Readonly<{
   nom: string
   perimetreActuel?: string
   perimetres: ReadonlyArray<LabelValue>
+  resetPerimetre?: boolean
   validerFormulaire(event: FormEvent<HTMLFormElement>): void
 }>>


### PR DESCRIPTION
Le radiobox a un comportement particulier.  Dans AjouterUneFeuilleDeRoute.tsx ligne 84, il y a un (event.target as HTMLFormElement).reset() qui réinitialise le    formulaire HTML, ce qui explique pourquoi les champs TextInput et Select sont réinitialisés. Mais le RadioGroup contrôlé par React state  n'est pas réinitialisé par cette méthode.
=> Il faut le gérer programmatiquement
