### PR TITLE
fix(tableau-de-bord): corriger l'affichage des enveloppes Conseiller …

### DIFF
--- a/src/app/(connecte)/(avec-menu)/(default)/tableau-de-bord/blocs/BlocFinancements.tsx
+++ b/src/app/(connecte)/(avec-menu)/(default)/tableau-de-bord/blocs/BlocFinancements.tsx
@@ -74,11 +74,21 @@ async function financementsDepartement(code: string): Promise<ReactElement> {
 }
 
 async function financementsStructure(structureId: number): Promise<ReactElement> {
-  const financementsLoader = new PrismaFinancementsStructureLoader()
-  const financementsReadModel = await financementsLoader.get(structureId)
+  const cnLoader = new PrismaEnveloppesConseillerNumeriqueLoader()
+  const [financementsReadModel, enveloppesConumReadModel] = await Promise.all([
+    new PrismaFinancementsStructureLoader().get(structureId),
+    cnLoader.getParStructure(structureId),
+  ])
   const financementsViewModel = handleReadModelOrError(financementsReadModel, financementsStructurePresenter)
+  const enveloppesConum = enveloppesConseillerNumeriquePresenter(enveloppesConumReadModel.enveloppes, new Date())
 
-  return <FinancementsStructure lienFinancements="/gouvernance/financements" viewModel={financementsViewModel} />
+  return (
+    <FinancementsStructure
+      enveloppesConseillerNumerique={enveloppesConum}
+      lienFinancements="/gouvernance/financements"
+      viewModel={financementsViewModel}
+    />
+  )
 }
 
 type Props = Readonly<{

--- a/src/components/TableauDeBord/EnveloppesConseillerNumerique.tsx
+++ b/src/components/TableauDeBord/EnveloppesConseillerNumerique.tsx
@@ -5,7 +5,7 @@ import { ReactElement } from 'react'
 import Dot from '../shared/Dot/Dot'
 import { EnveloppeConseillerNumeriqueViewModel } from '@/presenters/tableauDeBord/enveloppesConseillerNumeriquePresenter'
 
-export default function EnveloppesConseillerNumerique({ enveloppes }: Props): ReactElement {
+export default function EnveloppesConseillerNumerique({ contexte, enveloppes }: Props): ReactElement {
   return (
     <ul>
       {enveloppes.map((enveloppe) => (
@@ -26,27 +26,29 @@ export default function EnveloppesConseillerNumerique({ enveloppes }: Props): Re
             >
               {enveloppe.total}
             </div>
-            <div style={{ width: '6.25rem' }} title={`${enveloppe.pourcentageConsomme}% de l'enveloppe consommée`}>
-              <div
-                className="fr-text--sm fr-mb-1w"
-                style={{
-                  backgroundColor: 'var(--grey-900-175)',
-                  borderRadius: '4px',
-                  height: '8px',
-                  width: '100%',
-                }}
-              >
+            {contexte === 'admin' && (
+              <div style={{ width: '6.25rem' }} title={`${enveloppe.pourcentageConsomme}% de l'enveloppe consommée`}>
                 <div
+                  className="fr-text--sm fr-mb-1w"
                   style={{
-                    backgroundColor: 'var(--blue-france-main-525)',
+                    backgroundColor: 'var(--grey-900-175)',
                     borderRadius: '4px',
                     height: '8px',
-                    transition: 'width 0.3s ease',
-                    width: `${Math.min(enveloppe.pourcentageConsomme, 100)}%`,
+                    width: '100%',
                   }}
-                />
+                >
+                  <div
+                    style={{
+                      backgroundColor: 'var(--blue-france-main-525)',
+                      borderRadius: '4px',
+                      height: '8px',
+                      transition: 'width 0.3s ease',
+                      width: `${Math.min(enveloppe.pourcentageConsomme, 100)}%`,
+                    }}
+                  />
+                </div>
               </div>
-            </div>
+            )}
           </div>
         </li>
       ))}
@@ -55,5 +57,6 @@ export default function EnveloppesConseillerNumerique({ enveloppes }: Props): Re
 }
 
 type Props = Readonly<{
+  contexte: 'admin' | 'departement'
   enveloppes: ReadonlyArray<EnveloppeConseillerNumeriqueViewModel>
 }>

--- a/src/components/TableauDeBord/FinancementsAdmin.tsx
+++ b/src/components/TableauDeBord/FinancementsAdmin.tsx
@@ -94,7 +94,7 @@ export default function FinancementsAdmin({
         ventilationSubventionsParEnveloppe={financementViewModel.ventilationSubventionsParEnveloppe}
       />
       {enveloppesConseillerNumerique !== undefined && enveloppesConseillerNumerique.length > 0 && (
-        <EnveloppesConseillerNumerique enveloppes={enveloppesConseillerNumerique} />
+        <EnveloppesConseillerNumerique contexte="admin" enveloppes={enveloppesConseillerNumerique} />
       )}
     </BlocCard>
   )

--- a/src/components/TableauDeBord/FinancementsPref.tsx
+++ b/src/components/TableauDeBord/FinancementsPref.tsx
@@ -97,7 +97,7 @@ export default function FinancementsPref({
         ventilationSubventionsParEnveloppe={conventionnement.ventilationSubventionsParEnveloppe}
       />
       {enveloppesConseillerNumerique !== undefined && enveloppesConseillerNumerique.length > 0 && (
-        <EnveloppesConseillerNumerique enveloppes={enveloppesConseillerNumerique} />
+        <EnveloppesConseillerNumerique contexte="departement" enveloppes={enveloppesConseillerNumerique} />
       )}
     </BlocCard>
   )

--- a/src/components/TableauDeBord/FinancementsStructure.tsx
+++ b/src/components/TableauDeBord/FinancementsStructure.tsx
@@ -4,16 +4,22 @@ import Link from 'next/link'
 import { ReactElement } from 'react'
 
 import BlocCard from './BlocCard'
+import EnveloppesConseillerNumerique from './EnveloppesConseillerNumerique'
 import styles from './TableauDeBord.module.css'
 import Dot from '../shared/Dot/Dot'
 import Doughnut from '../shared/Doughnut/Doughnut'
 import TitleIcon from '../shared/TitleIcon/TitleIcon'
 import { ErrorViewModel } from '@/components/shared/ErrorViewModel'
+import { EnveloppeConseillerNumeriqueViewModel } from '@/presenters/tableauDeBord/enveloppesConseillerNumeriquePresenter'
 import { FinancementsStructureViewModel } from '@/presenters/tableauDeBord/financementsStructurePresenter'
 
 const COULEUR_VIDE = '#DDDDDD'
 
-export default function FinancementsStructure({ lienFinancements, viewModel }: Props): ReactElement {
+export default function FinancementsStructure({
+  enveloppesConseillerNumerique,
+  lienFinancements,
+  viewModel,
+}: Props): ReactElement {
   if (isErrorViewModel(viewModel)) {
     return (
       <BlocCard labelledBy="financements-structure">
@@ -104,6 +110,9 @@ export default function FinancementsStructure({ lienFinancements, viewModel }: P
               </li>
             ))}
           </ul>
+          {enveloppesConseillerNumerique !== undefined && enveloppesConseillerNumerique.length > 0 && (
+            <EnveloppesConseillerNumerique contexte="departement" enveloppes={enveloppesConseillerNumerique} />
+          )}
         </div>
       </div>
     </BlocCard>
@@ -115,6 +124,7 @@ function isErrorViewModel(viewModel: ErrorViewModel | FinancementsStructureViewM
 }
 
 type Props = Readonly<{
+  enveloppesConseillerNumerique?: ReadonlyArray<EnveloppeConseillerNumeriqueViewModel>
   lienFinancements: string
   viewModel: ErrorViewModel | FinancementsStructureViewModel
 }>

--- a/src/gateways/tableauDeBord/PrismaEnveloppesConseillerNumeriqueLoader.ts
+++ b/src/gateways/tableauDeBord/PrismaEnveloppesConseillerNumeriqueLoader.ts
@@ -32,6 +32,53 @@ export class PrismaEnveloppesConseillerNumeriqueLoader implements EnveloppesCons
     }
   }
 
+  async getParStructure(structureId: number): Promise<EnveloppesConseillerNumeriqueReadModel> {
+    try {
+      const rows = await prisma.$queryRaw<Array<QueryResult>>`
+        WITH agg AS (
+          SELECT
+            COALESCE(SUM(s.montant_subvention_v1), 0)::bigint AS total_v1,
+            COALESCE(SUM(s.montant_subvention_v2), 0)::bigint AS total_v2
+          FROM main.subvention s
+          JOIN main.poste p ON p.id = s.poste_id
+          WHERE p.structure_id = ${structureId}
+        )
+        SELECT
+          e.libelle,
+          e.date_debut AS "dateDeDebut",
+          e.date_fin AS "dateDeFin",
+          0 AS plafond,
+          CASE
+            WHEN e.libelle LIKE '%Renouvellement%' THEN agg.total_v2
+            WHEN e.libelle LIKE '%Plan France Relance%' THEN agg.total_v1
+            ELSE 0
+          END AS consommation
+        FROM min.enveloppe_financement e
+        CROSS JOIN agg
+        WHERE e.libelle LIKE 'Conseiller Numérique%'
+        ORDER BY e.libelle
+      `
+
+      return {
+        enveloppes: rows.map(
+          (row): EnveloppeConseillerNumeriqueReadModel => ({
+            consommation: row.consommation,
+            dateDeDebut: row.dateDeDebut,
+            dateDeFin: row.dateDeFin,
+            libelle: row.libelle,
+            plafond: row.plafond,
+          })
+        ),
+      }
+    } catch (error) {
+      reportLoaderError(error, 'PrismaEnveloppesConseillerNumeriqueLoader', {
+        operation: 'getParStructure',
+        structureId,
+      })
+      return { enveloppes: [] }
+    }
+  }
+
   async #queryDepartement(code: string): Promise<ReadonlyArray<QueryResult>> {
     return prisma.$queryRaw<Array<QueryResult>>`
       WITH agg AS (

--- a/src/presenters/shared/number.test.ts
+++ b/src/presenters/shared/number.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatMontantEnMillions } from './number'
+
+describe(formatMontantEnMillions, () => {
+  it('affiche en M€ pour un montant >= 1 000 000', () => {
+    expect(formatMontantEnMillions(1_500_000)).toBe('1,50 M€')
+  })
+
+  it('affiche en M€ pour un montant exactement égal à 1 000 000', () => {
+    expect(formatMontantEnMillions(1_000_000)).toBe('1,00 M€')
+  })
+
+  it('affiche en K€ pour un montant >= 10 000 et < 1 000 000', () => {
+    expect(formatMontantEnMillions(500_000)).toBe('500,00 K€')
+  })
+
+  it('affiche en K€ pour un montant exactement égal à 10 000', () => {
+    expect(formatMontantEnMillions(10_000)).toBe('10,00 K€')
+  })
+
+  it('affiche en € pour un montant < 10 000', () => {
+    expect(formatMontantEnMillions(9_999)).toBe('9\u202f999 €')
+  })
+
+  it('affiche en € pour 0', () => {
+    expect(formatMontantEnMillions(0)).toBe('0 €')
+  })
+})

--- a/src/presenters/shared/number.ts
+++ b/src/presenters/shared/number.ts
@@ -7,6 +7,13 @@ export function formatMontant(montant: number): string {
 }
 
 export function formatMontantEnMillions(montant: number): string {
-  const millions = montant / 1_000_000
-  return `${millions.toLocaleString('fr-FR', { maximumFractionDigits: 2, minimumFractionDigits: 2 })} M€`
+  if (montant >= 1_000_000) {
+    return `${(montant / 1_000_000).toLocaleString('fr-FR', { maximumFractionDigits: 2, minimumFractionDigits: 2 })} M€`
+  }
+
+  if (montant >= 10_000) {
+    return `${(montant / 1_000).toLocaleString('fr-FR', { maximumFractionDigits: 2, minimumFractionDigits: 2 })} K€`
+  }
+
+  return `${formaterEnNombreFrancais(montant)} €`
 }

--- a/src/presenters/tableauDeBord/enveloppesConseillerNumeriquePresenter.test.ts
+++ b/src/presenters/tableauDeBord/enveloppesConseillerNumeriquePresenter.test.ts
@@ -27,7 +27,7 @@ describe(enveloppesConseillerNumeriquePresenter, () => {
         disponible: true,
         label: 'Conseiller Numérique - initiale - État',
         pourcentageConsomme: 50,
-        total: '0,50 M€',
+        total: '500,00 K€',
       },
     ])
   })

--- a/src/use-cases/queries/RecupererLesEnveloppesConseillerNumerique.ts
+++ b/src/use-cases/queries/RecupererLesEnveloppesConseillerNumerique.ts
@@ -1,5 +1,6 @@
 export interface EnveloppesConseillerNumeriqueLoader {
   get(codeDepartement: string): Promise<EnveloppesConseillerNumeriqueReadModel>
+  getParStructure(structureId: number): Promise<EnveloppesConseillerNumeriqueReadModel>
 }
 
 export type EnveloppesConseillerNumeriqueReadModel = Readonly<{


### PR DESCRIPTION
…Numérique

  - Barre de progression conditionnée au rôle admin uniquement
  - Enveloppes CN affichées pour le scope structure (filtrées par structure_id)
  - Formatage des montants : M€ (>= 1M), K€ (>= 10K), € (< 10K)

# Contrat du dev

## Qualité

- [x] Relire le code
- [x] Relire le ticket
- [x] [Relire les critères d'acceptation](https://github.com/anct-cnum/suite-gestionnaire-numerique/discussions/252)


> **Et n'oublie pas de vérifier ce que tu as fait en production !**
