### PR TITLE
refactor(enveloppes): expliciter le type Conum/FNE sans changement mé…

### DIFF
--- a/src/gateways/PrismaUneStructureLoader.test.ts
+++ b/src/gateways/PrismaUneStructureLoader.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { PrismaUneStructureLoader } from './PrismaUneStructureLoader'
+import {
+  creerUnBeneficiaireSubvention,
+  creerUnDepartement,
+  creerUneAction,
+  creerUneDemandeDeSubvention,
+  creerUneEnveloppeFinancement,
+  creerUneFeuilleDeRoute,
+  creerUneGouvernance,
+  creerUneRegion,
+  creerUneStructure,
+  creerUnMembre,
+  creerUnUtilisateur,
+} from './testHelper'
+import prisma from '../../prisma/prismaClient'
+
+describe('une structure loader : caractérisation des enveloppes (accumulation FNE par libellé)', () => {
+  beforeEach(async () => prisma.$queryRaw`START TRANSACTION`)
+
+  afterEach(async () => prisma.$queryRaw`ROLLBACK TRANSACTION`)
+
+  it('les demandes de subvention acceptées sont cumulées par libellé d’enveloppe (Formation + Ingénierie FNE)', async () => {
+    // GIVEN
+    await creerUneRegion({ code: '11' })
+    await creerUnDepartement({ code: '69', regionCode: '11' })
+    await creerUneGouvernance({ departementCode: '69' })
+    await creerUnUtilisateur({ id: 1 })
+    await creerUneStructure({ departementCode: '69', id: 28_189 })
+    await creerUnMembre({ gouvernanceDepartementCode: '69', id: 'membre-fne-test', structureId: 28_189 })
+    await creerUneFeuilleDeRoute({ gouvernanceDepartementCode: '69', id: 1 })
+    await creerUneAction({ feuilleDeRouteId: 1, id: 1 })
+    await creerUneAction({ feuilleDeRouteId: 1, id: 2 })
+    await creerUneEnveloppeFinancement({
+      id: 3,
+      libelle: 'Formation Aidant Numérique/Aidants Connect - 2024 - État',
+    })
+    await creerUneEnveloppeFinancement({
+      id: 4,
+      libelle: 'Ingénierie France Numérique Ensemble - 2024 - État',
+    })
+    await creerUneDemandeDeSubvention({
+      actionId: 1,
+      enveloppeFinancementId: 4,
+      id: 1,
+      statut: 'acceptee',
+      subventionDemandee: 47_200,
+    })
+    await creerUneDemandeDeSubvention({
+      actionId: 2,
+      enveloppeFinancementId: 3,
+      id: 2,
+      statut: 'acceptee',
+      subventionDemandee: 20_000,
+    })
+    await creerUnBeneficiaireSubvention({ demandeDeSubventionId: 1, membreId: 'membre-fne-test' })
+    await creerUnBeneficiaireSubvention({ demandeDeSubventionId: 2, membreId: 'membre-fne-test' })
+
+    // WHEN
+    const readModel = await new PrismaUneStructureLoader().get(28_189)
+
+    // THEN
+    const enveloppesTriees = [...readModel.conventionsEtFinancements.enveloppes].sort((enveloppeA, enveloppeB) =>
+      enveloppeA.libelle.localeCompare(enveloppeB.libelle)
+    )
+    expect(enveloppesTriees).toStrictEqual([
+      { libelle: 'Formation Aidant Numérique/Aidants Connect - 2024 - État', montant: 20_000, type: 'fne' },
+      { libelle: 'Ingénierie France Numérique Ensemble - 2024 - État', montant: 47_200, type: 'fne' },
+    ])
+    expect(readModel.conventionsEtFinancements.creditsEngagesParLEtat).toBe(67_200)
+    // Enveloppe formation → récipiendaire ; enveloppe non-formation → bénéficiaire
+    const rolesGouvernance = readModel.role.gouvernances
+      .flatMap((gouvernance) => [...gouvernance.roles])
+      .sort((roleA, roleB) => roleA.localeCompare(roleB))
+    expect(rolesGouvernance).toStrictEqual(['beneficiaire', 'recipiendaire'])
+  })
+
+  it('les demandes de subvention non acceptées sont exclues du cumul', async () => {
+    // GIVEN
+    await creerUneRegion({ code: '11' })
+    await creerUnDepartement({ code: '69', regionCode: '11' })
+    await creerUneGouvernance({ departementCode: '69' })
+    await creerUnUtilisateur({ id: 1 })
+    await creerUneStructure({ departementCode: '69', id: 28_189 })
+    await creerUnMembre({ gouvernanceDepartementCode: '69', id: 'membre-fne-test', structureId: 28_189 })
+    await creerUneFeuilleDeRoute({ gouvernanceDepartementCode: '69', id: 1 })
+    await creerUneAction({ feuilleDeRouteId: 1, id: 1 })
+    await creerUneEnveloppeFinancement({
+      id: 4,
+      libelle: 'Ingénierie France Numérique Ensemble - 2024 - État',
+    })
+    await creerUneDemandeDeSubvention({
+      actionId: 1,
+      enveloppeFinancementId: 4,
+      id: 1,
+      statut: 'deposee',
+      subventionDemandee: 47_200,
+    })
+    await creerUnBeneficiaireSubvention({ demandeDeSubventionId: 1, membreId: 'membre-fne-test' })
+
+    // WHEN
+    const readModel = await new PrismaUneStructureLoader().get(28_189)
+
+    // THEN
+    expect(readModel.conventionsEtFinancements.enveloppes).toStrictEqual([])
+    expect(readModel.conventionsEtFinancements.creditsEngagesParLEtat).toBe(0)
+  })
+})

