### PR TITLE
feat(tableau-de-bord): afficher les enveloppes Conseiller Numérique d…

### DIFF
--- a/src/app/(connecte)/(avec-menu)/(default)/tableau-de-bord/blocs/BlocFinancements.tsx
+++ b/src/app/(connecte)/(avec-menu)/(default)/tableau-de-bord/blocs/BlocFinancements.tsx
@@ -4,9 +4,14 @@ import { handleReadModelOrError } from '@/components/shared/ErrorHandler'
 import FinancementsAdmin from '@/components/TableauDeBord/FinancementsAdmin'
 import FinancementsPref from '@/components/TableauDeBord/FinancementsPref'
 import FinancementsStructure from '@/components/TableauDeBord/FinancementsStructure'
+import { PrismaEnveloppesConseillerNumeriqueLoader } from '@/gateways/tableauDeBord/PrismaEnveloppesConseillerNumeriqueLoader'
 import { PrismaFinancementsAdminLoader } from '@/gateways/tableauDeBord/PrismaFinancementsAdminLoader'
 import { PrismaFinancementsLoader } from '@/gateways/tableauDeBord/PrismaFinancementsLoader'
 import { PrismaFinancementsStructureLoader } from '@/gateways/tableauDeBord/PrismaFinancementsStructureLoader'
+import {
+  EnveloppeConseillerNumeriqueViewModel,
+  enveloppesConseillerNumeriquePresenter,
+} from '@/presenters/tableauDeBord/enveloppesConseillerNumeriquePresenter'
 import { financementAdminPresenter } from '@/presenters/tableauDeBord/financementAdminPresenter'
 import { financementsPrefPresenter } from '@/presenters/tableauDeBord/financementPrefPresenter'
 import { financementsStructurePresenter } from '@/presenters/tableauDeBord/financementsStructurePresenter'
@@ -21,26 +26,50 @@ export default async function BlocFinancements({ scope }: Props): Promise<ReactE
     return financementsStructure(parseInt(scope.code, 10))
   }
 
+  if (scope.type === 'departement') {
+    return financementsDepartement(scope.code)
+  }
+
   return financementsDepartement(scope.code)
 }
 
+async function chargerEnveloppesConseillerNumerique(
+  code: string
+): Promise<ReadonlyArray<EnveloppeConseillerNumeriqueViewModel>> {
+  const loader = new PrismaEnveloppesConseillerNumeriqueLoader()
+  const readModel = await loader.get(code)
+  return enveloppesConseillerNumeriquePresenter(readModel.enveloppes, new Date())
+}
+
 async function financementsNationaux(): Promise<ReactElement> {
-  const financementsAdminLoader = new PrismaFinancementsAdminLoader()
-  const financementsReadModel = await financementsAdminLoader.get()
+  const [financementsReadModel, enveloppesConum] = await Promise.all([
+    new PrismaFinancementsAdminLoader().get(),
+    chargerEnveloppesConseillerNumerique('france'),
+  ])
   const financementsViewModel = handleReadModelOrError(financementsReadModel, financementAdminPresenter)
 
   return (
-    <FinancementsAdmin financementViewModel={financementsViewModel} lienFinancements="/gouvernance/01/beneficiaires" />
+    <FinancementsAdmin
+      enveloppesConseillerNumerique={enveloppesConum}
+      financementViewModel={financementsViewModel}
+      lienFinancements="/gouvernance/01/beneficiaires"
+    />
   )
 }
 
 async function financementsDepartement(code: string): Promise<ReactElement> {
-  const financementsLoader = new PrismaFinancementsLoader()
-  const financementsReadModel = await financementsLoader.get(code)
+  const [financementsReadModel, enveloppesConum] = await Promise.all([
+    new PrismaFinancementsLoader().get(code),
+    chargerEnveloppesConseillerNumerique(code),
+  ])
   const financementsViewModel = handleReadModelOrError(financementsReadModel, financementsPrefPresenter)
 
   return (
-    <FinancementsPref conventionnement={financementsViewModel} lienFinancements={`/gouvernance/${code}/financements`} />
+    <FinancementsPref
+      conventionnement={financementsViewModel}
+      enveloppesConseillerNumerique={enveloppesConum}
+      lienFinancements={`/gouvernance/${code}/financements`}
+    />
   )
 }
 

