### PR TITLE
560 lier les membres à des structures de MIN

### DIFF
--- a/prisma/migrations/20250929085813_lien_membre_structure/migration.sql
+++ b/prisma/migrations/20250929085813_lien_membre_structure/migration.sql
@@ -1,0 +1,44 @@
+-- AlterTable
+ALTER TABLE "min"."membre" ADD COLUMN     "structure_id" INTEGER;
+
+-- AddForeignKey
+ALTER TABLE "min"."membre" ADD CONSTRAINT "membre_structure_id_fkey" FOREIGN KEY ("structure_id") REFERENCES "min"."structure"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Créer les structures manquantes pour les membres avec siret_ridet
+INSERT INTO min.structure (
+    identifiant_etablissement,
+    nom,
+    adresse,
+    code_postal,
+    commune,
+    contact,
+    departement_code,
+    id_mongo,
+    statut,
+    type
+)
+SELECT DISTINCT
+    m.siret_ridet,
+    m.nom,
+    'À renseigner',
+    '00000',
+    'À renseigner',
+    '{}'::jsonb,
+    COALESCE(m.gouvernance_departement_code, '00'),
+    gen_random_uuid()::text,
+    'active',
+    'Association'
+FROM min.membre m
+WHERE m.siret_ridet IS NOT NULL
+    AND NOT EXISTS (
+        SELECT 1
+        FROM min.structure s
+        WHERE s.identifiant_etablissement = m.siret_ridet
+    );
+
+-- Lier les membres aux structures via leur siret_ridet
+UPDATE min.membre m
+SET structure_id = s.id
+FROM min.structure s
+WHERE m.siret_ridet IS NOT NULL
+    AND s.identifiant_etablissement = m.siret_ridet;

--- a/prisma/migrations/20251001102002_ajout_categorie_juridique_structure/migration.sql
+++ b/prisma/migrations/20251001102002_ajout_categorie_juridique_structure/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "min"."structure" ADD COLUMN     "categorie_juridique" VARCHAR(4);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,18 +55,19 @@ model StructureRecord {
   id Int @id @default(autoincrement())
 
   adresse                  String
-  codePostal               String @map("code_postal")
+  codePostal               String  @map("code_postal")
   commune                  String
   /// [Contact]
   contact                  Json
-  departementCode          String @map("departement_code")
+  departementCode          String  @map("departement_code")
   // SIRET ou RIDET
-  identifiantEtablissement String @map("identifiant_etablissement")
+  identifiantEtablissement String  @map("identifiant_etablissement")
   // TODO: à supprimer après la migration finale
-  idMongo                  String @map("id_mongo")
-  nom                      String @db.Citext
+  idMongo                  String  @map("id_mongo")
+  nom                      String  @db.Citext
   statut                   String
   type                     String
+  categorieJuridique       String? @map("categorie_juridique") @db.VarChar(4)
 
   utilisateurs UtilisateurRecord[]
   membres      MembreRecord[]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -69,6 +69,7 @@ model StructureRecord {
   type                     String
 
   utilisateurs UtilisateurRecord[]
+  membres      MembreRecord[]
 
   relationDepartement DepartementRecord @relation(fields: [departementCode], references: [code])
 
@@ -203,12 +204,14 @@ model MembreRecord {
   nom                        String?   @map("nom")
   siretRidet                 String?   @map("siret_ridet")
   dateSuppression            DateTime? @map("date_suppression")
+  structureId                Int?      @map("structure_id")
 
   oldUUID String @map("old_uuid") @db.Uuid
 
   relationGouvernance      GouvernanceRecord               @relation(fields: [gouvernanceDepartementCode], references: [departementCode])
   relationContact          ContactMembreGouvernanceRecord  @relation("contact", fields: [contact], references: [email])
   relationContactTechnique ContactMembreGouvernanceRecord? @relation("contactTechnique", fields: [contactTechnique], references: [email])
+  relationStructure        StructureRecord?                @relation(fields: [structureId], references: [id])
 
   FeuilleDeRouteRecord         FeuilleDeRouteRecord[]
   BeneficiaireSubventionRecord BeneficiaireSubventionRecord[]

--- a/src/app/api/actions/ajouterUnMembreAction.ts
+++ b/src/app/api/actions/ajouterUnMembreAction.ts
@@ -7,6 +7,8 @@ import prisma from '../../../../prisma/prismaClient'
 import { getSessionSub } from '@/gateways/NextAuthAuthentificationGateway'
 import { PrismaGouvernanceRepository } from '@/gateways/PrismaGouvernanceRepository'
 import { PrismaMembreRepository } from '@/gateways/PrismaMembreRepository'
+import { PrismaStructureRepository } from '@/gateways/PrismaStructureRepository'
+import { PrismaTransactionRepository } from '@/gateways/PrismaTransactionRepository'
 import { PrismaUtilisateurRepository } from '@/gateways/PrismaUtilisateurRepository'
 import { ResultAsync } from '@/use-cases/CommandHandler'
 import { AjouterUnMembre } from '@/use-cases/commands/AjouterUnMembre'
@@ -23,12 +25,13 @@ export async function ajouterUnMembreAction(
   const result = await new AjouterUnMembre(
     new PrismaUtilisateurRepository(prisma.utilisateurRecord),
     new PrismaGouvernanceRepository(),
-    new PrismaMembreRepository()
+    new PrismaMembreRepository(),
+    new PrismaStructureRepository(),
+    new PrismaTransactionRepository()
   ).handle({
     contact: actionParams.contact,
     contactTechnique: actionParams.contactTechnique,
     entreprise: actionParams.entreprise,
-    nomEntreprise: actionParams.nomEntreprise,
     uidGestionnaire: await getSessionSub(),
     uidGouvernance: actionParams.codeDepartement, // Pour l'instant, on utilise le code département
   })
@@ -52,12 +55,15 @@ type ActionParams = Readonly<{
     nom: string
     prenom: string
   }>
-  entreprise?: Readonly<{
+  entreprise: Readonly<{
+    adresse: string
     categorieJuridiqueCode: string
     categorieJuridiqueUniteLegale: string
+    codePostal: string
+    commune: string
+    nom: string
     siret: string
   }>
-  nomEntreprise: string
   path: string
 }>
 
@@ -76,9 +82,13 @@ const validator = z.object({
     prenom: z.string().min(1, { message: 'Le prénom du contact technique doit être renseigné' }),
   }).optional(),
   entreprise: z.object({
+    adresse: z.string().min(1, { message: 'L\'adresse doit être renseignée' }),
+    categorieJuridiqueCode: z.string().optional(),
     categorieJuridiqueUniteLegale: z.string().min(1, { message: 'La catégorie juridique doit être renseignée' }),
+    codePostal: z.string().min(1, { message: 'Le code postal doit être renseigné' }),
+    commune: z.string().min(1, { message: 'La commune doit être renseignée' }),
+    nomEntreprise: z.string().min(1, { message: 'Le nom de l\'entreprise doit être renseigné' }),
     siret: z.string().min(1, { message: 'Le SIRET doit être renseigné' }),
   }).optional(),
-  nomEntreprise: z.string().min(1, { message: 'Le nom de l\'entreprise doit être renseigné' }),
   path: z.string().min(1, { message: 'Le chemin doit être renseigné' }),
 })

--- a/src/app/api/actions/ajouterUnMembreAction.ts
+++ b/src/app/api/actions/ajouterUnMembreAction.ts
@@ -19,6 +19,15 @@ export async function ajouterUnMembreAction(
   const validationResult = validator.safeParse(actionParams)
 
   if (validationResult.error) {
+    // Vérifier si l'erreur concerne les données de l'entreprise
+    const hasEntrepriseError = validationResult.error.issues.some(
+      issue => issue.path[0] === 'entreprise'
+    )
+
+    if (hasEntrepriseError) {
+      return ['Un problème est survenu en récupérant les informations de l\'entreprise. Contactez le support ANCT.']
+    }
+
     return validationResult.error.issues.map(({ message }) => message)
   }
 
@@ -87,8 +96,8 @@ const validator = z.object({
     categorieJuridiqueUniteLegale: z.string().min(1, { message: 'La catégorie juridique doit être renseignée' }),
     codePostal: z.string().min(1, { message: 'Le code postal doit être renseigné' }),
     commune: z.string().min(1, { message: 'La commune doit être renseignée' }),
-    nomEntreprise: z.string().min(1, { message: 'Le nom de l\'entreprise doit être renseigné' }),
+    nom: z.string().min(1, { message: 'Le nom de l\'entreprise doit être renseigné' }),
     siret: z.string().min(1, { message: 'Le SIRET doit être renseigné' }),
-  }).optional(),
+  }),
   path: z.string().min(1, { message: 'Le chemin doit être renseigné' }),
 })

