### PR TITLE
fix(wordings): harmoniser pluriels et majuscules (#1422) (#1424)

### DIFF
--- a/src/app/vitrine/dispositifs/page.tsx
+++ b/src/app/vitrine/dispositifs/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
   description:
     "Découvrez les dispositifs d'inclusion numérique : conseillers numériques, Aidants Connect, ateliers de montée en compétences. Répondre collectivement aux besoins d'accompagnement de la population.",
   keywords: [
-    'conseiller numérique',
+    'Conseiller Numérique',
     'Aidants Connect',
     'dispositifs inclusion',
     'accompagnement numérique',

--- a/src/app/vitrine/page.tsx
+++ b/src/app/vitrine/page.tsx
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
     'inclusion numérique',
     'ANCT',
     'France Numérique Ensemble',
-    'conseiller numérique',
+    'Conseiller Numérique',
     "lieux d'inclusion",
     'gouvernance territoriale',
   ],

--- a/src/components/AidantsMediateurs/AccompagnementsEtMediateurs.tsx
+++ b/src/components/AidantsMediateurs/AccompagnementsEtMediateurs.tsx
@@ -69,7 +69,7 @@ export default function AccompagnementsEtMediateurs({
       <div className="fr-grid-row fr-grid-row--middle separator fr-pb-3w fr-mb-3w">
         <div>
           <h2 className="fr-h4 color-blue-france fr-m-0" id="accompagnements-et-mediateurs">
-            Accompagnements et Médiateurs numériques
+            Accompagnements et médiateurs numériques
             <Information>
               <p className="fr-mb-0">
                 Les indicateurs affichés concernent les médiateurs numériques inscrits sur{' '}
@@ -162,7 +162,7 @@ export default function AccompagnementsEtMediateurs({
               onClick={() => {
                 void handleDownload()
               }}
-              title="Accompagnements et Médiateurs"
+              title="Accompagnements et médiateurs"
             />
           </div>
         </div>

--- a/src/components/AidantsMediateurs/AidantsMediateurs.tsx
+++ b/src/components/AidantsMediateurs/AidantsMediateurs.tsx
@@ -63,7 +63,7 @@ export default function AidantsMediateurs({
           <div className="fr-col">
             <div className="fr-grid-row fr-grid-row--middle">
               <InformationLogo />
-              <span>Aidants, médiateurs, conseillers numériques, … : Quelles différences ?</span>
+              <span>Aidant, médiateur, Conseiller Numérique : quelles différences ?</span>
             </div>
           </div>
           <div className="fr-col-auto">

--- a/src/components/ListeAidantsMediateurs/ListeAidantsMediateurs.tsx
+++ b/src/components/ListeAidantsMediateurs/ListeAidantsMediateurs.tsx
@@ -267,7 +267,7 @@ export default function ListeAidantsMediateurs({
         <div className="fr-col">
           <PageTitle>
             <TitleIcon icon="group-line" />
-            Suivi aidants et médiateurs
+            Suivi des aidants et médiateurs
           </PageTitle>
         </div>
         <div className="fr-col-auto fr-grid-row fr-grid-row--middle fr-grid-row--gutters">
@@ -348,7 +348,7 @@ export default function ListeAidantsMediateurs({
           }}
         >
           <p className="fr-text--md fr-mb-0" style={{ textAlign: 'center' }}>
-            <span className="fr-text--bold">👻 Aucuns aidants et médiateurs trouvés sur votre territoire</span>
+            <span className="fr-text--bold">👻 Aucun aidant ou médiateur trouvé sur votre territoire</span>
           </p>
         </div>
       ) : (

--- a/src/components/Poste/Poste.tsx
+++ b/src/components/Poste/Poste.tsx
@@ -71,7 +71,7 @@ const items: ReadonlyArray<SideMenuItem> = [
   },
   {
     linkProps: { href: '#conventions' },
-    text: 'Convention et financement',
+    text: 'Conventions et financements',
   },
   {
     linkProps: { href: '#contrats' },

--- a/src/components/PostesConseillerNumerique/ListePostesConseillerNumerique.tsx
+++ b/src/components/PostesConseillerNumerique/ListePostesConseillerNumerique.tsx
@@ -234,7 +234,7 @@ export default function ListePostesConseillerNumerique({
       <div className="fr-callout fr-callout--blue-ecume fr-mb-3w">
         <p className="fr-callout__text fr-text--sm fr-mb-0">
           <span className="fr-icon-information-fill fr-mr-1w" />
-          {'Pour gérer les postes de conseiller numérique, connectez-vous au tableau de pilotage '}
+          {'Pour gérer les postes de Conseiller Numérique, connectez-vous au tableau de pilotage '}
           <a
             className="fr-link"
             href="https://pilotage.conseiller-numerique.gouv.fr"
@@ -258,7 +258,7 @@ export default function ListePostesConseillerNumerique({
           }}
         >
           <p className="fr-text--md fr-mb-0" style={{ textAlign: 'center' }}>
-            <span className="fr-text--bold">Aucun poste de conseiller numérique trouvé sur votre territoire</span>
+            <span className="fr-text--bold">Aucun poste de Conseiller Numérique trouvé sur votre territoire</span>
           </p>
         </div>
       ) : (

--- a/src/components/Structure/Structure.tsx
+++ b/src/components/Structure/Structure.tsx
@@ -63,7 +63,7 @@ const items: ReadonlyArray<SideMenuItem> = [
   },
   {
     linkProps: { href: '#conventions' },
-    text: 'Convention et financement',
+    text: 'Conventions et financements',
   },
   {
     linkProps: { href: '#aidants' },

--- a/src/components/Structure/StructureContratsRattaches.tsx
+++ b/src/components/Structure/StructureContratsRattaches.tsx
@@ -4,7 +4,7 @@ import ContratsRattaches from '@/components/shared/ContratsRattaches/ContratsRat
 import { StructureViewModel } from '@/presenters/structurePresenter'
 
 export default function StructureContratsRattaches({ contratsRattaches }: Props): ReactElement {
-  return <ContratsRattaches contrats={contratsRattaches} titre="Contrat des conseillers numériques" />
+  return <ContratsRattaches contrats={contratsRattaches} titre="Contrats des conseillers numériques" />
 }
 
 type Props = Readonly<{

--- a/src/components/shared/ConventionsEtFinancements/ConventionsEtFinancements.tsx
+++ b/src/components/shared/ConventionsEtFinancements/ConventionsEtFinancements.tsx
@@ -26,7 +26,7 @@ export default function ConventionsEtFinancements({ data }: Props): ReactElement
       }}
     >
       <h2 className="fr-h6 fr-m-0" id="conventions">
-        Conventions et financement
+        Conventions et financements
       </h2>
 
       <article aria-label="Résumé des financements">

--- a/src/components/vitrine/MediateursNumeriques/CarteStatistiqueConseillersNumeriques.tsx
+++ b/src/components/vitrine/MediateursNumeriques/CarteStatistiqueConseillersNumeriques.tsx
@@ -4,7 +4,7 @@ export default function CarteStatistiqueConseillersNumeriques({ nombre, sousText
   return (
     <div className="background-blue-france fr-p-3w fr-mb-1w" style={{ flex: 1 }}>
       <div className="fr-h2 fr-m-0">{nombre}</div>
-      <div className="font-weight-500">Labellisés Conseiller numérique</div>
+      <div className="font-weight-500">Labellisés Conseiller Numérique</div>
       <div className="fr-text--xs color-blue-france fr-mb-0">{sousTexte}</div>
     </div>
   )

--- a/src/presenters/tableauDeBord/accompagnementsEtMediateursPresenter.ts
+++ b/src/presenters/tableauDeBord/accompagnementsEtMediateursPresenter.ts
@@ -47,7 +47,7 @@ export function accompagnementsEtMediateursPresenter(
     metriques: [
       {
         chiffre: readModel.mediateursNumeriques.toLocaleString('fr-FR'),
-        sousTitre: `Dont ${readModel.conseillerNumeriques.toLocaleString('fr-FR')} Conseillers numériques`,
+        sousTitre: `Dont ${readModel.conseillerNumeriques.toLocaleString('fr-FR')} conseillers numériques`,
         titre: 'Médiateurs numériques',
       },
       {


### PR DESCRIPTION
#1422 pluriels : Conventions et financements (menu Structure/Poste + h2), Contrats des conseillers numériques, "Aucun aidant ou médiateur trouvé", "Suivi des aidants et médiateurs".

#1424 majuscules : Conseiller Numérique (dispositif) pour les keywords SEO vitrine,carte statistique ; médiateur en minuscule (nom commun) dans "Accompagnements et médiateurs" ; bandeau didactique reformulé.
