### PR TITLE
fix(menu-lateral): aligner la largeur du menu et les graisses typogra…

### DIFF
--- a/src/app/(connecte)/(avec-menu)/(default)/layout.tsx
+++ b/src/app/(connecte)/(avec-menu)/(default)/layout.tsx
@@ -20,12 +20,12 @@ export default async function Layout({ children }: Readonly<PropsWithChildren>):
 
   return (
     <div className="fr-grid-row">
-      <div className="fr-col-12 fr-col-md-3 fr-col-xl-2">
+      <div className="fr-col-12 fr-col-md-3 fr-col-xl-3">
         <MenuActifProvider>
           <MenuLateral contexte={contexte} />
         </MenuActifProvider>
       </div>
-      <div className="fr-col-12 fr-col-md-9 fr-col-xl-10 fr-pl-md-7w menu-border">{children}</div>
+      <div className="fr-col-12 fr-col-md-9 fr-col-xl-9 fr-pl-md-7w menu-border">{children}</div>
     </div>
   )
 }

--- a/src/app/(connecte)/(avec-menu)/(default)/tableau-de-bord/blocs/BlocAccueil.module.css
+++ b/src/app/(connecte)/(avec-menu)/(default)/tableau-de-bord/blocs/BlocAccueil.module.css
@@ -1,9 +1,0 @@
-.sousTitre {
-  font-size: 1.25rem;
-  font-weight: 400;
-}
-
-.titre {
-  font-size: 3rem !important;
-  font-weight: 400 !important;
-}

--- a/src/app/(connecte)/(avec-menu)/(default)/tableau-de-bord/blocs/BlocAccueil.tsx
+++ b/src/app/(connecte)/(avec-menu)/(default)/tableau-de-bord/blocs/BlocAccueil.tsx
@@ -1,6 +1,5 @@
 import { ReactElement } from 'react'
 
-import styles from './BlocAccueil.module.css'
 import SelecteurGouvernance from '@/components/transverse/SelecteurGouvernance/SelecteurGouvernance'
 import { gouvernancesSelecteurPresenteur } from '@/presenters/tableauDeBord/selecteurGouvernancePresenter'
 import { Contexte, Scope } from '@/use-cases/queries/ResoudreContexte'
@@ -26,9 +25,9 @@ export default function BlocAccueil({ contexte, prenom, scope }: Props): ReactEl
   return (
     <>
       <div className="fr-mb-3w" style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-        <h1 className={`color-blue-france fr-mt-5w fr-mb-0 ${styles.titre}`}>👋 Bonjour {prenom}</h1>
+        <h1 className="color-blue-france fr-display--xs fr-text--regular fr-mt-5w fr-mb-0">👋 Bonjour {prenom}</h1>
         <div style={{ alignItems: 'flex-end', display: 'flex', gap: '2rem' }}>
-          <p className={`color-blue-france fr-m-0 ${styles.sousTitre}`} style={{ flex: '1 0 0' }}>
+          <p className="color-blue-france fr-m-0 fr-text--xl fr-text--regular" style={{ flex: '1 0 0' }}>
             {sousTitre}
           </p>
           {options.length >= 2 && (

--- a/src/app/(connecte)/(avec-menu)/gouvernance/[codeDepartement]/(avec-menu)/layout.tsx
+++ b/src/app/(connecte)/(avec-menu)/gouvernance/[codeDepartement]/(avec-menu)/layout.tsx
@@ -21,12 +21,12 @@ export default async function Layout({ children }: Readonly<PropsWithChildren>):
 
     return (
       <div className="fr-grid-row">
-        <div className="fr-col-3 fr-col-lg-2">
+        <div className="fr-col-12 fr-col-md-3 fr-col-xl-3">
           <MenuActifProvider>
             <MenuLateral contexte={contexte} />
           </MenuActifProvider>
         </div>
-        <div className="fr-col-9 fr-col-lg-10 fr-pl-7w menu-border">{children}</div>
+        <div className="fr-col-12 fr-col-md-9 fr-col-xl-9 fr-pl-md-7w menu-border">{children}</div>
       </div>
     )
   } catch {

--- a/src/components/transverse/MenuLateral/MenuLateral.module.css
+++ b/src/components/transverse/MenuLateral/MenuLateral.module.css
@@ -3,5 +3,5 @@
 }
 
 .menu {
-  max-width: 20rem;
+  max-width: 25rem;
 }


### PR DESCRIPTION
…phiques

  - Augmente la max-width du menu latéral (20rem → 25rem)
  - Aligne les colonnes DSFR des layouts dashboard et gouvernance (fr-col-xl-3/9)
  - Remplace les overrides !important par les classes DSFR fr-text--regular sur le titre et sous-titre du tableau de bord

# Contrat du dev

## Qualité

- [x] Relire le code
- [x] Relire le ticket
- [x] [Relire les critères d'acceptation](https://github.com/anct-cnum/suite-gestionnaire-numerique/discussions/252)


> **Et n'oublie pas de vérifier ce que tu as fait en production !**