--- a/src/components/GestionMembresGouvernance/AjouterUnMembrePage.tsx
+++ b/src/components/GestionMembresGouvernance/AjouterUnMembrePage.tsx
@@ -77,11 +77,14 @@ export default function AjouterUnMembrePage({ codeDepartement }: AjouterUnMembre
         contact: donneesMembre.contact,
         contactTechnique: donneesMembre.contactSecondaire ?? undefined,
         entreprise: {
+          adresse: donneesMembre.entreprise.adresse,
           categorieJuridiqueCode: donneesMembre.entreprise.categorieJuridiqueCode,
           categorieJuridiqueUniteLegale: donneesMembre.entreprise.categorieJuridiqueLibelle,
+          codePostal: donneesMembre.entreprise.codePostal,
+          commune: donneesMembre.entreprise.commune,
+          nom: donneesMembre.entreprise.denomination,
           siret: donneesMembre.entreprise.identifiant,
         },
-        nomEntreprise: donneesMembre.entreprise.denomination,
         path: pathname,
       })
 

--- a/src/components/shared/Membre/EntrepriseType.ts
+++ b/src/components/shared/Membre/EntrepriseType.ts
@@ -5,6 +5,8 @@ export type EntrepriseViewModel = Readonly<{
   adresse: string
   categorieJuridiqueCode: string
   categorieJuridiqueLibelle: string
+  codePostal: string
+  commune: string
   denomination: string
   identifiant: string
 }>

--- a/src/domain/Membre.ts
+++ b/src/domain/Membre.ts
@@ -1,5 +1,6 @@
 import { GouvernanceUid, GouvernanceUidState } from './Gouvernance'
 import { Entity, Uid, ValueObject } from './shared/Model'
+import { StructureUid, StructureUidState } from './Structure'
 import { Result } from '@/shared/lang'
 
 export abstract class Membre extends Entity<MembreState> {
@@ -11,6 +12,7 @@ export abstract class Membre extends Entity<MembreState> {
       statut: this.statut.state.value,
       uid: this.uid.state,
       uidGouvernance: this.uidGouvernance.state,
+      uidStructure: this.uidStructure.state,
     }
   }
 
