### PR TITLE
fix(structure): corriger la source aidants-connect et renommer l'enca…

### DIFF
--- a/src/components/Structure/StructureAidantsMediateurs.tsx
+++ b/src/components/Structure/StructureAidantsMediateurs.tsx
@@ -77,7 +77,7 @@ export default function StructureAidantsMediateurs({ aidantsEtMediateurs }: Prop
                     {aidantsEtMediateurs.totalAidant}{' '}
                   </span>
                   <br />
-                  <span className="font-weight-500 color-blue-france">Aidants numériques</span>
+                  <span className="font-weight-500 color-blue-france">Aidants Connect</span>
                 </p>
               </div>
             </div>

--- a/src/gateways/PrismaUneStructureLoader.ts
+++ b/src/gateways/PrismaUneStructureLoader.ts
@@ -174,7 +174,7 @@ function buildAidantsEtMediateurs(personnesAffectations: ReadonlyArray<PersonneA
   const totalAidant = personnesDedupliquees.filter((affectation) => {
     const sources = sourcesParPersonne.get(affectation.personne.id) ?? new Set<string>()
     return (
-      sources.has('aidant-connect') ||
+      sources.has('aidants-connect') ||
       affectation.personne.is_coordinateur === true ||
       affectation.personne.is_mediateur === true
     )
@@ -190,7 +190,7 @@ function buildAidantsEtMediateurs(personnesAffectations: ReadonlyArray<PersonneA
     if (personne.is_mediateur === true) {
       fonctions.push('Médiateur numérique')
     }
-    if (sources.has('aidant-connect')) {
+    if (sources.has('aidants-connect')) {
       fonctions.push('Aidant numérique')
     }
 
@@ -198,7 +198,7 @@ function buildAidantsEtMediateurs(personnesAffectations: ReadonlyArray<PersonneA
     if (personne.conseiller_numerique_id !== null && personne.conseiller_numerique_id !== '') {
       logos.push(`${process.env.NEXT_PUBLIC_HOST}/conum.svg`)
     }
-    if (sources.has('aidant-connect')) {
+    if (sources.has('aidants-connect')) {
       logos.push(`${process.env.NEXT_PUBLIC_HOST}/aidant-numerique.svg`)
     }
     return {


### PR DESCRIPTION
…rt (#1416)

La source en base est 'aidants-connect' (au pluriel) ; le code testait 'aidant-connect' (sans s), ce qui empêchait totalAidant de comptabiliser les personnes rattachées via Aidants Connect, et privait la liste du libellé/logo correspondant. L'encart est par ailleurs renommé "Aidants Connect" pour refléter sa sémantique réelle.
