### PR TITLE
feat(postes-conum): rendre le menu Suivi des postes accessible à tous…

### DIFF
--- a/src/components/transverse/MenuLateral/registreMenus.ts
+++ b/src/components/transverse/MenuLateral/registreMenus.ts
@@ -148,8 +148,6 @@ function sectionPilotageParContexte(contexte: Contexte): Section {
 
   const nb = contexte.nbGouvernances()
   const estAdmin = contexte.aCesRoles('administrateur_dispositif')
-  const nestPasGestionnaireStructure = !contexte.aCesRoles('gestionnaire_structure')
-  const estCoporteur = contexte.estCoporteur()
 
   if (estAdmin) {
     menus.push({
@@ -186,13 +184,11 @@ function sectionPilotageParContexte(contexte: Contexte): Section {
     })
   }
 
-  if (nestPasGestionnaireStructure || estCoporteur) {
-    menus.push({
-      customIcon: `${process.env.NEXT_PUBLIC_HOST}/conum-full.svg`,
-      label: 'Suivi des postes CoNum',
-      url: () => '/postes-conseiller-numerique',
-    })
-  }
+  menus.push({
+    customIcon: `${process.env.NEXT_PUBLIC_HOST}/conum-full.svg`,
+    label: 'Suivi des postes CoNum',
+    url: () => '/postes-conseiller-numerique',
+  })
 
   return { menus, titre: estAdmin ? 'ADMINISTRATION' : 'PILOTAGE' }
 }

--- a/src/gateways/PrismaPostesConseillerNumeriqueLoader.ts
+++ b/src/gateways/PrismaPostesConseillerNumeriqueLoader.ts
@@ -84,6 +84,10 @@ export class PrismaPostesConseillerNumeriqueLoader implements PostesConseillerNu
   }
 
   private addTerritoireFilter(filtres: FiltresPostesConseillerNumerique, conditions: Array<Prisma.Sql>): void {
+    if (filtres.scopeFiltre.type === 'structure') {
+      conditions.push(Prisma.sql`v.structure_id = ${filtres.scopeFiltre.id}`)
+      return
+    }
     if (filtres.codeDepartement !== undefined) {
       conditions.push(Prisma.sql`a.departement = ${filtres.codeDepartement}`)
     } else if (


### PR DESCRIPTION
… les gestionnaires de structure

Le menu n'était visible que pour les gestionnaires de structure coporteurs. Le loader gère désormais le scope structure en filtrant sur structure_id pour limiter la vue aux postes rattachés à la structure de l'utilisateur. #1414

