### PR TITLE
fix: remplacer France par 01 dans les liens du menu à venir

### DIFF
--- a/src/components/transverse/MenuLateral/registreMenus.ts
+++ b/src/components/transverse/MenuLateral/registreMenus.ts
@@ -44,18 +44,23 @@ const menuMaStructure: MenuItem = {
   url: (contexte) => `/structure/${contexte.idStructure()}`,
 }
 
+function codeTerritoireOuPremierDepartement(contexte: Contexte): string {
+  const code = contexte.codeTerritoire()
+  return code === 'France' ? '01' : code
+}
+
 const sectionAVenir: Section = {
   badge: true,
   menus: [
     {
       icon: 'pen-nib-line',
       label: 'Financements',
-      url: (contexte) => `/gouvernance/${contexte.codeTerritoire()}/financements`,
+      url: (contexte) => `/gouvernance/${codeTerritoireOuPremierDepartement(contexte)}/financements`,
     },
     {
       icon: 'community-line',
       label: 'Bénéficiaires',
-      url: (contexte) => `/gouvernance/${contexte.codeTerritoire()}/beneficiaires`,
+      url: (contexte) => `/gouvernance/${codeTerritoireOuPremierDepartement(contexte)}/beneficiaires`,
     },
   ],
   titre: 'à venir',

--- a/src/components/transverse/SelecteurGouvernance/SelecteurGouvernance.tsx
+++ b/src/components/transverse/SelecteurGouvernance/SelecteurGouvernance.tsx
@@ -3,7 +3,7 @@
 import { useRouter } from 'next/navigation'
 import { ReactElement } from 'react'
 
-import { OptionGouvernance } from '@/presenters/tableauDeBord/selecteurGouvernancePresenter'
+import type { OptionGouvernance } from '@/presenters/tableauDeBord/selecteurGouvernancePresenter'
 
 export default function SelecteurGouvernance({ options, selectedValue }: Props): ReactElement {
   const router = useRouter()


### PR DESCRIPTION
  Ajout de codeTerritoireOuPremierDepartement() dans registreMenus.ts
  pour éviter les URLs /gouvernance/France/... pour les utilisateurs
  nationaux dans la section "à venir".

  Correction de l import type dans SelecteurGouvernance.tsx.

# Contrat du dev

## Qualité

- [x] Relire le code
- [x] Relire le ticket
- [x] [Relire les critères d'acceptation](https://github.com/anct-cnum/suite-gestionnaire-numerique/discussions/252)


> **Et n'oublie pas de vérifier ce que tu as fait en production !**
