### PR TITLE
feat(structure): bandeau explicatif des contrats en cours (#1423)

### DIFF
--- a/src/components/Structure/StructureContratsRattaches.tsx
+++ b/src/components/Structure/StructureContratsRattaches.tsx
@@ -1,10 +1,35 @@
 import { ReactElement } from 'react'
 
 import ContratsRattaches from '@/components/shared/ContratsRattaches/ContratsRattaches'
+import ExternalLink from '@/components/shared/ExternalLink/ExternalLink'
 import { StructureViewModel } from '@/presenters/structurePresenter'
 
 export default function StructureContratsRattaches({ contratsRattaches }: Props): ReactElement {
-  return <ContratsRattaches contrats={contratsRattaches} titre="Contrats des conseillers numériques" />
+  return (
+    <ContratsRattaches
+      bandeau={
+        <div className="fr-notice fr-notice--info border-radius fr-mt-3w">
+          <div className="fr-notice__body fr-px-3w">
+            <p className="fr-notice__title fr-text--sm fr-text--regular">
+              <span className="fr-text-default--grey">
+                Un contrat est considéré comme en cours tant qu’aucune rupture n’a été déclarée sur le{' '}
+                <ExternalLink
+                  className="fr-link fr-text--sm"
+                  href="https://pilotage.conseiller-numerique.gouv.fr/"
+                  title="Tableau de pilotage"
+                >
+                  tableau de pilotage
+                </ExternalLink>{' '}
+                et que les documents de fin de contrat n’ont pas été transmis.
+              </span>
+            </p>
+          </div>
+        </div>
+      }
+      contrats={contratsRattaches}
+      titre="Contrats des conseillers numériques"
+    />
+  )
 }
 
 type Props = Readonly<{

--- a/src/components/shared/ContratsRattaches/ContratsRattaches.tsx
+++ b/src/components/shared/ContratsRattaches/ContratsRattaches.tsx
@@ -1,10 +1,10 @@
-import { ReactElement } from 'react'
+import { ReactElement, ReactNode } from 'react'
 
 import Badge from '@/components/shared/Badge/Badge'
 import Table from '@/components/shared/Table/Table'
 import TableauVide from '@/components/shared/TableauVide/TableauVide'
 
-export default function ContratsRattaches({ contrats, titre }: Props): ReactElement {
+export default function ContratsRattaches({ bandeau, contrats, titre }: Props): ReactElement {
   return (
     <section aria-labelledby="contrats" className="grey-border border-radius fr-mb-2w fr-p-4w" id="contrats">
       <h2 className="fr-h6" id="contratsRattaches">
@@ -39,6 +39,7 @@ export default function ContratsRattaches({ contrats, titre }: Props): ReactElem
           </Table>
         )}
       </article>
+      {bandeau}
     </section>
   )
 }
@@ -57,6 +58,7 @@ export type ContratRattacheViewModel = Readonly<{
 }>
 
 type Props = Readonly<{
+  bandeau?: ReactNode
   contrats: ReadonlyArray<ContratRattacheViewModel>
   titre: string
 }>


### PR DESCRIPTION
## Contexte

Ticket #1423 — Fiche structure, encart « Contrats des conseillers numériques ».

Ajout d'un bandeau explicatif sous le tableau des contrats, avec un lien vers le tableau de pilotage pour inciter les structures à faire les démarches nécessaires.

## Changements

- `ContratsRattaches` (composant partagé) : nouvelle prop optionnelle `bandeau?: ReactNode`, rendue sous le tableau, à l'intérieur de la section. Sans la prop (cas fiche poste), le rendu est inchangé.
- `StructureContratsRattaches` : passe le bandeau d'information DSFR (`fr-notice--info`) conforme à la maquette Figma, avec « tableau de pilotage » en lien inline vers https://pilotage.conseiller-numerique.gouv.fr/

## Conformité Figma

Implémentation du node `18947:24085`. Styles calculés vérifiés : fond `#E8EDFF`, radius `8px`, icône info `#0063CB`, texte gris `#3A3A3A` Marianne 14px/24px régulier, lien `#000091` souligné.

Écart assumé : le lien externe affiche l'icône « nouvelle fenêtre » (convention `ExternalLink` du projet, accessibilité), absente de la maquette.

## Vérifications

- `pnpm typecheck` ✅
- `pnpm lint:ts` ✅
- Rendu vérifié sur `/structure/28189`

🤖 Generated with [Claude Code](https://claude.com/claude-code)