@@ -19,6 +21,7 @@ export abstract class Membre extends Entity<MembreState> {
   protected readonly roles: ReadonlyArray<Role>
   protected readonly statut: Statut
   protected readonly uidGouvernance: GouvernanceUid
+  protected readonly uidStructure: StructureUid
 
   constructor(
     uid: MembreUid,
@@ -26,7 +29,8 @@ export abstract class Membre extends Entity<MembreState> {
     roles: ReadonlyArray<Role>,
     uidGouvernance: GouvernanceUid,
     statut: Statut,
-    dateSuppression: Date | undefined
+    dateSuppression: Date | undefined,
+    uidStructure: StructureUid
   ) {
     super(uid)
     this.uidGouvernance = uidGouvernance
@@ -34,6 +38,7 @@ export abstract class Membre extends Entity<MembreState> {
     this.roles = roles
     this.statut = statut
     this.dateSuppression = dateSuppression
+    this.uidStructure = uidStructure
   }
 
   appartientALaGouvernance(uidGouvernance: string): boolean {
@@ -69,6 +74,7 @@ export type MembreState = Readonly<{
   statut: string
   uid: UidState
   uidGouvernance: GouvernanceUidState
+  uidStructure: StructureUidState
 }>
 
 export type MembreFailure = 'membreDejaConfirme' | 'membreSupprimer'

--- a/src/domain/MembreCandidat.ts
+++ b/src/domain/MembreCandidat.ts
@@ -1,12 +1,17 @@
 import { GouvernanceUid } from './Gouvernance'
 import { Membre, MembreFailure, MembreUid, Role, Statut } from './Membre'
 import { membreFactory } from './MembreFactory'
+import { StructureUid } from './Structure'
 import { MembreSupprimer } from '@/domain/MembreSupprimer'
 import { Result } from '@/shared/lang'
 
 export class MembreCandidat extends Membre {
-  constructor(uid: MembreUid, nom: string, uidGouvernance: GouvernanceUid, statut: Statut) {
-    super(uid, nom, [new Role('observateur')], uidGouvernance, statut, undefined)
+  constructor(uid: MembreUid,
+    nom: string,
+    uidGouvernance: GouvernanceUid,
+    statut: Statut,
+    uidStructure: StructureUid) {
+    super(uid, nom, [new Role('observateur')], uidGouvernance, statut, undefined, uidStructure)
   }
 
   confirmer(): Result<MembreFailure, Membre> {
@@ -16,6 +21,7 @@ export class MembreCandidat extends Membre {
       statut: 'confirme',
       uid: this.uid.state,
       uidGouvernance: this.uidGouvernance.state,
+      uidStructure: this.uidStructure.state,
     })
   }
 
@@ -26,7 +32,8 @@ export class MembreCandidat extends Membre {
       this.state.roles.filter( role=> role !== 'coporteur').map(role => new Role(role)),
       this.uidGouvernance,
       new Statut('supprimer'),
-      date
+      date,
+      this.uidStructure
     )
   }
 }

--- a/src/domain/MembreConfirme.ts
+++ b/src/domain/MembreConfirme.ts
@@ -1,4 +1,5 @@
 import { Membre, MembreFailure, MembreUid, Role, Statut } from './Membre'
+import { StructureUid } from './Structure'
 import { GouvernanceUid } from '@/domain/Gouvernance'
 import { MembreSupprimer } from '@/domain/MembreSupprimer'
 import { Result } from '@/shared/lang'
@@ -9,9 +10,10 @@ export class MembreConfirme extends Membre {
     nom: string,
     roles: ReadonlyArray<Role>,
     uidGouvernance: GouvernanceUid,
-    statut: Statut
+    statut: Statut,
+    uidStructure: StructureUid
   ) {
-    super(uid, nom, roles, uidGouvernance, statut, undefined)
+    super(uid, nom, roles, uidGouvernance, statut, undefined, uidStructure)
   }
 
   override confirmer(): Result<MembreFailure, Membre> {
@@ -25,7 +27,8 @@ export class MembreConfirme extends Membre {
       this.state.roles.filter( role=> role !== 'coporteur').map(role => new Role(role)),
       this.uidGouvernance,
       new Statut('supprimer'),
-      date
+      date,
+      this.uidStructure
     )
   }
 }

--- a/src/domain/MembreFactory.ts
+++ b/src/domain/MembreFactory.ts
@@ -2,6 +2,7 @@ import { GouvernanceUid, GouvernanceUidState } from './Gouvernance'
 import { Membre, MembreFailure, MembreState, MembreUid, Role, Statut } from './Membre'
 import { MembreCandidat } from './MembreCandidat'
 import { MembreConfirme } from './MembreConfirme'
+import { StructureUid, StructureUidState } from './Structure'
 import { Result } from '@/shared/lang'
 
 export function membreFactory({
@@ -10,6 +11,7 @@ export function membreFactory({
   statut,
   uid,
   uidGouvernance,
+  uidStructure,
 }: FactoryParams): Result<MembreFailure, Membre> {
   if (statut === 'confirme') {
     return new MembreConfirme(
@@ -17,7 +19,8 @@ export function membreFactory({
       nom,
       roles.map((role) => new Role(role)),
       new GouvernanceUid(uidGouvernance.value),
-      new Statut(statut)
+      new Statut(statut),
+      new StructureUid(uidStructure.value)
     )
   }
 
@@ -25,7 +28,8 @@ export function membreFactory({
     new MembreUid(uid.value),
     nom,
     new GouvernanceUid(uidGouvernance.value),
-    new Statut(statut)
+    new Statut(statut),
+    new StructureUid(uidStructure.value)
   )
 }
 
@@ -37,4 +41,5 @@ type FactoryParams = Readonly<{
   statut: StatutFactory
   uid: MembreState['uid']
   uidGouvernance: GouvernanceUidState
+  uidStructure: StructureUidState
 }>

--- a/src/domain/Structure.ts
+++ b/src/domain/Structure.ts
@@ -1,13 +1,67 @@
-import { Uid } from './shared/Model'
+import { Entity, Uid } from './shared/Model'
+
+export class Structure extends Entity<StructureState> {
+  override get state(): StructureState {
+    return {
+      departementCode: this.#departementCode,
+      identifiantEtablissement: this.#identifiantEtablissement,
+      nom: this.#nom,
+      uid: this.uid.state,
+    }
+  }
+
+  readonly #departementCode: string
+  readonly #identifiantEtablissement: string
+  readonly #nom: string
+
+  private constructor(
+    uid: StructureUid,
+    nom: string,
+    identifiantEtablissement: string,
+    departementCode: string
+  ) {
+    super(uid)
+    this.#nom = nom
+    this.#identifiantEtablissement = identifiantEtablissement
+    this.#departementCode = departementCode
+  }
+
+  static create({
+    departementCode,
+    identifiantEtablissement,
+    nom,
+    uid,
+  }: StructureFactoryParams): Structure {
+    return new Structure(
+      new StructureUid(uid.value),
+      nom,
+      identifiantEtablissement,
+      departementCode
+    )
+  }
+}
+
+export class StructureUid extends Uid<StructureUidState> {
+  constructor(value: number) {
+    super({ value })
+  }
+}
 
 export type StructureState = Readonly<{
+  departementCode: string
+  identifiantEtablissement: string
   nom: string
   uid: StructureUidState
 }>
 
-export class StructureUid extends Uid<StructureUidState> {}
+export type StructureUidState = Readonly<{ value: number }>
 
-type StructureUidState = Readonly<{ value: number }>
+type StructureFactoryParams = Readonly<{
+  departementCode: string
+  identifiantEtablissement: string
+  nom: string
+  uid: { value: number }
+}>
 
 /*
  * A décommenter quand ça sera utile

--- a/src/domain/UtilisateurFactory.ts
+++ b/src/domain/UtilisateurFactory.ts
@@ -136,7 +136,7 @@ export class UtilisateurFactory {
   }
 
   #createGestionnaireStructure(structureUidValue: number): Utilisateur {
-    const structureUid = new StructureUid({ value: this.#structureUid ?? structureUidValue })
+    const structureUid = new StructureUid(this.#structureUid ?? structureUidValue)
     return new GestionnaireStructure(
       this.#uid,
       this.#nom,

--- a/src/domain/testHelper.ts
+++ b/src/domain/testHelper.ts
@@ -124,6 +124,9 @@ export function membrePotentielFactory(override?: Partial<Parameters<typeof memb
     uidGouvernance: {
       value: 'gouvernanceFooId',
     },
+    uidStructure: {
+      value: 1,
+    },
     ...override,
   }) as Membre
 }
@@ -138,6 +141,9 @@ export function membreConfirmeFactory(override?: Partial<Parameters<typeof membr
     },
     uidGouvernance: {
       value: 'gouvernanceFooId',
+    },
+    uidStructure: {
+      value: 1,
     },
     ...override,
   }) as Membre

--- a/src/gateways/PrismaMembreRepository.test.ts
+++ b/src/gateways/PrismaMembreRepository.test.ts
@@ -101,8 +101,8 @@ describe('membre repository', () => {
     await creerUnDepartement({ code: '93', regionCode: '84' })
     await creerUneGouvernance({ departementCode: '69' })
     await creerUnContact()
-    await creerUneStructure({ id: 5, departementCode: '69', nom: 'Structure Paris' })
-    await creerUneStructure({ id: 6, departementCode: '93', nom: 'Structure 93' })
+    await creerUneStructure({ departementCode: '69', id: 5, nom: 'Structure Paris' })
+    await creerUneStructure({ departementCode: '93', id: 6, nom: 'Structure 93' })
     await creerUnMembre({ id: 'commune-69-69', nom: 'Paris', statut: 'confirme', structureId: 5 })
     await creerUnMembre({ id: 'commune-93-93', statut: 'confirme', structureId: 6 })
 
@@ -134,8 +134,8 @@ describe('membre repository', () => {
     await creerUnDepartement({ code: '93', regionCode: '84' })
     await creerUneGouvernance({ departementCode: '69' })
     await creerUnContact()
-    await creerUneStructure({ id: 7, departementCode: '69', nom: 'Structure Bordeaux Métropole' })
-    await creerUneStructure({ id: 8, departementCode: '93', nom: 'Structure EPCI 93' })
+    await creerUneStructure({ departementCode: '69', id: 7, nom: 'Structure Bordeaux Métropole' })
+    await creerUneStructure({ departementCode: '93', id: 8, nom: 'Structure EPCI 93' })
     await creerUnMembre({ id: 'epci-69-69', nom: 'Bordeaux Métropole', statut: 'confirme', structureId: 7 })
     await creerUnMembre({ id: 'epci-93-93', statut: 'confirme', structureId: 8 })
 
@@ -167,8 +167,8 @@ describe('membre repository', () => {
     await creerUnDepartement({ code: '93', regionCode: '84' })
     await creerUneGouvernance({ departementCode: '69' })
     await creerUnContact()
-    await creerUneStructure({ id: 9, departementCode: '69', nom: 'HUBIKOOP' })
-    await creerUneStructure({ id: 10, departementCode: '93', nom: 'Structure 93' })
+    await creerUneStructure({ departementCode: '69', id: 9, nom: 'HUBIKOOP' })
+    await creerUneStructure({ departementCode: '93', id: 10, nom: 'Structure 93' })
     await creerUnMembre({ id: 'structure-69-69', nom: 'HUBIKOOP', statut: 'candidat', structureId: 9 })
     await creerUnMembre({ id: 'structure-93-93', statut: 'confirme', structureId: 10 })
 

--- a/src/gateways/PrismaMembreRepository.test.ts
+++ b/src/gateways/PrismaMembreRepository.test.ts
@@ -1,7 +1,7 @@
 import { Prisma } from '@prisma/client'
 
 import { PrismaMembreRepository } from './PrismaMembreRepository'
-import { creerUnContact, creerUnDepartement, creerUneGouvernance, creerUneRegion, creerUnMembre } from './testHelper'
+import { creerUnContact, creerUnDepartement, creerUneGouvernance, creerUneRegion, creerUneStructure, creerUnMembre } from './testHelper'
 import prisma from '../../prisma/prismaClient'
 import { MembreUid } from '@/domain/Membre'
 import { membreConfirmeFactory } from '@/domain/testHelper'
@@ -11,13 +11,14 @@ describe('membre repository', () => {
 
   afterEach(async () => prisma.$queryRaw`ROLLBACK TRANSACTION`)
 
-  it('rechercher un membre qui n’existe pas', async () => {
+  it('rechercher un membre qui n\'existe pas', async () => {
     // GIVEN
     await creerUneRegion()
     await creerUnDepartement({ code: '69' })
     await creerUneGouvernance({ departementCode: '69' })
     await creerUnContact()
-    await creerUnMembre({ id: 'prefecture-69' })
+    await creerUneStructure({ departementCode: '69', id: 1 })
+    await creerUnMembre({ id: 'prefecture-69', structureId: 1 })
 
     // WHEN
     const membre = new PrismaMembreRepository().get(new MembreUid('prefecture-93').state.value)
@@ -31,10 +32,13 @@ describe('membre repository', () => {
     // GIVEN
     await creerUneRegion({ code: '84' })
     await creerUnDepartement({ code: '69', nom: 'Lyon', regionCode: '84' })
+    await creerUnDepartement({ code: '93', nom: 'Seine-Saint-Denis', regionCode: '84' })
     await creerUneGouvernance({ departementCode: '69' })
     await creerUnContact()
-    await creerUnMembre({ id: 'departement-69-69', nom: 'Lyon', statut: 'confirme' })
-    await creerUnMembre({ id: 'departement-93-93', statut: 'confirme' })
+    await creerUneStructure({ departementCode: '69', id: 1, nom: 'Structure Lyon' })
+    await creerUneStructure({ departementCode: '93', id: 2, nom: 'Structure 93' })
+    await creerUnMembre({ id: 'departement-69-69', nom: 'Lyon', statut: 'confirme', structureId: 1 })
+    await creerUnMembre({ id: 'departement-93-93', statut: 'confirme', structureId: 2 })
 
     // WHEN
     const membre = await new PrismaMembreRepository().get(new MembreUid('departement-69-69').state.value)
@@ -51,6 +55,9 @@ describe('membre repository', () => {
       uidGouvernance: {
         value: '69',
       },
+      uidStructure: {
+        value: 1,
+      },
     })
   })
 
@@ -58,10 +65,13 @@ describe('membre repository', () => {
     // GIVEN
     await creerUneRegion({ code: '84', nom: 'Auvergne-Rhône-Alpes' })
     await creerUnDepartement({ code: '69', regionCode: '84' })
+    await creerUnDepartement({ code: '93', regionCode: '84' })
     await creerUneGouvernance({ departementCode: '69' })
     await creerUnContact()
-    await creerUnMembre({ id: 'sgar-69-69', nom:'Auvergne-Rhône-Alpes', statut: 'confirme' })
-    await creerUnMembre({ id: 'sgar-93-93', nom:'93', statut: 'confirme' })
+    await creerUneStructure({ departementCode: '69', id: 3, nom: 'Structure SGAR' })
+    await creerUneStructure({ departementCode: '93', id: 4, nom: 'Structure SGAR 93' })
+    await creerUnMembre({ id: 'sgar-69-69', nom:'Auvergne-Rhône-Alpes', statut: 'confirme', structureId: 3 })
+    await creerUnMembre({ id: 'sgar-93-93', nom:'93', statut: 'confirme', structureId: 4 })
 
     // WHEN
     const membre = await new PrismaMembreRepository().get(new MembreUid('sgar-69-69').state.value)
@@ -78,6 +88,9 @@ describe('membre repository', () => {
       uidGouvernance: {
         value: '69',
       },
+      uidStructure: {
+        value: 3,
+      },
     })
   })
 
@@ -85,10 +98,13 @@ describe('membre repository', () => {
     // GIVEN
     await creerUneRegion({ code: '84' })
     await creerUnDepartement({ code: '69', regionCode: '84' })
+    await creerUnDepartement({ code: '93', regionCode: '84' })
     await creerUneGouvernance({ departementCode: '69' })
     await creerUnContact()
-    await creerUnMembre({ id: 'commune-69-69', nom: 'Paris', statut: 'confirme' })
-    await creerUnMembre({ id: 'commune-93-93', statut: 'confirme' })
+    await creerUneStructure({ id: 5, departementCode: '69', nom: 'Structure Paris' })
+    await creerUneStructure({ id: 6, departementCode: '93', nom: 'Structure 93' })
+    await creerUnMembre({ id: 'commune-69-69', nom: 'Paris', statut: 'confirme', structureId: 5 })
+    await creerUnMembre({ id: 'commune-93-93', statut: 'confirme', structureId: 6 })
 
     // WHEN
     const membre = await new PrismaMembreRepository().get(new MembreUid('commune-69-69').state.value)
@@ -105,6 +121,9 @@ describe('membre repository', () => {
       uidGouvernance: {
         value: '69',
       },
+      uidStructure: {
+        value: 5,
+      },
     })
   })
 
@@ -112,10 +131,13 @@ describe('membre repository', () => {
     // GIVEN
     await creerUneRegion({ code: '84' })
     await creerUnDepartement({ code: '69', regionCode: '84' })
+    await creerUnDepartement({ code: '93', regionCode: '84' })
     await creerUneGouvernance({ departementCode: '69' })
     await creerUnContact()
-    await creerUnMembre({ id: 'epci-69-69', nom: 'Bordeaux Métropole', statut: 'confirme' })
-    await creerUnMembre({ id: 'epci-93-93', statut: 'confirme' })
+    await creerUneStructure({ id: 7, departementCode: '69', nom: 'Structure Bordeaux Métropole' })
+    await creerUneStructure({ id: 8, departementCode: '93', nom: 'Structure EPCI 93' })
+    await creerUnMembre({ id: 'epci-69-69', nom: 'Bordeaux Métropole', statut: 'confirme', structureId: 7 })
+    await creerUnMembre({ id: 'epci-93-93', statut: 'confirme', structureId: 8 })
 
     // WHEN
     const membre = await new PrismaMembreRepository().get(new MembreUid('epci-69-69').state.value)
@@ -132,6 +154,9 @@ describe('membre repository', () => {
       uidGouvernance: {
         value: '69',
       },
+      uidStructure: {
+        value: 7,
+      },
     })
   })
 
@@ -139,10 +164,13 @@ describe('membre repository', () => {
     // GIVEN
     await creerUneRegion({ code: '84' })
     await creerUnDepartement({ code: '69', regionCode: '84' })
+    await creerUnDepartement({ code: '93', regionCode: '84' })
     await creerUneGouvernance({ departementCode: '69' })
     await creerUnContact()
-    await creerUnMembre({ id: 'structure-69-69', nom: 'HUBIKOOP', statut: 'candidat' })
-    await creerUnMembre({ id: 'structure-93-93', statut: 'confirme' })
+    await creerUneStructure({ id: 9, departementCode: '69', nom: 'HUBIKOOP' })
+    await creerUneStructure({ id: 10, departementCode: '93', nom: 'Structure 93' })
+    await creerUnMembre({ id: 'structure-69-69', nom: 'HUBIKOOP', statut: 'candidat', structureId: 9 })
+    await creerUnMembre({ id: 'structure-93-93', statut: 'confirme', structureId: 10 })
 
     // WHEN
     const membre = await new PrismaMembreRepository().get(new MembreUid('structure-69-69').state.value)
@@ -158,6 +186,9 @@ describe('membre repository', () => {
       },
       uidGouvernance: {
         value: '69',
+      },
+      uidStructure: {
+        value: 9,
       },
     })
   })
@@ -204,6 +235,7 @@ describe('membre repository', () => {
       oldUUID: '30ca3fa5-76b8-471d-a811-d96074b18eb1',
       siretRidet: null,
       statut: 'confirme',
+      structureId: null,
       type: 'Préfecture départementale',
     })
   })

--- a/src/gateways/PrismaMembreRepository.ts
+++ b/src/gateways/PrismaMembreRepository.ts
@@ -75,7 +75,7 @@ export class PrismaMembreRepository implements MembreRepository {
         oldUUID: crypto.randomUUID(),
         siretRidet: entrepriseData.siret,
         statut: membre.state.statut,
-        structureId: membre.state.uidStructure?.value,
+        structureId: membre.state.uidStructure.value,
         type : entrepriseData.categorieJuridiqueUniteLegale,
       },
     })
@@ -90,7 +90,7 @@ export class PrismaMembreRepository implements MembreRepository {
       },
     })
 
-    if (!record.structureId) {
+    if (record.structureId === null) {
       throw new Error(`Membre ${uid} n'a pas de structure associée`)
     }
 

--- a/src/gateways/PrismaStructureRepository.ts
+++ b/src/gateways/PrismaStructureRepository.ts
@@ -10,6 +10,7 @@ export class PrismaStructureRepository implements StructureRepository {
     const structure = await client.structureRecord.create({
       data: {
         adresse: data.adresse,
+        categorieJuridique: data.categorieJuridique,
         codePostal: data.codePostal,
         commune: data.commune,
         contact: {
@@ -24,7 +25,7 @@ export class PrismaStructureRepository implements StructureRepository {
         idMongo: crypto.randomUUID(),
         nom: data.nom,
         statut: 'active',
-        type: 'Association',
+        type: data.categorieJuridiqueLibelle,
       },
     })
 

--- a/src/gateways/PrismaStructureRepository.ts
+++ b/src/gateways/PrismaStructureRepository.ts
@@ -1,0 +1,58 @@
+import { Prisma } from '@prisma/client'
+
+import prisma from '../../prisma/prismaClient'
+import { Structure } from '@/domain/Structure'
+import { StructureData, StructureRepository } from '@/use-cases/commands/shared/StructureRepository'
+
+export class PrismaStructureRepository implements StructureRepository {
+  async create(data: StructureData, tx?: Prisma.TransactionClient): Promise<Structure> {
+    const client = tx ?? prisma
+    const structure = await client.structureRecord.create({
+      data: {
+        adresse: data.adresse,
+        codePostal: data.codePostal,
+        commune: data.commune,
+        contact: {
+          email: '',
+          fonction: '',
+          nom: '',
+          prenom: '',
+          telephone: '',
+        },
+        departementCode: data.departementCode,
+        identifiantEtablissement: data.identifiantEtablissement,
+        idMongo: crypto.randomUUID(),
+        nom: data.nom,
+        statut: 'active',
+        type: 'Association',
+      },
+    })
+
+    return Structure.create({
+      departementCode: structure.departementCode,
+      identifiantEtablissement: structure.identifiantEtablissement,
+      nom: structure.nom,
+      uid: { value: structure.id },
+    })
+  }
+
+  async getBySiret(siret: string, tx?: Prisma.TransactionClient): Promise<null | Structure> {
+    const client = tx ?? prisma
+    const structure = await client.structureRecord.findFirst({
+      where: {
+        identifiantEtablissement: siret,
+      },
+    })
+
+    if (!structure) {
+      return null
+    }
+
+    return Structure.create({
+      departementCode: structure.departementCode,
+      identifiantEtablissement: structure.identifiantEtablissement,
+      nom: structure.nom,
+      uid: { value: structure.id },
+    })
+  }
+}

--- a/src/presenters/entreprisePresenter.ts
+++ b/src/presenters/entreprisePresenter.ts
@@ -9,6 +9,8 @@ export function entreprisePresenter(readModel: EntrepriseReadModel): EntrepriseV
     adresse: readModel.adresse,
     categorieJuridiqueCode: readModel.categorieJuridiqueCode,
     categorieJuridiqueLibelle: readModel.categorieJuridiqueLibelle ?? `Code ${readModel.categorieJuridiqueCode}`,
+    codePostal: readModel.codePostal,
+    commune: readModel.commune,
     denomination: readModel.denomination,
     identifiant: readModel.identifiant,
   }

--- a/src/use-cases/commands/AjouterUnMembre.test.ts
+++ b/src/use-cases/commands/AjouterUnMembre.test.ts
@@ -1,0 +1,292 @@
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/require-await */
+import { Prisma } from '@prisma/client'
+
+import { AjouterUnMembre } from './AjouterUnMembre'
+import { GetGouvernanceRepository } from './shared/GouvernanceRepository'
+import { ContactData, CreateMembreRepository, EntrepriseData, GetMembreRepository } from './shared/MembreRepository'
+import { CreateStructureRepository, GetStructureBySiretRepository, StructureData } from './shared/StructureRepository'
+import { TransactionRepository } from './shared/TransactionRepository'
+import { GetUtilisateurRepository } from './shared/UtilisateurRepository'
+import { Gouvernance, GouvernanceUid } from '@/domain/Gouvernance'
+import { Membre, MembreUid, Statut } from '@/domain/Membre'
+import { MembreCandidat } from '@/domain/MembreCandidat'
+import { Structure, StructureUid } from '@/domain/Structure'
+import { gouvernanceFactory, utilisateurFactory } from '@/domain/testHelper'
+import { Utilisateur, UtilisateurUidState } from '@/domain/Utilisateur'
+
+describe('ajouter un membre', () => {
+  beforeEach(() => {
+    spiedMembreCreated = null
+    spiedEntrepriseData = undefined
+    spiedStructureIdLinked = null
+    structureExistante = null
+  })
+
+  it('étant donné une gouvernance et une structure existante, quand un membre est créé avec un SIRET correspondant, alors le membre est lié à la structure existante', async () => {
+    // GIVEN
+    const siret = '12345678901234'
+    structureExistante = { id: 123, identifiantEtablissement: siret }
+
+    const ajouterUnMembre = new AjouterUnMembre(
+      new GestionnaireRepositorySpy(),
+      new GouvernanceRepositorySpy(),
+      new MembreAvecStructureRepositorySpy(),
+      new StructureExistanteRepositorySpy(),
+      new TransactionRepositorySpy()
+    )
+
+    // WHEN
+    const result = await ajouterUnMembre.handle({
+      contact: {
+        email: 'contact@example.com',
+        fonction: 'Directeur',
+        nom: 'Dupont',
+        prenom: 'Jean',
+      },
+      entreprise: {
+        adresse: '123 rue de la Paix',
+        categorieJuridiqueCode: '5710',
+        categorieJuridiqueUniteLegale: 'SAS',
+        codePostal: '75001',
+        commune: 'Paris',
+        nom: 'Entreprise Test',
+        siret,
+      },
+      uidGestionnaire,
+      uidGouvernance,
+    })
+
+    // THEN
+    expect(result).toBe('OK')
+    expect(spiedStructureIdLinked).toBe(123)
+    expect(spiedMembreCreated).not.toBeNull()
+    expect(spiedEntrepriseData?.siret).toBe(siret)
+  })
+
+  it('étant donné une gouvernance et aucune structure existante, quand un membre est créé avec un SIRET, alors une nouvelle structure est créée et le membre y est lié', async () => {
+    // GIVEN
+    const siret = '98765432109876'
+    structureExistante = null
+
+    const ajouterUnMembre = new AjouterUnMembre(
+      new GestionnaireRepositorySpy(),
+      new GouvernanceRepositorySpy(),
+      new MembreAvecNouvelleStructureRepositorySpy(),
+      new StructureNouvelleRepositorySpy(),
+      new TransactionRepositorySpy()
+    )
+
+    // WHEN
+    const result = await ajouterUnMembre.handle({
+      contact: {
+        email: 'contact@example.com',
+        fonction: 'Directeur',
+        nom: 'Martin',
+        prenom: 'Pierre',
+      },
+      entreprise: {
+        adresse: '123 rue de la Paix',
+        categorieJuridiqueCode: '5710',
+        categorieJuridiqueUniteLegale: 'SAS',
+        codePostal: '75001',
+        commune: 'Paris',
+        nom: 'Nouvelle Entreprise',
+        siret,
+      },
+      uidGestionnaire,
+      uidGouvernance,
+    })
+
+    // THEN
+    expect(result).toBe('OK')
+    expect(spiedStructureCreated).toStrictEqual({
+      departementCode: '75',
+      identifiantEtablissement: siret,
+      nom: 'Nouvelle Entreprise',
+    })
+    expect(spiedMembreCreated).not.toBeNull()
+    expect(spiedEntrepriseData?.siret).toBe(siret)
+  })
+
+  it('étant donné une gouvernance, quand un membre est créé par un gestionnaire qui n\'a pas ce droit, alors une erreur est renvoyée', async () => {
+    // GIVEN
+    const ajouterUnMembre = new AjouterUnMembre(
+      new GestionnaireAutreRepositorySpy(),
+      new GouvernanceRepositorySpy(),
+      new MembreRepositorySpy(),
+      new StructureSansResultatRepositorySpy(),
+      new TransactionRepositorySpy()
+    )
+
+    // WHEN
+    const result = await ajouterUnMembre.handle({
+      contact: {
+        email: 'contact@example.com',
+        fonction: 'Directeur',
+        nom: 'Test',
+        prenom: 'Test',
+      },
+      entreprise: {
+        adresse: '123 rue de la Paix',
+        categorieJuridiqueCode: '5710',
+        categorieJuridiqueUniteLegale: 'SAS',
+        codePostal: '75001',
+        commune: 'Paris',
+        nom: 'Test',
+        siret: '',
+      },
+      uidGestionnaire: 'utilisateurUsurpateur',
+      uidGouvernance,
+    })
+
+    // THEN
+    expect(spiedMembreCreated).toBeNull()
+    expect(result).toBe('gestionnaireNePeutPasAjouterDeMembreDansLaGouvernance')
+  })
+})
+
+const uidGouvernance = 'gouvernanceFooId'
+const uidGestionnaire = 'userFooId'
+let spiedMembreCreated: Membre | null
+let spiedEntrepriseData: EntrepriseData | undefined
+let spiedStructureIdLinked: null | number
+let spiedStructureCreated: { departementCode: string; identifiantEtablissement: string; nom: string } | undefined
+let structureExistante: { id: number; identifiantEtablissement: string } | null
+
+class GouvernanceRepositorySpy implements GetGouvernanceRepository {
+  async get(_: GouvernanceUid): Promise<Gouvernance> {
+    return Promise.resolve(
+      gouvernanceFactory({
+        departement: {
+          code: '75',
+          codeRegion: '11',
+          nom: 'Paris',
+        },
+        uid: uidGouvernance,
+      })
+    )
+  }
+}
+
+class GestionnaireRepositorySpy implements GetUtilisateurRepository {
+  async get(_: UtilisateurUidState['value']): Promise<Utilisateur> {
+    return Promise.resolve(utilisateurFactory({ codeOrganisation: '75', role: 'Gestionnaire département' }))
+  }
+}
+
+class GestionnaireAutreRepositorySpy implements GetUtilisateurRepository {
+  async get(_: UtilisateurUidState['value']): Promise<Utilisateur> {
+    return Promise.resolve(utilisateurFactory({ codeOrganisation: '10', role: 'Gestionnaire département' }))
+  }
+}
+
+class TransactionRepositorySpy implements TransactionRepository {
+  async transaction<T>(fn: (tx: Prisma.TransactionClient) => Promise<T>): Promise<T> {
+    // Simule une transaction en exécutant directement la fonction
+    return fn({} as Prisma.TransactionClient)
+  }
+}
+
+class MembreRepositorySpy implements CreateMembreRepository, GetMembreRepository {
+  async create(membre: Membre, entrepriseData: EntrepriseData, _?: ContactData, __?: ContactData,  ___?: 
+  Prisma.TransactionClient): Promise<void> {
+    spiedMembreCreated = membre
+    spiedEntrepriseData = entrepriseData
+    return Promise.resolve()
+  }
+
+  async get(_uid: string, __?: Prisma.TransactionClient): Promise<Membre> {
+    return Promise.resolve(new MembreCandidat(
+      new MembreUid('test-uid'),
+      'Test',
+      new GouvernanceUid(uidGouvernance),
+      new Statut('candidat'),
+      new StructureUid(1)
+    ))
+  }
+}
+
+class MembreAvecStructureRepositorySpy extends MembreRepositorySpy {
+  override async create(membre: Membre, entrepriseData: EntrepriseData,_?: ContactData, __?: ContactData,  ___?:
+  Prisma.TransactionClient): Promise<void> {
+    spiedMembreCreated = membre
+    spiedEntrepriseData = entrepriseData
+
+    // Simuler la recherche d'une structure existante par SIRET et lier le membre
+    if (entrepriseData.siret && structureExistante) {
+      spiedStructureIdLinked = structureExistante.id
+      // Dans la vraie implémentation, on lierait le membre à la structure via structure_id
+    }
+
+    return Promise.resolve()
+  }
+}
+
+class MembreAvecNouvelleStructureRepositorySpy extends MembreRepositorySpy {
+  override async create(membre: Membre,  entrepriseData: EntrepriseData, __?: ContactData, _?: ContactData, ___?: 
+  Prisma.TransactionClient): Promise<void> {
+    spiedMembreCreated = membre
+    spiedEntrepriseData = entrepriseData
+
+    // Simuler la création d'une nouvelle structure si SIRET fourni et aucune structure existante
+    if (entrepriseData.siret && !structureExistante) {
+      spiedStructureCreated = {
+        departementCode: '75',
+        identifiantEtablissement: entrepriseData.siret,
+        nom: 'Nouvelle Entreprise',
+      }
+      spiedStructureIdLinked = 999 // ID de la nouvelle structure créée
+    }
+
+    return Promise.resolve()
+  }
+}
+
+// Classes spy pour StructureRepository
+class StructureExistanteRepositorySpy implements CreateStructureRepository, GetStructureBySiretRepository {
+  async create(_: StructureData, __?: Prisma.TransactionClient): Promise<Structure> {
+    throw new Error('Ne devrait pas cr\u00e9er de structure dans ce cas')
+  }
+
+  async getBySiret(siret: string, __?: Prisma.TransactionClient): Promise<null | Structure> {
+    if (structureExistante && structureExistante.identifiantEtablissement === siret) {
+      return Structure.create({
+        departementCode: '75',
+        identifiantEtablissement: siret,
+        nom: 'Structure existante',
+        uid: { value: structureExistante.id },
+      })
+    }
+    return null
+  }
+}
+
+class StructureNouvelleRepositorySpy implements CreateStructureRepository, GetStructureBySiretRepository {
+  async create(data: StructureData, __?: Prisma.TransactionClient): Promise<Structure> {
+    spiedStructureCreated = {
+      departementCode: data.departementCode,
+      identifiantEtablissement: data.identifiantEtablissement,
+      nom: data.nom,
+    }
+    return Structure.create({
+      departementCode: data.departementCode,
+      identifiantEtablissement: data.identifiantEtablissement,
+      nom: data.nom,
+      uid: { value: 999 },
+    })
+  }
+
+  async getBySiret(_: string, __?: Prisma.TransactionClient): Promise<null | Structure> {
+    return null // Aucune structure existante
+  }
+}
+
+class StructureSansResultatRepositorySpy implements CreateStructureRepository, GetStructureBySiretRepository {
+  async create(_data: StructureData, __?: Prisma.TransactionClient): Promise<Structure> {
+    throw new Error('Ne devrait pas cr\u00e9er de structure dans ce cas')
+  }
+
+  async getBySiret(_: string, __?: Prisma.TransactionClient): Promise<null | Structure> {
+    return null
+  }
+}

--- a/src/use-cases/commands/AjouterUnMembre.ts
+++ b/src/use-cases/commands/AjouterUnMembre.ts
@@ -52,6 +52,8 @@ export class AjouterUnMembre implements CommandHandler<Command> {
         // Créer une nouvelle structure dans la transaction
         const nouvelleStructure = await this.#structureRepository.create({
           adresse: command.entreprise.adresse,
+          categorieJuridique: command.entreprise.categorieJuridiqueCode,
+          categorieJuridiqueLibelle: command.entreprise.categorieJuridiqueUniteLegale,
           codePostal: command.entreprise.codePostal,
           commune: command.entreprise.commune,
           departementCode: gouvernance.state.departement.code,

--- a/src/use-cases/commands/DefinirUnCoPorteur.ts
+++ b/src/use-cases/commands/DefinirUnCoPorteur.ts
@@ -3,6 +3,7 @@ import { GouvernanceUid } from '@/domain/Gouvernance'
 import { MembreFailure, MembreUid, Role, Statut } from '@/domain/Membre'
 import { MembreCandidat } from '@/domain/MembreCandidat'
 import { MembreConfirme } from '@/domain/MembreConfirme'
+import { StructureUid } from '@/domain/Structure'
 import { GouvernanceRepository } from '@/use-cases/commands/AjouterNoteDeContexteAGouvernance'
 import { MembreRepository } from '@/use-cases/commands/shared/MembreRepository'
 import { UtilisateurRepository } from '@/use-cases/commands/shared/UtilisateurRepository'
@@ -42,7 +43,8 @@ export class DefinirUnCoPorteur implements CommandHandler<Command> {
       membre.state.nom,
       nouveauxRoles.map(role => new Role(role)),
       new GouvernanceUid(membre.state.uidGouvernance.value),
-      new Statut(membre.state.statut)
+      new Statut(membre.state.statut),
+      new StructureUid(membre.state.uidStructure.value)
     )
 
     await this.membreRepository.update(membreConfirmer)

--- a/src/use-cases/commands/RetirerUnCoPorteur.ts
+++ b/src/use-cases/commands/RetirerUnCoPorteur.ts
@@ -3,6 +3,7 @@ import { GouvernanceUid } from '@/domain/Gouvernance'
 import { MembreFailure, MembreUid, Role, Statut } from '@/domain/Membre'
 import { MembreCandidat } from '@/domain/MembreCandidat'
 import { MembreConfirme } from '@/domain/MembreConfirme'
+import { StructureUid } from '@/domain/Structure'
 import { GouvernanceRepository } from '@/use-cases/commands/AjouterNoteDeContexteAGouvernance'
 import { MembreRepository } from '@/use-cases/commands/shared/MembreRepository'
 import { UtilisateurRepository } from '@/use-cases/commands/shared/UtilisateurRepository'
@@ -42,7 +43,8 @@ export class RetirerUnCoPorteur implements CommandHandler<Command> {
       membre.state.nom,
       nouveauxRoles.map(role => new Role(role)),
       new GouvernanceUid(membre.state.uidGouvernance.value),
-      new Statut(membre.state.statut)
+      new Statut(membre.state.statut),
+      new StructureUid(membre.state.uidStructure.value)
     )
 
     await this.membreRepository.update(membreConfirmer)

--- a/src/use-cases/commands/shared/MembreRepository.ts
+++ b/src/use-cases/commands/shared/MembreRepository.ts
@@ -1,19 +1,22 @@
+import { Prisma } from '@prisma/client'
+
 import { Membre, MembreState } from '@/domain/Membre'
 
 export interface GetMembreRepository {
-  get(uid: MembreState['uid']['value']): Promise<Membre>
+  get(uid: MembreState['uid']['value'], tx?: Prisma.TransactionClient): Promise<Membre>
 }
 
 export interface UpdateMembreRepository {
-  update(membre: Membre): Promise<void>
+  update(membre: Membre, tx?: Prisma.TransactionClient): Promise<void>
 }
 
 export interface CreateMembreRepository {
   create(
-    membre: Membre, 
-    contactData?: ContactData, 
-    contactTechniqueData?: ContactData, 
-    entrepriseData?: EntrepriseData
+    membre: Membre,
+    entrepriseData: EntrepriseData,
+    contactData?: ContactData,
+    contactTechniqueData?: ContactData,
+    tx?: Prisma.TransactionClient
   ): Promise<void>
 }
 

--- a/src/use-cases/commands/shared/StructureRepository.ts
+++ b/src/use-cases/commands/shared/StructureRepository.ts
@@ -12,6 +12,8 @@ export interface CreateStructureRepository {
 
 export type StructureData = Readonly<{
   adresse: string
+  categorieJuridique?: string
+  categorieJuridiqueLibelle: string
   codePostal: string
   commune: string
   departementCode: string

--- a/src/use-cases/commands/shared/StructureRepository.ts
+++ b/src/use-cases/commands/shared/StructureRepository.ts
@@ -1,0 +1,24 @@
+import { Prisma } from '@prisma/client'
+
+import { Structure } from '@/domain/Structure'
+
+export interface GetStructureBySiretRepository {
+  getBySiret(siret: string, tx?: Prisma.TransactionClient): Promise<null | Structure>
+}
+
+export interface CreateStructureRepository {
+  create(structure: StructureData, tx?: Prisma.TransactionClient): Promise<Structure>
+}
+
+export type StructureData = Readonly<{
+  adresse: string
+  codePostal: string
+  commune: string
+  departementCode: string
+  identifiantEtablissement: string
+  nom: string
+}>
+
+export interface StructureRepository
+  extends CreateStructureRepository,
+  GetStructureBySiretRepository {}


### PR DESCRIPTION
Pour les nouveaux membre candidats créées, on va les lier à des strucutres de MIN. 
Cela permet d'avancer sur les gestionnaires de structure et d'avancer sur la notion de 'membre est une table d'asso gouvernance <=> structure)
Nous nous occupons pour l'instant pas des membres déjà créé. 