### PR TITLE
feat(structure): libellé identité non éditable via l'Annuaire des entreprises (#1421)

### DIFF
--- a/src/components/Structure/StructureIdentite.tsx
+++ b/src/components/Structure/StructureIdentite.tsx
@@ -52,6 +52,16 @@ export default function StructureIdentite({ identite }: Props): ReactElement {
           <div style={{ flex: '1 0 0' }} />
         </div>
       </article>
+      <div className="fr-notice fr-notice--info border-radius fr-mt-3w">
+        <div className="fr-notice__body fr-px-3w">
+          <p className="fr-notice__title fr-text--sm fr-text--regular">
+            <span className="fr-text-default--grey">
+              Les informations d’identité de la structure sont récupérées via l’Annuaire des entreprises et ne sont pas
+              éditables
+            </span>
+          </p>
+        </div>
+      </div>
     </section>
   )
 }


### PR DESCRIPTION
## Contexte

Ticket #1421 — Fiche structure, section « Identité ».

Ajout d'un libellé précisant que les informations d'identité de la structure sont récupérées via l'Annuaire des entreprises et ne sont pas éditables.

## Périmètre

Le libellé doit apparaître **uniquement** sur la fiche structure, pas sur la page d'un lieu d'inclusion. Vérifié : `StructureIdentite` n'est utilisé que par `Structure.tsx` (page `/structure/[structureId]`). La page lieu d'inclusion (`/lieu/[id]`) utilise un composant distinct (`LieuxInclusionDetails`) — aucun risque de fuite.

## Changements

`StructureIdentite` : bandeau d'information DSFR (`fr-notice--info`) ajouté en bas de la section, conforme à la maquette Figma (node `18418:27918`) — fond `#E8EDFF`, radius `8px`, icône info `#0063CB`, texte gris `#3A3A3A` Marianne 14px régulier. Style cohérent avec le bandeau des contrats en cours (#1423).

## Vérifications

- `pnpm typecheck` ✅
- `pnpm lint:ts` ✅
- Rendu vérifié sur `/structure/28189`

🤖 Generated with [Claude Code](https://claude.com/claude-code)