### PR TITLE
feat(gestionnaire-structure): accès et filtrage des listes pour les g…

### DIFF
--- a/src/app/api/export/postes-conseiller-numerique-csv/route.ts
+++ b/src/app/api/export/postes-conseiller-numerique-csv/route.ts
@@ -42,7 +42,12 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
     const estAdmin = scopeFiltre.type === 'national'
 
-    if (!estAdmin && filtres.codeDepartement !== undefined && !scopeFiltre.codes.includes(filtres.codeDepartement)) {
+    if (
+      !estAdmin &&
+      scopeFiltre.type === 'departemental' &&
+      filtres.codeDepartement !== undefined &&
+      !scopeFiltre.codes.includes(filtres.codeDepartement)
+    ) {
       return NextResponse.json(
         { error: 'Accès refusé : vous ne pouvez exporter que les données de votre département' },
         { status: 403 }

--- a/src/components/transverse/MenuLateral/registreMenus.ts
+++ b/src/components/transverse/MenuLateral/registreMenus.ts
@@ -135,7 +135,7 @@ function sectionPilotageParContexte(contexte: Contexte): Section {
   const nb = contexte.nbGouvernances()
   const estAdmin = contexte.aCesRoles('administrateur_dispositif')
 
-  if (estAdmin || nb === 0) {
+  if (estAdmin) {
     menus.push({
       icon: 'group-line',
       label: 'Aidants et médiateurs',

--- a/src/gateways/PrismaListeAidantsMediateursLoader.ts
+++ b/src/gateways/PrismaListeAidantsMediateursLoader.ts
@@ -135,9 +135,10 @@ export class PrismaListeAidantsMediateursLoader implements ListeAidantsMediateur
     geographique: FiltresListeAidants['geographique'],
     whereConditions: Prisma.Sql,
     departementFilter: Prisma.Sql,
-    limitOffset: Prisma.Sql
+    limitOffset: Prisma.Sql,
+    structureFilter: Prisma.Sql
   ): Promise<Array<PersonneAvecAccompagnementQueryResult>> {
-    if (!geographique && departementFilter === Prisma.empty) {
+    if (!geographique && departementFilter === Prisma.empty && structureFilter === Prisma.empty) {
       return prisma.$queryRaw<Array<PersonneAvecAccompagnementQueryResult>>`
         SELECT
           pe.id,
@@ -191,6 +192,7 @@ export class PrismaListeAidantsMediateursLoader implements ListeAidantsMediateur
                LEFT JOIN main.adresse a ON a.id = s.adresse_id
         WHERE (pe.est_actuellement_mediateur_en_poste = true OR pe.est_actuellement_aidant_numerique_en_poste = true)
           ${departementFilter}
+          ${structureFilter}
           ${whereConditions}
         GROUP BY pe.id, pe.nom, pe.prenom, pe.est_actuellement_mediateur_en_poste, pe.is_coordinateur, pe.labellisation_aidant_connect, pe.est_actuellement_conseiller_numerique, pe.nb_accompagnements_ac
         ORDER BY pe.nom, pe.prenom
@@ -315,13 +317,32 @@ export class PrismaListeAidantsMediateursLoader implements ListeAidantsMediateur
       const whereConditions = this.buildWhereConditions(roles, habilitations, formations)
       const departementFilter =
         departementsFilter.length > 0 ? Prisma.sql`AND a.departement = ANY(${departementsFilter})` : Prisma.empty
+      const structureFilter =
+        !geographique && scopeFiltre.type === 'structure'
+          ? Prisma.sql`AND (
+              pe.structure_employeuse_id = ${scopeFiltre.id}
+              OR EXISTS (SELECT 1 FROM main.personne_affectations aff WHERE aff.personne_id = pe.id AND aff.est_active = true AND aff.structure_id = ${scopeFiltre.id})
+            )`
+          : Prisma.empty
 
       const limitOffset =
         limite !== undefined && offset !== undefined ? Prisma.sql`LIMIT ${limite} OFFSET ${offset}` : Prisma.empty
 
       const personnes = includeAccompagnements
-        ? await this.avecAccompagnementQuery(geographique, whereConditions, departementFilter, limitOffset)
-        : await this.sansAccompagnementQuery(geographique, whereConditions, departementFilter, limitOffset)
+        ? await this.avecAccompagnementQuery(
+            geographique,
+            whereConditions,
+            departementFilter,
+            limitOffset,
+            structureFilter
+          )
+        : await this.sansAccompagnementQuery(
+            geographique,
+            whereConditions,
+            departementFilter,
+            limitOffset,
+            structureFilter
+          )
 
       return this.mapPersonnesToAidants(personnes, includeAccompagnements)
     } catch (error) {
@@ -373,10 +394,17 @@ export class PrismaListeAidantsMediateursLoader implements ListeAidantsMediateur
     const whereConditions = this.buildWhereConditions(roles, habilitations, formations)
     const departementFilterPersonnes =
       departementsFilter.length > 0 ? Prisma.sql`AND a.departement = ANY(${departementsFilter})` : Prisma.empty
+    const structureFilterPersonnes =
+      !geographique && scopeFiltre.type === 'structure'
+        ? Prisma.sql`AND (
+            pe.structure_employeuse_id = ${scopeFiltre.id}
+            OR EXISTS (SELECT 1 FROM main.personne_affectations aff WHERE aff.personne_id = pe.id AND aff.est_active = true AND aff.structure_id = ${scopeFiltre.id})
+          )`
+        : Prisma.empty
 
     // Statistiques des personnes en poste
     const conseillersResult =
-      !geographique && departementsFilter.length === 0
+      !geographique && departementsFilter.length === 0 && structureFilterPersonnes === Prisma.empty
         ? await prisma.$queryRaw<Array<{ aidant_connect: bigint; conseillers_numeriques: bigint; mediateur: bigint }>>`
         SELECT
           COUNT(*) FILTER (WHERE est_actuellement_conseiller_numerique = true) AS conseillers_numeriques,
@@ -398,6 +426,7 @@ export class PrismaListeAidantsMediateursLoader implements ListeAidantsMediateur
         LEFT JOIN main.adresse a ON a.id = s.adresse_id
         WHERE (pe.est_actuellement_mediateur_en_poste = true OR pe.est_actuellement_aidant_numerique_en_poste = true)
         ${departementFilterPersonnes}
+        ${structureFilterPersonnes}
         ${whereConditions}
           `
     const totalConseillersNumeriques = Number(conseillersResult[0]?.conseillers_numeriques || 0)
@@ -478,9 +507,10 @@ export class PrismaListeAidantsMediateursLoader implements ListeAidantsMediateur
     geographique: FiltresListeAidants['geographique'],
     whereConditions: Prisma.Sql,
     departementFilter: Prisma.Sql,
-    limitOffset: Prisma.Sql
+    limitOffset: Prisma.Sql,
+    structureFilter: Prisma.Sql
   ): Promise<Array<PersonneQueryResult>> {
-    if (!geographique && departementFilter === Prisma.empty) {
+    if (!geographique && departementFilter === Prisma.empty && structureFilter === Prisma.empty) {
       return prisma.$queryRaw<Array<PersonneQueryResult>>`
         SELECT
           pe.id,
@@ -520,6 +550,7 @@ export class PrismaListeAidantsMediateursLoader implements ListeAidantsMediateur
                LEFT JOIN main.adresse a ON a.id = s.adresse_id
         WHERE (pe.est_actuellement_mediateur_en_poste = true OR pe.est_actuellement_aidant_numerique_en_poste = true)
           ${departementFilter}
+          ${structureFilter}
           ${whereConditions}
         GROUP BY pe.id, pe.nom, pe.prenom, pe.est_actuellement_mediateur_en_poste, pe.is_coordinateur, pe.labellisation_aidant_connect, pe.est_actuellement_conseiller_numerique
         ORDER BY pe.nom, pe.prenom

--- a/src/gateways/PrismaListeLieuxInclusionLoader.ts
+++ b/src/gateways/PrismaListeLieuxInclusionLoader.ts
@@ -27,9 +27,28 @@ export class PrismaListeLieuxInclusionLoader implements RecupererLieuxInclusionP
 
     const codesDepartements =
       scopeFiltre?.type === 'departemental' && scopeFiltre.codes.length > 0 ? scopeFiltre.codes : undefined
+    const structureId = scopeFiltre?.type === 'structure' ? scopeFiltre.id : undefined
+
+    const baseConditions: Array<Prisma.Sql> = [Prisma.sql`s.structure_cartographie_nationale_id IS NOT NULL`]
+    if (structureId !== undefined) {
+      baseConditions.push(Prisma.sql`(
+        s.id = ${structureId}
+        OR EXISTS (
+          SELECT 1 FROM main.personne_affectations pa_lieu
+          WHERE pa_lieu.structure_id = s.id AND pa_lieu.est_active = true
+          AND pa_lieu.personne_id IN (
+            SELECT pa.personne_id FROM main.personne_affectations pa
+            WHERE pa.structure_id = ${structureId} AND pa.est_active = true
+            UNION
+            SELECT pe.id FROM min.personne_enrichie pe
+            WHERE pe.structure_employeuse_id = ${structureId}
+          )
+        )
+      )`)
+    }
 
     const whereClause = buildWhereClause(
-      [Prisma.sql`s.structure_cartographie_nationale_id IS NOT NULL`],
+      baseConditions,
       { codeDepartement, codeRegion, codesDepartements, typeStructure },
       { frr, horsZonePrioritaire, qpv }
     )
@@ -103,7 +122,22 @@ export class PrismaListeLieuxInclusionLoader implements RecupererLieuxInclusionP
     // Pour la requête dispositif, on utilise le nom de la catégorie juridique
     const dispositifConditions = [Prisma.sql`dispositif_programmes_nationaux IS NOT NULL`]
 
-    if (codeDepartement) {
+    if (structureId !== undefined) {
+      dispositifConditions.push(Prisma.sql`(
+        s.id = ${structureId}
+        OR EXISTS (
+          SELECT 1 FROM main.personne_affectations pa_lieu
+          WHERE pa_lieu.structure_id = s.id AND pa_lieu.est_active = true
+          AND pa_lieu.personne_id IN (
+            SELECT pa.personne_id FROM main.personne_affectations pa
+            WHERE pa.structure_id = ${structureId} AND pa.est_active = true
+            UNION
+            SELECT pe.id FROM min.personne_enrichie pe
+            WHERE pe.structure_employeuse_id = ${structureId}
+          )
+        )
+      )`)
+    } else if (codeDepartement) {
       dispositifConditions.push(Prisma.sql`a.departement = ${codeDepartement}`)
     }
 

--- a/src/gateways/tableauDeBord/PrismaDonneesStructureLoader.ts
+++ b/src/gateways/tableauDeBord/PrismaDonneesStructureLoader.ts
@@ -4,21 +4,42 @@ import { DonneesStructureLoader, DonneesStructureReadModel } from '@/use-cases/q
 import { ErrorReadModel } from '@/use-cases/queries/shared/ErrorReadModel'
 
 export class PrismaDonneesStructureLoader implements DonneesStructureLoader {
-  readonly #structureDao = prisma.main_structure
-
   async get(structureId: number, maintenant: Date): Promise<DonneesStructureReadModel | ErrorReadModel> {
     try {
-      const structure = await this.#structureDao.findUnique({
-        select: {
-          structure_cartographie_nationale_id: true,
-        },
-        where: { id: structureId },
-      })
+      const nombreLieuxResult = await prisma.$queryRaw<Array<{ total: bigint }>>`
+        SELECT COUNT(*)::bigint AS total
+        FROM main.structure s
+        WHERE s.structure_cartographie_nationale_id IS NOT NULL
+          AND (
+            s.id = ${structureId}
+            OR EXISTS (
+              SELECT 1 FROM main.personne_affectations pa_lieu
+              WHERE pa_lieu.structure_id = s.id AND pa_lieu.est_active = true
+              AND pa_lieu.personne_id IN (
+                SELECT pa.personne_id FROM main.personne_affectations pa
+                WHERE pa.structure_id = ${structureId} AND pa.est_active = true
+                UNION
+                SELECT pe.id FROM min.personne_enrichie pe
+                WHERE pe.structure_employeuse_id = ${structureId}
+              )
+            )
+          )
+      `
+      const nombreLieux = Number(nombreLieuxResult[0]?.total ?? 0)
 
-      const nombreLieux = structure?.structure_cartographie_nationale_id === null ? 0 : 1
-      const nombreMediateurs = await prisma.personne_affectations.count({
-        where: { est_active: true, structure_id: structureId },
-      })
+      const nombreMediateursResult = await prisma.$queryRaw<Array<{ total: bigint }>>`
+        SELECT COUNT(DISTINCT pe.id)::bigint AS total
+        FROM min.personne_enrichie pe
+        WHERE (pe.est_actuellement_mediateur_en_poste = true OR pe.est_actuellement_aidant_numerique_en_poste = true)
+          AND (
+            pe.structure_employeuse_id = ${structureId}
+            OR EXISTS (
+              SELECT 1 FROM main.personne_affectations aff
+              WHERE aff.personne_id = pe.id AND aff.est_active = true AND aff.structure_id = ${structureId}
+            )
+          )
+      `
+      const nombreMediateurs = Number(nombreMediateursResult[0]?.total ?? 0)
 
       const accompagnementsParMois = await prisma.$queryRaw<
         Array<{

--- a/src/use-cases/queries/ResoudreContexte.test.ts
+++ b/src/use-cases/queries/ResoudreContexte.test.ts
@@ -299,7 +299,7 @@ describe('résoudre contexte - scopes', () => {
     expect(contexte.scopeFiltre()).toStrictEqual({ codes: ['64', '75'], type: 'departemental' })
   })
 
-  it('scopeFiltre — gestionnaire structure sans gouvernance retourne un tableau vide', async () => {
+  it('scopeFiltre — gestionnaire structure sans gouvernance retourne son id de structure', async () => {
     // GIVEN
     const utilisateur = utilisateurAvecRole('gestionnaire_structure', { structureId: 42 })
 
@@ -307,7 +307,7 @@ describe('résoudre contexte - scopes', () => {
     const contexte = await resoudreContexte(utilisateur, loaderStub())
 
     // THEN
-    expect(contexte.scopeFiltre()).toStrictEqual({ codes: [], type: 'departemental' })
+    expect(contexte.scopeFiltre()).toStrictEqual({ id: 42, type: 'structure' })
   })
 
   it('le contexte contient le rôle de l utilisateur', async () => {

--- a/src/use-cases/queries/ResoudreContexte.ts
+++ b/src/use-cases/queries/ResoudreContexte.ts
@@ -14,6 +14,7 @@ export interface ScopeLoader {
 
 export type ScopeFiltre =
   | Readonly<{ codes: ReadonlyArray<string>; type: 'departemental' }>
+  | Readonly<{ id: number; type: 'structure' }>
   | Readonly<{ type: 'national' }>
 
 export class Contexte {
@@ -124,6 +125,9 @@ export class Contexte {
   scopeFiltre(): ScopeFiltre {
     if (this.estNational()) {
       return { type: 'national' }
+    }
+    if (this.estGestionnaireStructureSansGouvernance()) {
+      return { id: this.idStructure(), type: 'structure' }
     }
     return { codes: this.codesDepartements(), type: 'departemental' }
   }


### PR DESCRIPTION
…estionnaires sans gouvernance

  - Redirige les gestionnaires de structure sans gouvernance vers /liste-aidants-mediateurs et /liste-lieux-inclusion (menu + suppression de la garde qui bloquait l'accès)
  - Ajoute le type 'structure' dans ScopeFiltre pour distinguer ce cas des scopes départementaux vides
  - Liste aidants/médiateurs : filtre sur les personnes actuellement en poste ET (affectées OU employées par la structure)
  - Liste lieux : filtre sur le lieu propre à la structure OU les lieux où exercent les personnes liées (affectées ou employées)
  - Tableau de bord : aligne les compteurs aidants et lieux sur les mêmes règles que les listes

# Contrat du dev

## Qualité

- [x] Relire le code
- [x] Relire le ticket
- [x] [Relire les critères d'acceptation](https://github.com/anct-cnum/suite-gestionnaire-numerique/discussions/252)

> **Et n'oublie pas de vérifier ce que tu as fait en production !**