--- a/src/components/TableauDeBord/EnveloppesConseillerNumerique.tsx
+++ b/src/components/TableauDeBord/EnveloppesConseillerNumerique.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { ReactElement } from 'react'
+
+import Dot from '../shared/Dot/Dot'
+import { EnveloppeConseillerNumeriqueViewModel } from '@/presenters/tableauDeBord/enveloppesConseillerNumeriquePresenter'
+
+export default function EnveloppesConseillerNumerique({ enveloppes }: Props): ReactElement {
+  return (
+    <ul>
+      {enveloppes.map((enveloppe) => (
+        <li key={enveloppe.label} style={{ listStyle: 'none' }}>
+          <div style={{ alignItems: 'center', display: 'flex' }}>
+            <div className="fr-text--sm fr-mb-1w" style={{ flex: '1 1 auto', fontWeight: 400, minWidth: 0 }}>
+              <Dot color={enveloppe.color} /> {enveloppe.label}
+            </div>
+            <div
+              className="fr-text--sm fr-mb-1w"
+              style={{
+                fontWeight: 700,
+                marginLeft: '1rem',
+                marginRight: '1rem',
+                minWidth: '3rem',
+                textAlign: 'right',
+              }}
+            >
+              {enveloppe.total}
+            </div>
+            <div style={{ width: '6.25rem' }} title={`${enveloppe.pourcentageConsomme}% de l'enveloppe consommée`}>
+              <div
+                className="fr-text--sm fr-mb-1w"
+                style={{
+                  backgroundColor: 'var(--grey-900-175)',
+                  borderRadius: '4px',
+                  height: '8px',
+                  width: '100%',
+                }}
+              >
+                <div
+                  style={{
+                    backgroundColor: 'var(--blue-france-main-525)',
+                    borderRadius: '4px',
+                    height: '8px',
+                    transition: 'width 0.3s ease',
+                    width: `${Math.min(enveloppe.pourcentageConsomme, 100)}%`,
+                  }}
+                />
+              </div>
+            </div>
+          </div>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+type Props = Readonly<{
+  enveloppes: ReadonlyArray<EnveloppeConseillerNumeriqueViewModel>
+}>

--- a/src/components/TableauDeBord/FinancementsAdmin.tsx
+++ b/src/components/TableauDeBord/FinancementsAdmin.tsx
@@ -2,13 +2,19 @@ import Link from 'next/link'
 import { ReactElement } from 'react'
 
 import BlocCard from './BlocCard'
+import EnveloppesConseillerNumerique from './EnveloppesConseillerNumerique'
 import styles from './TableauDeBord.module.css'
 import VentilationFinancements from './VentilationFinancements'
 import TitleIcon from '../shared/TitleIcon/TitleIcon'
 import { ErrorViewModel } from '@/components/shared/ErrorViewModel'
+import { EnveloppeConseillerNumeriqueViewModel } from '@/presenters/tableauDeBord/enveloppesConseillerNumeriquePresenter'
 import { FinancementAdminViewModel } from '@/presenters/tableauDeBord/financementAdminPresenter'
 
-export default function FinancementsAdmin({ financementViewModel, lienFinancements }: Props): ReactElement {
+export default function FinancementsAdmin({
+  enveloppesConseillerNumerique,
+  financementViewModel,
+  lienFinancements,
+}: Props): ReactElement {
   if (isErrorViewModel(financementViewModel)) {
     return (
       <BlocCard labelledBy="financements">
@@ -87,6 +93,9 @@ export default function FinancementsAdmin({ financementViewModel, lienFinancemen
         nombreDeFinancementsEngagesParLEtat={financementViewModel.nombreDeFinancementsEngagesParLEtat}
         ventilationSubventionsParEnveloppe={financementViewModel.ventilationSubventionsParEnveloppe}
       />
+      {enveloppesConseillerNumerique !== undefined && enveloppesConseillerNumerique.length > 0 && (
+        <EnveloppesConseillerNumerique enveloppes={enveloppesConseillerNumerique} />
+      )}
     </BlocCard>
   )
 }
@@ -96,6 +105,7 @@ function isErrorViewModel(viewModel: ErrorViewModel | FinancementAdminViewModel)
 }
 
 type Props = Readonly<{
+  enveloppesConseillerNumerique?: ReadonlyArray<EnveloppeConseillerNumeriqueViewModel>
   financementViewModel: ErrorViewModel | FinancementAdminViewModel
   lienFinancements: string
 }>

--- a/src/components/TableauDeBord/FinancementsPref.tsx
+++ b/src/components/TableauDeBord/FinancementsPref.tsx
@@ -2,13 +2,19 @@ import Link from 'next/link'
 import { ReactElement } from 'react'
 
 import BlocCard from './BlocCard'
+import EnveloppesConseillerNumerique from './EnveloppesConseillerNumerique'
 import styles from './TableauDeBord.module.css'
 import VentilationFinancements from './VentilationFinancements'
 import TitleIcon from '../shared/TitleIcon/TitleIcon'
 import { ErrorViewModel } from '@/components/shared/ErrorViewModel'
+import { EnveloppeConseillerNumeriqueViewModel } from '@/presenters/tableauDeBord/enveloppesConseillerNumeriquePresenter'
 import { FinancementViewModel } from '@/presenters/tableauDeBord/financementPrefPresenter'
 
-export default function FinancementsPref({ conventionnement, lienFinancements }: Props): ReactElement {
+export default function FinancementsPref({
+  conventionnement,
+  enveloppesConseillerNumerique,
+  lienFinancements,
+}: Props): ReactElement {
   if (isErrorViewModel(conventionnement)) {
     return (
       <BlocCard labelledBy="conventionnements">
@@ -90,6 +96,9 @@ export default function FinancementsPref({ conventionnement, lienFinancements }:
         nombreDeFinancementsEngagesParLEtat={conventionnement.nombreDeFinancementsEngagesParLEtat}
         ventilationSubventionsParEnveloppe={conventionnement.ventilationSubventionsParEnveloppe}
       />
+      {enveloppesConseillerNumerique !== undefined && enveloppesConseillerNumerique.length > 0 && (
+        <EnveloppesConseillerNumerique enveloppes={enveloppesConseillerNumerique} />
+      )}
     </BlocCard>
   )
 }
@@ -100,5 +109,6 @@ function isErrorViewModel(viewModel: ErrorViewModel | FinancementViewModel): vie
 
 type Props = Readonly<{
   conventionnement: ErrorViewModel | FinancementViewModel
+  enveloppesConseillerNumerique?: ReadonlyArray<EnveloppeConseillerNumeriqueViewModel>
   lienFinancements: string
 }>

--- a/src/gateways/tableauDeBord/PrismaBeneficiairesLoader.ts
+++ b/src/gateways/tableauDeBord/PrismaBeneficiairesLoader.ts
@@ -9,33 +9,35 @@ export class PrismaBeneficiairesLoader implements BeneficiairesLoader {
 
   async get(territoire: string): Promise<ErrorReadModel | TableauDeBordLoaderBeneficiaires> {
     try {
-      // Récupérer toutes les demandes de subvention acceptées avec leurs bénéficiaires et enveloppes
-      const demandesAcceptees = await this.#demandeDeSubventionDao.findMany({
-        include: {
-          action: {
-            include: {
-              feuilleDeRoute: true,
+      const [demandesAcceptees, beneficiairesCn] = await Promise.all([
+        this.#demandeDeSubventionDao.findMany({
+          include: {
+            action: {
+              include: {
+                feuilleDeRoute: true,
+              },
             },
+            beneficiaire: true,
+            enveloppe: true,
           },
-          beneficiaire: true,
-          enveloppe: true,
-        },
-        where: {
-          action: {
-            feuilleDeRoute:
-              territoire === 'France'
-                ? {
-                    gouvernanceDepartementCode: {
-                      not: 'zzz',
+          where: {
+            action: {
+              feuilleDeRoute:
+                territoire === 'France'
+                  ? {
+                      gouvernanceDepartementCode: {
+                        not: 'zzz',
+                      },
+                    }
+                  : {
+                      gouvernanceDepartementCode: territoire,
                     },
-                  }
-                : {
-                    gouvernanceDepartementCode: territoire,
-                  },
+            },
+            statut: StatutSubvention.ACCEPTEE,
           },
-          statut: StatutSubvention.ACCEPTEE,
-        },
-      })
+        }),
+        this.#queryBeneficiairesCn(territoire),
+      ])
 
       // Regrouper les bénéficiaires par enveloppe
       const beneficiairesParEnveloppe = new Map<string, Set<string>>()
@@ -54,13 +56,11 @@ export class PrismaBeneficiairesLoader implements BeneficiairesLoader {
         })
       })
 
-      // Créer le tableau des détails par enveloppe
       const details = Array.from(beneficiairesParEnveloppe.entries()).map(([label, beneficiaires]) => ({
         label,
         total: beneficiaires.size,
       }))
 
-      // Calculer le total unique de bénéficiaires (tous les bénéficiaires uniques)
       const tousLesBeneficiaires = new Set<string>()
       beneficiairesParEnveloppe.forEach((beneficiaires) => {
         beneficiaires.forEach((id) => {
@@ -68,10 +68,17 @@ export class PrismaBeneficiairesLoader implements BeneficiairesLoader {
         })
       })
 
+      const detailsCn = beneficiairesCn.map((row) => ({
+        label: row.label,
+        total: Number(row.total),
+      }))
+
+      const totalCn = detailsCn.reduce((acc, row) => acc + row.total, 0)
+
       return {
-        collectivite: 0, // Pour l'instant on ne peut pas catégoriser
-        details,
-        total: tousLesBeneficiaires.size,
+        collectivite: 0,
+        details: [...details, ...detailsCn],
+        total: tousLesBeneficiaires.size + totalCn,
       }
     } catch (error) {
       reportLoaderError(error, 'PrismaBeneficiairesLoader', {
@@ -84,4 +91,50 @@ export class PrismaBeneficiairesLoader implements BeneficiairesLoader {
       }
     }
   }
+
+  async #queryBeneficiairesCn(territoire: string): Promise<ReadonlyArray<BeneficiairesCnQueryResult>> {
+    if (territoire === 'France') {
+      return prisma.$queryRaw<Array<BeneficiairesCnQueryResult>>`
+        WITH agg AS (
+          SELECT
+            COUNT(DISTINCT CASE WHEN s.montant_subvention_v1 > 0 THEN p.structure_id END) AS total_v1,
+            COUNT(DISTINCT CASE WHEN s.montant_subvention_v2 > 0 THEN p.structure_id END) AS total_v2
+          FROM main.subvention s
+          JOIN main.poste p ON p.id = s.poste_id
+        )
+        SELECT
+          e.libelle AS label,
+          CASE WHEN e.libelle LIKE '%Renouvellement%' THEN agg.total_v2 WHEN e.libelle LIKE '%Plan France Relance%' THEN agg.total_v1 ELSE 0 END AS total
+        FROM min.enveloppe_financement e
+        CROSS JOIN agg
+        WHERE e.libelle LIKE 'Conseiller Numérique%'
+        ORDER BY e.libelle
+      `
+    }
+
+    return prisma.$queryRaw<Array<BeneficiairesCnQueryResult>>`
+      WITH agg AS (
+        SELECT
+          COUNT(DISTINCT CASE WHEN s.montant_subvention_v1 > 0 THEN p.structure_id END) AS total_v1,
+          COUNT(DISTINCT CASE WHEN s.montant_subvention_v2 > 0 THEN p.structure_id END) AS total_v2
+        FROM main.subvention s
+        JOIN main.poste p ON p.id = s.poste_id
+        JOIN main.structure st ON st.id = p.structure_id
+        JOIN main.adresse a ON a.id = st.adresse_id
+        WHERE a.departement = ${territoire}
+      )
+      SELECT
+        e.libelle AS label,
+        CASE WHEN e.libelle LIKE '%Renouvellement%' THEN agg.total_v2 WHEN e.libelle LIKE '%Plan France Relance%' THEN agg.total_v1 ELSE 0 END AS total
+      FROM min.enveloppe_financement e
+      CROSS JOIN agg
+      WHERE e.libelle LIKE 'Conseiller Numérique%'
+      ORDER BY e.libelle
+    `
+  }
+}
+
+type BeneficiairesCnQueryResult = {
+  label: string
+  total: bigint
 }

--- a/src/gateways/tableauDeBord/PrismaEnveloppesConseillerNumeriqueLoader.ts
+++ b/src/gateways/tableauDeBord/PrismaEnveloppesConseillerNumeriqueLoader.ts
@@ -1,0 +1,98 @@
+import prisma from '../../../prisma/prismaClient'
+import { reportLoaderError } from '../shared/sentryErrorReporter'
+import {
+  EnveloppeConseillerNumeriqueReadModel,
+  EnveloppesConseillerNumeriqueLoader,
+  EnveloppesConseillerNumeriqueReadModel,
+} from '@/use-cases/queries/RecupererLesEnveloppesConseillerNumerique'
+
+export class PrismaEnveloppesConseillerNumeriqueLoader implements EnveloppesConseillerNumeriqueLoader {
+  async get(codeDepartement: string): Promise<EnveloppesConseillerNumeriqueReadModel> {
+    try {
+      const rows =
+        codeDepartement === 'france' ? await this.#queryFrance() : await this.#queryDepartement(codeDepartement)
+
+      return {
+        enveloppes: rows.map(
+          (row): EnveloppeConseillerNumeriqueReadModel => ({
+            consommation: row.consommation,
+            dateDeDebut: row.dateDeDebut,
+            dateDeFin: row.dateDeFin,
+            libelle: row.libelle,
+            plafond: row.plafond,
+          })
+        ),
+      }
+    } catch (error) {
+      reportLoaderError(error, 'PrismaEnveloppesConseillerNumeriqueLoader', {
+        codeDepartement,
+        operation: 'get',
+      })
+      return { enveloppes: [] }
+    }
+  }
+
+  async #queryDepartement(code: string): Promise<ReadonlyArray<QueryResult>> {
+    return prisma.$queryRaw<Array<QueryResult>>`
+      WITH agg AS (
+        SELECT
+          COALESCE(SUM(s.montant_subvention_v1), 0)::bigint AS total_v1,
+          COALESCE(SUM(s.montant_subvention_v2), 0)::bigint AS total_v2
+        FROM main.subvention s
+        JOIN main.poste p ON p.id = s.poste_id
+        JOIN main.structure st ON st.id = p.structure_id
+        JOIN main.adresse a ON a.id = st.adresse_id
+        WHERE a.departement = ${code}
+      )
+      SELECT
+        e.libelle,
+        e.date_debut AS "dateDeDebut",
+        e.date_fin AS "dateDeFin",
+        COALESCE(de.plafond, 0) AS plafond,
+        CASE
+          WHEN e.libelle LIKE '%Renouvellement%' THEN agg.total_v2
+          WHEN e.libelle LIKE '%Plan France Relance%' THEN agg.total_v1
+          ELSE 0
+        END AS consommation
+      FROM min.enveloppe_financement e
+      CROSS JOIN agg
+      LEFT JOIN min.departement_enveloppe de
+        ON de.enveloppe_id = e.id AND de.departement_code = ${code}
+      WHERE e.libelle LIKE 'Conseiller Numérique%'
+      ORDER BY e.libelle
+    `
+  }
+
+  async #queryFrance(): Promise<ReadonlyArray<QueryResult>> {
+    return prisma.$queryRaw<Array<QueryResult>>`
+      WITH agg AS (
+        SELECT
+          COALESCE(SUM(s.montant_subvention_v1), 0)::bigint AS total_v1,
+          COALESCE(SUM(s.montant_subvention_v2), 0)::bigint AS total_v2
+        FROM main.subvention s
+      )
+      SELECT
+        e.libelle,
+        e.date_debut AS "dateDeDebut",
+        e.date_fin AS "dateDeFin",
+        e.montant AS plafond,
+        CASE
+          WHEN e.libelle LIKE '%Renouvellement%' THEN agg.total_v2
+          WHEN e.libelle LIKE '%Plan France Relance%' THEN agg.total_v1
+          ELSE 0
+        END AS consommation
+      FROM min.enveloppe_financement e
+      CROSS JOIN agg
+      WHERE e.libelle LIKE 'Conseiller Numérique%'
+      ORDER BY e.libelle
+    `
+  }
+}
+
+type QueryResult = {
+  consommation: bigint
+  dateDeDebut: Date
+  dateDeFin: Date
+  libelle: string
+  plafond: number
+}

--- a/src/gateways/tableauDeBord/PrismaFinancementsAdminLoader.ts
+++ b/src/gateways/tableauDeBord/PrismaFinancementsAdminLoader.ts
@@ -10,33 +10,36 @@ export class PrismaFinancementsAdminLoader implements FinancementAdminLoader {
 
   async get(): Promise<ErrorReadModel | TableauDeBordLoaderFinancementsAdmin> {
     try {
-      // Récupérer les enveloppes hors Conseiller Numérique (gérées séparément)
-      const enveloppes = await this.#enveloppeDao.findMany({
-        where: { libelle: { not: { startsWith: 'Conseiller Numérique' } } },
-      })
+      const [enveloppes, demandesAcceptees, cnConsomme] = await Promise.all([
+        this.#enveloppeDao.findMany(),
+        // Récupérer toutes les demandes de subvention acceptées (en excluant zzz)
+        this.#demandeDeSubventionDao.findMany({
+          include: {
+            enveloppe: true,
+          },
+          where: {
+            action: {
+              feuilleDeRoute: {
+                gouvernanceDepartementCode: {
+                  not: 'zzz',
+                },
+              },
+            },
+            statut: StatutSubvention.ACCEPTEE,
+          },
+        }),
+        prisma.$queryRaw<[{ total: bigint }]>`
+          SELECT (COALESCE(SUM(montant_subvention_v1), 0) + COALESCE(SUM(montant_subvention_v2), 0))::bigint AS total
+          FROM main.subvention
+        `,
+      ])
+
       const montantTotalEnveloppes = enveloppes.reduce((acc, env) => acc + env.montant, 0)
       const nombreEnveloppes = enveloppes.length
 
-      // Récupérer toutes les demandes de subvention acceptées (en excluant zzz)
-      const demandesAcceptees = await this.#demandeDeSubventionDao.findMany({
-        include: {
-          enveloppe: true,
-        },
-        where: {
-          action: {
-            feuilleDeRoute: {
-              gouvernanceDepartementCode: {
-                not: 'zzz',
-              },
-            },
-          },
-          statut: StatutSubvention.ACCEPTEE,
-        },
-      })
-
-      // Calculer les crédits engagés et la ventilation par enveloppe
+      // Calculer les crédits engagés et la ventilation par enveloppe (hors CN)
       const subventionsParEnveloppe = new Map<string, { enveloppeTotale: number; total: number }>()
-      let creditsEngagesTotal = 0
+      let creditsEngagesTotal = Number(cnConsomme[0].total)
 
       demandesAcceptees.forEach((demande) => {
         creditsEngagesTotal += demande.subventionDemandee

--- a/src/presenters/shared/enveloppe.ts
+++ b/src/presenters/shared/enveloppe.ts
@@ -6,12 +6,14 @@ export type Enveloppe =
 
 export const couleursEnveloppes = {
   'Conseiller Numérique - initiale - État': 'dot-purple-glycine-850-200',
+  'Conseiller Numérique - Plan France Relance - État': 'dot-blue-france-main-525',
   'Conseiller Numérique - Renouvellement - État': 'dot-purple-glycine-main-494',
   'Formation Aidant Numérique/Aidants Connect - 2024 - État': 'dot-green-tilleul-verveine-925',
   'Ingénierie France Numérique Ensemble - 2024 - État': 'dot-orange-terre-battue-850-200',
 } as const
 
 export const couleursGraphiqueEnveloppes = {
+  'dot-blue-france-main-525': '#000091',
   'dot-green-tilleul-verveine-925': '#FFE800',
   'dot-grey-925-125': '#666666',
   'dot-orange-terre-battue-850-200': '#fcc0b0',

--- a/src/presenters/tableauDeBord/enveloppesConseillerNumeriquePresenter.test.ts
+++ b/src/presenters/tableauDeBord/enveloppesConseillerNumeriquePresenter.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+
+import { enveloppesConseillerNumeriquePresenter } from './enveloppesConseillerNumeriquePresenter'
+import { EnveloppeConseillerNumeriqueReadModel } from '@/use-cases/queries/RecupererLesEnveloppesConseillerNumerique'
+
+describe(enveloppesConseillerNumeriquePresenter, () => {
+  it('formate une enveloppe disponible avec consommation partielle', () => {
+    // GIVEN
+    const enveloppes: ReadonlyArray<EnveloppeConseillerNumeriqueReadModel> = [
+      {
+        consommation: BigInt(500_000),
+        dateDeDebut: new Date('2024-01-01'),
+        dateDeFin: new Date('2026-12-31'),
+        libelle: 'Conseiller Numérique - initiale - État',
+        plafond: 1_000_000,
+      },
+    ]
+    const now = new Date('2025-06-01')
+
+    // WHEN
+    const result = enveloppesConseillerNumeriquePresenter(enveloppes, now)
+
+    // THEN
+    expect(result).toStrictEqual([
+      {
+        color: 'dot-purple-glycine-850-200',
+        disponible: true,
+        label: 'Conseiller Numérique - initiale - État',
+        pourcentageConsomme: 50,
+        total: '0,50 M€',
+      },
+    ])
+  })
+
+  it('marque une enveloppe fermée si la date courante est hors période', () => {
+    // GIVEN
+    const enveloppes: ReadonlyArray<EnveloppeConseillerNumeriqueReadModel> = [
+      {
+        consommation: BigInt(0),
+        dateDeDebut: new Date('2024-01-01'),
+        dateDeFin: new Date('2024-12-31'),
+        libelle: 'Conseiller Numérique - Renouvellement - État',
+        plafond: 2_000_000,
+      },
+    ]
+    const now = new Date('2025-06-01')
+
+    // WHEN
+    const result = enveloppesConseillerNumeriquePresenter(enveloppes, now)
+
+    // THEN
+    expect(result[0].disponible).toBe(false)
+  })
+
+  it('retourne 0% si plafond est nul', () => {
+    // GIVEN
+    const enveloppes: ReadonlyArray<EnveloppeConseillerNumeriqueReadModel> = [
+      {
+        consommation: BigInt(0),
+        dateDeDebut: new Date('2024-01-01'),
+        dateDeFin: new Date('2026-12-31'),
+        libelle: 'Conseiller Numérique - initiale - État',
+        plafond: 0,
+      },
+    ]
+    const now = new Date('2025-06-01')
+
+    // WHEN
+    const result = enveloppesConseillerNumeriquePresenter(enveloppes, now)
+
+    // THEN
+    expect(result[0].pourcentageConsomme).toBe(0)
+  })
+})

--- a/src/presenters/tableauDeBord/enveloppesConseillerNumeriquePresenter.ts
+++ b/src/presenters/tableauDeBord/enveloppesConseillerNumeriquePresenter.ts
@@ -1,0 +1,30 @@
+import { obtenirCouleurEnveloppe } from '../shared/enveloppe'
+import { formatMontantEnMillions } from '../shared/number'
+import { EnveloppeConseillerNumeriqueReadModel } from '@/use-cases/queries/RecupererLesEnveloppesConseillerNumerique'
+
+export function enveloppesConseillerNumeriquePresenter(
+  enveloppes: ReadonlyArray<EnveloppeConseillerNumeriqueReadModel>,
+  now: Date
+): ReadonlyArray<EnveloppeConseillerNumeriqueViewModel> {
+  return enveloppes.map((enveloppe) => {
+    const consommation = Number(enveloppe.consommation)
+    const plafond = enveloppe.plafond
+    const pourcentageConsomme = plafond > 0 ? Math.round((consommation / plafond) * 100) : 0
+
+    return {
+      color: obtenirCouleurEnveloppe(enveloppe.libelle),
+      disponible: now >= enveloppe.dateDeDebut && now <= enveloppe.dateDeFin,
+      label: enveloppe.libelle,
+      pourcentageConsomme,
+      total: formatMontantEnMillions(consommation),
+    }
+  })
+}
+
+export type EnveloppeConseillerNumeriqueViewModel = Readonly<{
+  color: string
+  disponible: boolean
+  label: string
+  pourcentageConsomme: number
+  total: string
+}>

--- a/src/use-cases/queries/RecupererLesEnveloppesConseillerNumerique.ts
+++ b/src/use-cases/queries/RecupererLesEnveloppesConseillerNumerique.ts
@@ -1,0 +1,15 @@
+export interface EnveloppesConseillerNumeriqueLoader {
+  get(codeDepartement: string): Promise<EnveloppesConseillerNumeriqueReadModel>
+}
+
+export type EnveloppesConseillerNumeriqueReadModel = Readonly<{
+  enveloppes: ReadonlyArray<EnveloppeConseillerNumeriqueReadModel>
+}>
+
+export type EnveloppeConseillerNumeriqueReadModel = Readonly<{
+  consommation: bigint
+  dateDeDebut: Date
+  dateDeFin: Date
+  libelle: string
+  plafond: number
+}>


### PR DESCRIPTION
…ans le bloc Financement

  - Nouveau gateway PrismaEnveloppesConseillerNumeriqueLoader (main.subvention v1/v2)
  - Plafonds depuis min.departement_enveloppe (dept) et min.enveloppe_financement (france)
  - Composant EnveloppesConseillerNumerique homogène avec VentilationFinancements
  - Bénéficiaires CN intégrés dans PrismaBeneficiairesLoader
  - Totaux "Montant global" et "Crédits engagés" mis à jour dans PrismaFinancementsAdminLoader
  - Couleur dot-blue-france-main-525 pour "Plan France Relance" (donut inclus)

# Contrat du dev

## Qualité

- [x] Relire le code
- [x] Relire le ticket
- [x] [Relire les critères d'acceptation](https://github.com/anct-cnum/suite-gestionnaire-numerique/discussions/252)


> **Et n'oublie pas de vérifier ce que tu as fait en production !**
