### PR TITLE
feat(menu): ouvrir le menu "Suivi des postes CoNum" aux coporteurs

### DIFF
--- a/src/components/transverse/MenuLateral/registreMenus.ts
+++ b/src/components/transverse/MenuLateral/registreMenus.ts
@@ -146,6 +146,8 @@ function sectionPilotageParContexte(contexte: Contexte): Section {
 
   const nb = contexte.nbGouvernances()
   const estAdmin = contexte.aCesRoles('administrateur_dispositif')
+  const nestPasGestionnaireStructure = !contexte.aCesRoles('gestionnaire_structure')
+  const estCoporteur = contexte.estCoporteur()
 
   if (estAdmin) {
     menus.push({
@@ -182,7 +184,7 @@ function sectionPilotageParContexte(contexte: Contexte): Section {
     })
   }
 
-  if (estAdmin) {
+  if (nestPasGestionnaireStructure || estCoporteur) {
     menus.push({
       customIcon: `${process.env.NEXT_PUBLIC_HOST}/conum-full.svg`,
       label: 'Suivi des postes CoNum',

--- a/src/use-cases/queries/ResoudreContexte.test.ts
+++ b/src/use-cases/queries/ResoudreContexte.test.ts
@@ -310,6 +310,41 @@ describe('résoudre contexte - scopes', () => {
     expect(contexte.scopeFiltre()).toStrictEqual({ id: 42, type: 'structure' })
   })
 
+  it('estCoporteur — gestionnaire structure coporteur retourne true', async () => {
+    // GIVEN
+    const utilisateur = utilisateurAvecRole('gestionnaire_structure', { structureId: 42 })
+    const loader = loaderStub({ appartenances: [{ codeDepartement: '75', estCoporteur: true }] })
+
+    // WHEN
+    const contexte = await resoudreContexte(utilisateur, loader)
+
+    // THEN
+    expect(contexte.estCoporteur()).toBe(true)
+  })
+
+  it('estCoporteur — gestionnaire structure membre simple retourne false', async () => {
+    // GIVEN
+    const utilisateur = utilisateurAvecRole('gestionnaire_structure', { structureId: 42 })
+    const loader = loaderStub({ appartenances: [{ codeDepartement: '75', estCoporteur: false }] })
+
+    // WHEN
+    const contexte = await resoudreContexte(utilisateur, loader)
+
+    // THEN
+    expect(contexte.estCoporteur()).toBe(false)
+  })
+
+  it('estCoporteur — gestionnaire structure sans gouvernance retourne false', async () => {
+    // GIVEN
+    const utilisateur = utilisateurAvecRole('gestionnaire_structure', { structureId: 42 })
+
+    // WHEN
+    const contexte = await resoudreContexte(utilisateur, loaderStub())
+
+    // THEN
+    expect(contexte.estCoporteur()).toBe(false)
+  })
+
   it('le contexte contient le rôle de l utilisateur', async () => {
     // GIVEN
     const utilisateur = utilisateurAvecRole('gestionnaire_departement', { departementCode: '69' })

--- a/src/use-cases/queries/ResoudreContexte.ts
+++ b/src/use-cases/queries/ResoudreContexte.ts
@@ -61,6 +61,10 @@ export class Contexte {
     return ''
   }
 
+  estCoporteur(): boolean {
+    return this.scopes.some((scope) => scope.type === 'coporteur')
+  }
+
   estDansGouvernance(): boolean {
     return this.scopes.some((scope) => scope.type === 'coporteur' || scope.type === 'membre')
   }


### PR DESCRIPTION
Les gestionnaires de structure coporteurs d'une gouvernance voient désormais le menu, les membres simples restent exclus.