--- a/src/gateways/PrismaUneStructureLoader.ts
+++ b/src/gateways/PrismaUneStructureLoader.ts
@@ -1,5 +1,6 @@
 import prisma from '../../prisma/prismaClient'
 import { calculerStatutContrat } from '@/domain/Contrat'
+import { classifierTypeEnveloppe, estEnveloppeDeFormation, TypeEnveloppe } from '@/shared/enveloppeFinancement'
 import { RoleType, UneStructureLoader, UneStructureReadModel } from '@/use-cases/queries/RecupererUneStructure'
 
 export class PrismaUneStructureLoader implements UneStructureLoader {
@@ -376,11 +377,11 @@ function ajouterRolesSubvention(
   }
 
   const aEnveloppeFormation = beneficiaires.some((beneficiaire) =>
-    beneficiaire.demandeDeSubvention.enveloppe.libelle.toLowerCase().includes('formation')
+    estEnveloppeDeFormation(beneficiaire.demandeDeSubvention.enveloppe.libelle)
   )
 
   const aEnveloppeNonFormation = beneficiaires.some(
-    (beneficiaire) => !beneficiaire.demandeDeSubvention.enveloppe.libelle.toLowerCase().includes('formation')
+    (beneficiaire) => !estEnveloppeDeFormation(beneficiaire.demandeDeSubvention.enveloppe.libelle)
   )
 
   if (aEnveloppeFormation) {
@@ -485,6 +486,7 @@ async function buildConventionsEtFinancements(
   enveloppes: ReadonlyArray<{
     libelle: string
     montant: number
+    type: TypeEnveloppe
   }>
   lienConventions: string
 }> {
@@ -510,6 +512,7 @@ async function buildConventionsEtFinancements(
   const enveloppes = Array.from(enveloppesMap.entries()).map(([libelle, montant]) => ({
     libelle,
     montant,
+    type: classifierTypeEnveloppe(libelle),
   }))
 
   return {

--- a/src/gateways/shared/Action.test.ts
+++ b/src/gateways/shared/Action.test.ts
@@ -1,0 +1,49 @@
+import { Prisma } from '@prisma/client'
+import { describe, expect, it } from 'vitest'
+
+import { isEnveloppeDeFormation } from './Action'
+import { epochTime, epochTimePlusOneDay } from '@/shared/testHelper'
+
+describe('isEnveloppeDeFormation : caractérisation sur les libellés réels en base', () => {
+  it.each([
+    {
+      attendu: false,
+      intention: 'enveloppe Conum Plan France Relance (id 1) → pas une enveloppe de formation',
+      libelle: 'Conseiller Numérique - Plan France Relance - État',
+    },
+    {
+      attendu: false,
+      intention: 'enveloppe Conum Renouvellement (id 2) → pas une enveloppe de formation',
+      libelle: 'Conseiller Numérique - Renouvellement - État',
+    },
+    {
+      attendu: true,
+      intention: 'enveloppe FNE Formation Aidant Numérique (id 3) → enveloppe de formation',
+      libelle: 'Formation Aidant Numérique/Aidants Connect - 2024 - État',
+    },
+    {
+      attendu: false,
+      intention: 'enveloppe FNE Ingénierie France Numérique Ensemble (id 4) → pas une enveloppe de formation',
+      libelle: 'Ingénierie France Numérique Ensemble - 2024 - État',
+    },
+  ])('$intention', ({ attendu, libelle }) => {
+    // GIVEN
+    const enveloppe = enveloppeFinancementRecord(libelle)
+
+    // WHEN
+    const resultat = isEnveloppeDeFormation(enveloppe)
+
+    // THEN
+    expect(resultat).toBe(attendu)
+  })
+})
+
+function enveloppeFinancementRecord(libelle: string): Prisma.EnveloppeFinancementRecordGetPayload<null> {
+  return {
+    dateDeDebut: epochTime,
+    dateDeFin: epochTimePlusOneDay,
+    id: 1,
+    libelle,
+    montant: 0,
+  }
+}

--- a/src/gateways/shared/Action.ts
+++ b/src/gateways/shared/Action.ts
@@ -1,5 +1,7 @@
 import { Prisma } from '@prisma/client'
 
+import { estEnveloppeDeFormation } from '@/shared/enveloppeFinancement'
+
 export function isEnveloppeDeFormation(enveloppe: Prisma.EnveloppeFinancementRecordGetPayload<null>): boolean {
-  return /formation/i.test(enveloppe.libelle)
+  return estEnveloppeDeFormation(enveloppe.libelle)
 }

--- a/src/gateways/shared/MembresGouvernance.ts
+++ b/src/gateways/shared/MembresGouvernance.ts
@@ -1,5 +1,7 @@
 import { Prisma } from '@prisma/client'
 
+import { estEnveloppeDeFormation } from '@/shared/enveloppeFinancement'
+
 export type Membre = Readonly<{
   contacts: ReadonlyArray<ContactMembre>
   id: string
@@ -61,12 +63,12 @@ function deduireRoles(membre: MembreRecord): ReadonlyArray<Role> {
   if (beneficiaireSubvention.length > 0) {
     // Vérifier si le membre a des demandes de subvention avec des enveloppes de formation
     const aEnveloppeFormation = beneficiaireSubvention.some((beneficiaire) =>
-      beneficiaire.demandeDeSubvention.enveloppe.libelle.toLowerCase().includes('formation')
+      estEnveloppeDeFormation(beneficiaire.demandeDeSubvention.enveloppe.libelle)
     )
 
     // Vérifier si le membre a des demandes de subvention avec des enveloppes non-formation
     const aEnveloppeNonFormation = beneficiaireSubvention.some(
-      (beneficiaire) => !beneficiaire.demandeDeSubvention.enveloppe.libelle.toLowerCase().includes('formation')
+      (beneficiaire) => !estEnveloppeDeFormation(beneficiaire.demandeDeSubvention.enveloppe.libelle)
     )
 
     if (aEnveloppeFormation) {

--- a/src/gateways/tableauDeBord/PrismaEnveloppesConseillerNumeriqueLoader.ts
+++ b/src/gateways/tableauDeBord/PrismaEnveloppesConseillerNumeriqueLoader.ts
@@ -55,6 +55,7 @@ export class PrismaEnveloppesConseillerNumeriqueLoader implements EnveloppesCons
           END AS consommation
         FROM min.enveloppe_financement e
         CROSS JOIN agg
+        -- Type « Conseiller Numérique » : règle canonique classifierTypeEnveloppe (@/shared/enveloppeFinancement)
         WHERE e.libelle LIKE 'Conseiller Numérique%'
         ORDER BY e.libelle
       `
@@ -105,6 +106,7 @@ export class PrismaEnveloppesConseillerNumeriqueLoader implements EnveloppesCons
       CROSS JOIN agg
       LEFT JOIN min.departement_enveloppe de
         ON de.enveloppe_id = e.id AND de.departement_code = ${code}
+      -- Type « Conseiller Numérique » : règle canonique classifierTypeEnveloppe (@/shared/enveloppeFinancement)
       WHERE e.libelle LIKE 'Conseiller Numérique%'
       ORDER BY e.libelle
     `
@@ -130,6 +132,7 @@ export class PrismaEnveloppesConseillerNumeriqueLoader implements EnveloppesCons
         END AS consommation
       FROM min.enveloppe_financement e
       CROSS JOIN agg
+      -- Type « Conseiller Numérique » : règle canonique classifierTypeEnveloppe (@/shared/enveloppeFinancement)
       WHERE e.libelle LIKE 'Conseiller Numérique%'
       ORDER BY e.libelle
     `

--- a/src/presenters/posteConseillerNumeriqueDetailPresenter.test.ts
+++ b/src/presenters/posteConseillerNumeriqueDetailPresenter.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+
+import { posteConseillerNumeriqueDetailPresenter } from './posteConseillerNumeriqueDetailPresenter'
+import { formatMontant } from './shared/number'
+import { epochTime, epochTimeMinusOneDay } from './testHelper'
+import { PosteConseillerNumeriqueDetailReadModel } from '@/use-cases/queries/RecupererUnPosteConseillerNumerique'
+
+describe('poste conseiller numérique presenter : caractérisation des enveloppes (Conum uniquement)', () => {
+  it('avec conventions V1 et V2, les enveloppes sont exactement les 2 enveloppes Conseiller Numérique (jamais de FNE)', () => {
+    // GIVEN
+    const readModel = posteReadModel({
+      v1: { bonification: 0, dateDebut: null, dateFin: epochTimeMinusOneDay, subvention: 56_098, versement: 56_098 },
+      v2: {
+        bonification: 7_500,
+        dateDebut: epochTimeMinusOneDay,
+        dateFin: epochTimeMinusOneDay,
+        subvention: 2_500,
+        versement: 10_000,
+      },
+    })
+
+    // WHEN
+    const conventionsEtFinancements = conventionsEtFinancementsDe(readModel)
+
+    // THEN
+    expect(conventionsEtFinancements.creditsEngagesParLEtat).toBe(formatMontant(66_098))
+    expect(conventionsEtFinancements.enveloppes).toStrictEqual([
+      {
+        color: 'menthe',
+        libelle: 'Conseiller Numérique - Renouvellement - État',
+        montant: 10_000,
+        montantFormate: formatMontant(10_000),
+      },
+      {
+        color: 'france',
+        libelle: 'Conseiller Numérique - initiale - État',
+        montant: 56_098,
+        montantFormate: formatMontant(56_098),
+      },
+    ])
+    expect(
+      conventionsEtFinancements.enveloppes.every((enveloppe) => enveloppe.libelle.startsWith('Conseiller Numérique'))
+    ).toBe(true)
+  })
+
+  it('avec seulement la convention V1, une seule enveloppe Conseiller Numérique initiale', () => {
+    // GIVEN
+    const readModel = posteReadModel({
+      v1: { bonification: 0, dateDebut: null, dateFin: epochTimeMinusOneDay, subvention: 56_098, versement: 56_098 },
+      v2: null,
+    })
+
+    // WHEN
+    const conventionsEtFinancements = conventionsEtFinancementsDe(readModel)
+
+    // THEN
+    expect(conventionsEtFinancements.enveloppes).toStrictEqual([
+      {
+        color: 'france',
+        libelle: 'Conseiller Numérique - initiale - État',
+        montant: 56_098,
+        montantFormate: formatMontant(56_098),
+      },
+    ])
+  })
+
+  it('sans aucune convention, aucune enveloppe', () => {
+    // GIVEN
+    const readModel = posteReadModel({ v1: null, v2: null })
+
+    // WHEN
+    const conventionsEtFinancements = conventionsEtFinancementsDe(readModel)
+
+    // THEN
+    expect(conventionsEtFinancements.enveloppes).toStrictEqual([])
+  })
+})
+
+function conventionsEtFinancementsDe(readModel: PosteConseillerNumeriqueDetailReadModel): {
+  creditsEngagesParLEtat: string
+  enveloppes: ReadonlyArray<{ color: string; libelle: string; montant: number; montantFormate: string }>
+} {
+  const viewModel = posteConseillerNumeriqueDetailPresenter(readModel, epochTime)
+  if ('type' in viewModel) {
+    throw new Error('viewModel inattendu : ErrorReadModel')
+  }
+  return viewModel.conventionsEtFinancements
+}
+
+function posteReadModel(
+  conventions: Partial<PosteConseillerNumeriqueDetailReadModel['conventions']>
+): PosteConseillerNumeriqueDetailReadModel {
+  const v1 = conventions.v1 ?? null
+  const v2 = conventions.v2 ?? null
+  const creditsEngagesParLEtat = (v1 ? v1.subvention + v1.bonification : 0) + (v2 ? v2.subvention + v2.bonification : 0)
+
+  return {
+    contrats: [],
+    conventions: {
+      creditsEngagesParLEtat,
+      v1,
+      v2,
+    },
+    estBonifie: true,
+    estCoordinateur: false,
+    posteConumId: 2672,
+    posteId: 1,
+    statut: 'rendu',
+    structure: {
+      adresse: '12 Rue Saint-Laurent, 14000 Caen',
+      contacts: [],
+      departement: 'Calvados',
+      nom: 'DEPARTEMENT DU CALVADOS',
+      region: 'Normandie',
+      siret: '22140118500014',
+      structureId: 28_189,
+      typologie: 'DEPT',
+    },
+  }
+}

--- a/src/presenters/posteConseillerNumeriqueDetailPresenter.ts
+++ b/src/presenters/posteConseillerNumeriqueDetailPresenter.ts
@@ -168,6 +168,10 @@ function buildConventionsEtFinancements(
     enveloppes.push(conventionV1.enveloppe)
   }
 
+  // Invariant métier : la vue Poste n'expose que des enveloppes Conseiller Numérique.
+  // Garanti par construction : `enveloppes` n'est alimenté que par buildConventionV1/V2,
+  // et le loader (PrismaPosteConseillerNumeriqueDetailLoader) ne lit jamais de demande
+  // de subvention / enveloppe_financement FNE. Verrouillé par le test de caractérisation.
   return {
     conventions: conventionsList,
     creditsEngagesParLEtat: formatMontant(conventions.creditsEngagesParLEtat),

--- a/src/presenters/structurePresenter.test.ts
+++ b/src/presenters/structurePresenter.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatMontant } from './shared/number'
+import { structurePresenter } from './structurePresenter'
+import { epochTime, epochTimePlusOneDay } from './testHelper'
+import { UneStructureReadModel } from '@/use-cases/queries/RecupererUneStructure'
+
+describe('structure presenter : caractérisation des enveloppes (Conum ET FNE, aucun filtrage)', () => {
+  it('cas mixte : les 4 enveloppes Conum + FNE sont toutes restituées avec couleurs cycliques', () => {
+    // GIVEN
+    const readModel = structureReadModel([
+      { libelle: 'Conseiller Numérique - initiale - État', montant: 1_200_009, type: 'conseiller_numerique' },
+      { libelle: 'Conseiller Numérique - Renouvellement - État', montant: 665_000, type: 'conseiller_numerique' },
+      { libelle: 'Ingénierie France Numérique Ensemble - 2024 - État', montant: 49_100, type: 'fne' },
+      { libelle: 'Formation Aidant Numérique/Aidants Connect - 2024 - État', montant: 20_000, type: 'fne' },
+    ])
+
+    // WHEN
+    const viewModel = structurePresenter(readModel, epochTimePlusOneDay)
+
+    // THEN
+    expect(viewModel.conventionsEtFinancements.enveloppes).toStrictEqual([
+      {
+        color: 'france',
+        libelle: 'Conseiller Numérique - initiale - État',
+        montant: 1_200_009,
+        montantFormate: formatMontant(1_200_009),
+      },
+      {
+        color: 'menthe',
+        libelle: 'Conseiller Numérique - Renouvellement - État',
+        montant: 665_000,
+        montantFormate: formatMontant(665_000),
+      },
+      {
+        color: 'tilleul',
+        libelle: 'Ingénierie France Numérique Ensemble - 2024 - État',
+        montant: 49_100,
+        montantFormate: formatMontant(49_100),
+      },
+      {
+        color: 'france',
+        libelle: 'Formation Aidant Numérique/Aidants Connect - 2024 - État',
+        montant: 20_000,
+        montantFormate: formatMontant(20_000),
+      },
+    ])
+  })
+
+  it('cas FNE pur : seules les enveloppes FNE sont restituées (aucune exclusion par type)', () => {
+    // GIVEN
+    const readModel = structureReadModel([
+      { libelle: 'Ingénierie France Numérique Ensemble - 2024 - État', montant: 47_200, type: 'fne' },
+      { libelle: 'Formation Aidant Numérique/Aidants Connect - 2024 - État', montant: 20_000, type: 'fne' },
+    ])
+
+    // WHEN
+    const viewModel = structurePresenter(readModel, epochTimePlusOneDay)
+
+    // THEN
+    expect(viewModel.conventionsEtFinancements.enveloppes.map((enveloppe) => enveloppe.libelle)).toStrictEqual([
+      'Ingénierie France Numérique Ensemble - 2024 - État',
+      'Formation Aidant Numérique/Aidants Connect - 2024 - État',
+    ])
+    expect(viewModel.conventionsEtFinancements.creditsEngagesParLEtat).toBe(formatMontant(67_200))
+  })
+})
+
+function structureReadModel(
+  enveloppes: ReadonlyArray<{ libelle: string; montant: number; type: 'conseiller_numerique' | 'fne' }>
+): UneStructureReadModel {
+  const creditsEngagesParLEtat = enveloppes.reduce((somme, enveloppe) => somme + enveloppe.montant, 0)
+
+  return {
+    aidantsEtMediateurs: {
+      liste: [],
+      totalAidant: 0,
+      totalCoordinateur: 0,
+      totalMediateur: 0,
+    },
+    contacts: [],
+    contratsRattaches: [],
+    conventionsEtFinancements: {
+      conventions: [],
+      creditsEngagesParLEtat,
+      enveloppes,
+      lienConventions: '#',
+    },
+    identite: {
+      adresse: '12 Rue Saint-Laurent, 14000 Caen',
+      codePostal: '14000',
+      commune: 'Caen',
+      departement: 'Calvados',
+      editeur: 'carto',
+      edition: epochTime,
+      nom: 'DEPARTEMENT DU CALVADOS',
+      region: 'Normandie',
+      siret: '22140118500014',
+      typologie: 'DEPT',
+    },
+    role: {
+      feuillesDeRoute: [],
+      gouvernances: [],
+      membreDepuisLe: undefined,
+    },
+    structureId: 28189,
+  }
+}

--- a/src/presenters/testHelper.ts
+++ b/src/presenters/testHelper.ts
@@ -6,7 +6,10 @@ import { GouvernanceViewModel } from './gouvernancePresenter'
 import { SessionUtilisateurViewModel } from './sessionUtilisateurPresenter'
 import { actionStatutViewModelByStatut } from './shared/action'
 import { formatMontant } from './shared/number'
+import { epochTime, epochTimeMinusOneDay, epochTimePlusOneDay } from '@/shared/testHelper'
 import { BesoinsPossible } from '@/use-cases/queries/shared/ActionReadModel'
+
+export { epochTime, epochTimeMinusOneDay, epochTimePlusOneDay }
 
 const enveloppes: ActionViewModel['enveloppes'] = [
   {

--- a/src/shared/enveloppeFinancement.test.ts
+++ b/src/shared/enveloppeFinancement.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+
+import { classifierTypeEnveloppe, estEnveloppeDeFormation, TypeEnveloppe } from './enveloppeFinancement'
+
+describe('classification des enveloppes de financement sur les libellés réels en base', () => {
+  it.each([
+    {
+      intention: 'enveloppe id 1 Plan France Relance → Conseiller Numérique',
+      libelle: 'Conseiller Numérique - Plan France Relance - État',
+      typeAttendu: 'conseiller_numerique' as TypeEnveloppe,
+    },
+    {
+      intention: 'enveloppe id 2 Renouvellement → Conseiller Numérique',
+      libelle: 'Conseiller Numérique - Renouvellement - État',
+      typeAttendu: 'conseiller_numerique' as TypeEnveloppe,
+    },
+    {
+      intention: 'enveloppe id 3 Formation Aidant Numérique → FNE',
+      libelle: 'Formation Aidant Numérique/Aidants Connect - 2024 - État',
+      typeAttendu: 'fne' as TypeEnveloppe,
+    },
+    {
+      intention: 'enveloppe id 4 Ingénierie France Numérique Ensemble → FNE',
+      libelle: 'Ingénierie France Numérique Ensemble - 2024 - État',
+      typeAttendu: 'fne' as TypeEnveloppe,
+    },
+    {
+      intention: 'libellé fantôme historique « initiale » → Conseiller Numérique',
+      libelle: 'Conseiller Numérique - initiale - État',
+      typeAttendu: 'conseiller_numerique' as TypeEnveloppe,
+    },
+  ])('classifierTypeEnveloppe : $intention', ({ libelle, typeAttendu }) => {
+    // WHEN
+    const type = classifierTypeEnveloppe(libelle)
+
+    // THEN
+    expect(type).toBe(typeAttendu)
+  })
+
+  it.each([
+    {
+      formationAttendue: false,
+      intention: 'enveloppe id 1 Plan France Relance → pas formation',
+      libelle: 'Conseiller Numérique - Plan France Relance - État',
+    },
+    {
+      formationAttendue: false,
+      intention: 'enveloppe id 2 Renouvellement → pas formation',
+      libelle: 'Conseiller Numérique - Renouvellement - État',
+    },
+    {
+      formationAttendue: true,
+      intention: 'enveloppe id 3 Formation Aidant Numérique → formation',
+      libelle: 'Formation Aidant Numérique/Aidants Connect - 2024 - État',
+    },
+    {
+      formationAttendue: false,
+      intention: 'enveloppe id 4 Ingénierie France Numérique Ensemble → pas formation',
+      libelle: 'Ingénierie France Numérique Ensemble - 2024 - État',
+    },
+  ])('estEnveloppeDeFormation : $intention', ({ formationAttendue, libelle }) => {
+    // WHEN
+    const estFormation = estEnveloppeDeFormation(libelle)
+
+    // THEN
+    expect(estFormation).toBe(formationAttendue)
+  })
+})

--- a/src/shared/enveloppeFinancement.ts
+++ b/src/shared/enveloppeFinancement.ts
@@ -1,0 +1,22 @@
+/**
+ * Classification métier des enveloppes de financement.
+ *
+ * Deux types d'enveloppes : « Conseiller Numérique » (financement des postes conum)
+ * et « FNE » (France Numérique Ensemble, financement des actions des feuilles de route).
+ *
+ * La règle est dérivée des règles déjà présentes dans le code (préfixe de libellé,
+ * équivalent au filtre SQL `libelle LIKE 'Conseiller Numérique%'`) afin d'être
+ * strictement équivalente au comportement existant.
+ */
+
+export type TypeEnveloppe = 'conseiller_numerique' | 'fne'
+
+const PREFIXE_CONSEILLER_NUMERIQUE = 'Conseiller Numérique'
+
+export function classifierTypeEnveloppe(libelle: string): TypeEnveloppe {
+  return libelle.startsWith(PREFIXE_CONSEILLER_NUMERIQUE) ? 'conseiller_numerique' : 'fne'
+}
+
+export function estEnveloppeDeFormation(libelle: string): boolean {
+  return /formation/i.test(libelle)
+}

--- a/src/use-cases/queries/RecupererUneStructure.ts
+++ b/src/use-cases/queries/RecupererUneStructure.ts
@@ -1,5 +1,6 @@
 import { QueryHandler } from '../QueryHandler'
 import { StatutContrat } from '@/domain/Contrat'
+import { TypeEnveloppe } from '@/shared/enveloppeFinancement'
 
 export class RecupererUneStructure implements QueryHandler<Query, UneStructureReadModel> {
   readonly #uneStructureLoader: UneStructureLoader
@@ -63,6 +64,7 @@ export type UneStructureReadModel = Readonly<{
     enveloppes: ReadonlyArray<{
       libelle: string
       montant: number
+      type: TypeEnveloppe
     }>
     lienConventions: string
   }>


### PR DESCRIPTION
…tier (#1420)

Le ticket #1420 signalait des financements FNE affichés sur la page de détail d'un poste Conseiller Numérique. Vérification faite (code + tests empiriques 3 rôles) : cette page n'affiche jamais de FNE, son loader ne requête que les conventions Conseiller Numérique. La demande reposait sur une confusion avec la fiche structure (qui agrège légitimement CN + FNE).

Aucune correction métier nécessaire. À la place, refonte de la modélisation pour lever l'ambiguïté, à comportement et rendu strictement identiques (vérifié test par test et empiriquement, 0-pixel) :

- nouveau module @/shared/enveloppeFinancement : classifierTypeEnveloppe et estEnveloppeDeFormation, règle canonique unique, dérivée des règles existantes (équivalence par construction)
- remplacement des tests de chaîne dispersés (Action, MembresGouvernance, PrismaUneStructureLoader) par le module partagé ; LIKE SQL documenté
- type d'enveloppe explicite (additif) porté par le ReadModel RecupererUneStructure, calculé dans le gateway
- invariant « vue Poste = Conseiller Numérique uniquement » documenté et garanti par construction (suppression d'un filtre auto-référentiel)
- 20 tests de caractérisation verrouillant le comportement

Hors lot (décidés séparément) : correction du libellé historique « initiale » -> « Plan France Relance », exposition UI du type CN/FNE.

# Contrat du dev

## Qualité

- [ ] Relire le code
- [ ] Relire le ticket
- [ ] [Relire les critères d'acceptation](https://github.com/anct-cnum/suite-gestionnaire-numerique/discussions/252)
- [ ] Vérifier le coverage
- [ ] Recetter l'application
- [ ] Ajouter des variables d'environnement sur la production au besoin

## Accessibilité

- [ ] Vérifier l'accessibilité avec a11y.css, WAVE, Axe, headingMap
- [ ] Naviguer au clavier
- [ ] Vérifier le constraste en mode sombre

## Facultatif mais fortement conseillé

- [ ] Lancer les tests de mutation

> **Et n'oublie pas de vérifier ce que tu as fait en production !**
