### PR TITLE
feat(rapports): export des rapports de situation (national/région/département, Word/PDF) (#1244)

### DIFF
--- a/post-install.sh
+++ b/post-install.sh
@@ -4,10 +4,15 @@ if [ ! -f $FILE ]; then
   cp .env $FILE
 fi
 
-if type openssl > /dev/null; then
+if grep -q '^NEXTAUTH_SECRET=' $FILE; then
+  echo "* NEXTAUTH_SECRET déjà présent dans $FILE, on ne le régénère pas. *"
+elif type openssl > /dev/null; then
   echo NEXTAUTH_SECRET=$(openssl rand -base64 32) >> $FILE
 else
   echo "******************************************************"
   echo "* Il faut que tu affectes NEXTAUTH_SECRET à la main. *"
   echo "******************************************************"
 fi
+
+# Navigateur requis par Playwright pour l'export PDF des rapports
+pnpm exec playwright install chromium

--- a/src/app/(connecte)/(avec-menu)/(default)/rapports/page.tsx
+++ b/src/app/(connecte)/(avec-menu)/(default)/rapports/page.tsx
@@ -1,0 +1,47 @@
+import { Metadata } from 'next'
+import { redirect } from 'next/navigation'
+import { ReactElement } from 'react'
+
+import departementsJson from '../../../../../../ressources/departements.json'
+import regionsJson from '../../../../../../ressources/regions.json'
+import RapportsForm from '@/components/Rapports/RapportsForm'
+import PageTitle from '@/components/shared/PageTitle/PageTitle'
+import TitleIcon from '@/components/shared/TitleIcon/TitleIcon'
+import FilAriane from '@/components/vitrine/FilAriane/FilAriane'
+import { getSession, getSessionSub } from '@/gateways/NextAuthAuthentificationGateway'
+import { PrismaMembreLoader } from '@/gateways/PrismaMembreLoader'
+import { PrismaUtilisateurLoader } from '@/gateways/PrismaUtilisateurLoader'
+import { resoudreContexte } from '@/use-cases/queries/ResoudreContexte'
+
+export const metadata: Metadata = {
+  title: 'Rapports de situation de l’inclusion numérique',
+}
+
+export default async function RapportsController(): Promise<ReactElement> {
+  const session = await getSession()
+  if (!session) {
+    redirect('/connexion')
+  }
+
+  const utilisateur = await new PrismaUtilisateurLoader().findByUid(await getSessionSub())
+  const contexte = await resoudreContexte(utilisateur, new PrismaMembreLoader())
+  if (!contexte.aCesRoles('administrateur_dispositif')) {
+    redirect('/tableau-de-bord')
+  }
+
+  const regions = [...regionsJson].sort((regionA, regionB) => regionA.nom.localeCompare(regionB.nom, 'fr'))
+  const departements = [...departementsJson]
+    .map((departement) => ({ code: departement.code, nom: departement.nom }))
+    .sort((departementA, departementB) => departementA.nom.localeCompare(departementB.nom, 'fr'))
+
+  return (
+    <>
+      <FilAriane items={[{ href: '/tableau-de-bord', label: 'Tableau de bord' }, { label: 'Rapports' }]} />
+      <PageTitle>
+        <TitleIcon icon="file-text-line" />
+        Rapports de situation de l’inclusion numérique
+      </PageTitle>
+      <RapportsForm departements={departements} regions={regions} />
+    </>
+  )
+}

--- a/src/app/api/rapport/route.ts
+++ b/src/app/api/rapport/route.ts
@@ -12,10 +12,14 @@ import {
   WidthType,
 } from 'docx'
 import { NextRequest, NextResponse } from 'next/server'
+import { chromium } from 'playwright'
 
-import { getSession } from '@/gateways/NextAuthAuthentificationGateway'
-import { PrismaRapportRegionLoader, RapportRegionReadModel } from '@/gateways/PrismaRapportRegionLoader'
+import { getSession, getSessionSub } from '@/gateways/NextAuthAuthentificationGateway'
+import { PrismaMembreLoader } from '@/gateways/PrismaMembreLoader'
+import { PrismaRapportRegionLoader, RapportPerimetre, RapportReadModel } from '@/gateways/PrismaRapportRegionLoader'
+import { PrismaUtilisateurLoader } from '@/gateways/PrismaUtilisateurLoader'
 import { BESOINS_LABELS } from '@/presenters/shared/besoins'
+import { resoudreContexte } from '@/use-cases/queries/ResoudreContexte'
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
   try {
@@ -24,26 +28,41 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       return NextResponse.json({ error: 'Non autorisé' }, { status: 403 })
     }
 
-    const codeRegion = request.nextUrl.searchParams.get('codeRegion')
-    const format = request.nextUrl.searchParams.get('format')
-
-    if (codeRegion === null || codeRegion === '') {
-      return NextResponse.json({ error: 'Le paramètre codeRegion est requis' }, { status: 400 })
+    const utilisateur = await new PrismaUtilisateurLoader().findByUid(await getSessionSub())
+    const contexte = await resoudreContexte(utilisateur, new PrismaMembreLoader())
+    if (!contexte.aCesRoles('administrateur_dispositif')) {
+      return NextResponse.json({ error: 'Non autorisé' }, { status: 403 })
     }
 
+    const perimetre = resoudrePerimetre(request.nextUrl.searchParams)
+    if (perimetre === null) {
+      return NextResponse.json({ error: 'Le périmètre géographique est invalide' }, { status: 400 })
+    }
+
+    const format = request.nextUrl.searchParams.get('format') ?? 'docx'
+
     const loader = new PrismaRapportRegionLoader()
-    const rapport = await loader.get(codeRegion)
+    const rapport = await loader.get(perimetre)
 
     if (!rapport) {
-      return NextResponse.json({ error: 'Région non trouvée' }, { status: 404 })
+      return NextResponse.json({ error: 'Périmètre non trouvé' }, { status: 404 })
+    }
+
+    if (format === 'pdf') {
+      const buffer = await genererPdf(rapport)
+      return new NextResponse(new Uint8Array(buffer), {
+        headers: {
+          'Content-Disposition': `attachment; filename="${nomFichier(rapport, 'pdf')}"`,
+          'Content-Type': 'application/pdf',
+        },
+      })
     }
 
     if (format === 'docx') {
       const buffer = await genererDocx(rapport)
-      const filename = `rapport-${rapport.region.nom.replace(/\s+/g, '-')}.docx`
       return new NextResponse(buffer, {
         headers: {
-          'Content-Disposition': `attachment; filename="${filename}"`,
+          'Content-Disposition': `attachment; filename="${nomFichier(rapport, 'docx')}"`,
           'Content-Type': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
         },
       })
@@ -60,9 +79,37 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
     return NextResponse.json(rapport)
   } catch (error) {
-    console.error('Erreur lors de la génération du rapport régional:', error)
+    console.error('Erreur lors de la génération du rapport:', error)
     return NextResponse.json({ error: 'Erreur interne du serveur' }, { status: 500 })
   }
+}
+
+function resoudrePerimetre(searchParams: URLSearchParams): null | RapportPerimetre {
+  // Rétrocompatibilité : ?codeRegion=XX
+  const codeRegion = searchParams.get('codeRegion')
+  if (codeRegion !== null && codeRegion !== '') {
+    return { code: codeRegion, type: 'region' }
+  }
+
+  const type = searchParams.get('type')
+  const code = searchParams.get('code')
+
+  if (type === 'national') {
+    return { type: 'national' }
+  }
+  if ((type === 'region' || type === 'departement') && code !== null && code !== '') {
+    return { code, type }
+  }
+  return null
+}
+
+function nomFichier(rapport: RapportReadModel, extension: string): string {
+  const slug = rapport.perimetre.nom
+    .normalize('NFD')
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+    .toLowerCase()
+  return `rapport-${slug}.${extension}`
 }
 
 const noBorder = {
@@ -91,8 +138,8 @@ function celluleNombre(texte: string, bold = false): TableCell {
   })
 }
 
-async function genererDocx(rapport: RapportRegionReadModel): Promise<Blob> {
-  const { aidantsConnect, conseillersNumeriques, franceNumerique, region } = rapport
+async function genererDocx(rapport: RapportReadModel): Promise<Blob> {
+  const { aidantsConnect, conseillersNumeriques, franceNumerique, perimetre } = rapport
   const children: Array<Paragraph | Table> = []
 
   // Section 1 — Conseillers numériques
@@ -106,7 +153,7 @@ async function genererDocx(rapport: RapportRegionReadModel): Promise<Blob> {
     new Paragraph({
       text:
         `${formaterNombre(conseillersNumeriques.total)} conseillers numériques sont déployés` +
-        ` sur l'ensemble de la Région ${region.nom}.`,
+        ` sur ${perimetre.nom}.`,
     })
   )
   children.push(
@@ -147,7 +194,7 @@ async function genererDocx(rapport: RapportRegionReadModel): Promise<Blob> {
       text:
         "Aidants Connect est le service public numérique qui protège l'aidant et l'usager" +
         " lors de l'accompagnement aux démarches en ligne." +
-        ` Dans l'ensemble de la Région ${region.nom},` +
+        ` Dans ${perimetre.nom},` +
         ` ${formaterNombre(aidantsConnect.totalHabilites)} aidants et référents sont habilités Aidants Connect,` +
         ` dont ${formaterNombre(aidantsConnect.totalDontConseillers)} conseillers numériques.`,
     })
@@ -243,6 +290,108 @@ async function genererDocx(rapport: RapportRegionReadModel): Promise<Blob> {
   return Packer.toBlob(doc)
 }
 
+async function genererPdf(rapport: RapportReadModel): Promise<Buffer> {
+  const navigateur = await chromium.launch()
+  try {
+    const page = await navigateur.newPage()
+    await page.setContent(genererHtml(rapport), { waitUntil: 'load' })
+    return await page.pdf({
+      format: 'A4',
+      margin: { bottom: '20mm', left: '15mm', right: '15mm', top: '20mm' },
+      printBackground: true,
+    })
+  } finally {
+    await navigateur.close()
+  }
+}
+
+function echapperHtml(valeur: string): string {
+  return valeur.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+}
+
+function genererHtml(rapport: RapportReadModel): string {
+  const { aidantsConnect, conseillersNumeriques, franceNumerique, perimetre } = rapport
+  const sections: Array<string> = []
+
+  const lignesConseillers = conseillersNumeriques.departements
+    .map(
+      (dep) =>
+        `<tr><td>${echapperHtml(dep.nom)}</td>` +
+        `<td class="nb">${formaterNombre(dep.nbConseillers)}</td>` +
+        `<td class="nb">${formaterNombre(dep.nbBeneficiaires)}</td></tr>`
+    )
+    .join('')
+  sections.push(
+    `<h2>Conseillers numériques</h2>` +
+      `<p>${formaterNombre(conseillersNumeriques.total)} conseillers numériques sont déployés sur ` +
+      `${echapperHtml(perimetre.nom)}.</p>` +
+      `<table><thead><tr><th>Départements</th><th class="nb">Nombre de Conseillers numériques</th>` +
+      `<th class="nb">Nombre de bénéficiaires depuis 2021</th></tr></thead>` +
+      `<tbody>${lignesConseillers}</tbody></table>`
+  )
+
+  const lignesAidants = aidantsConnect.departements
+    .map((dep) => {
+      const suffixe =
+        dep.dontConseillers > 0 ? ` dont ${formaterNombre(dep.dontConseillers)} conseillers numériques` : ''
+      return `<tr><td>${echapperHtml(dep.nom)}</td><td>${formaterNombre(dep.nbHabilites)}${suffixe}</td></tr>`
+    })
+    .join('')
+  sections.push(
+    `<h2>Déploiement d'Aidants Connect</h2>` +
+      `<p>Aidants Connect est le service public numérique qui protège l'aidant et l'usager lors de ` +
+      `l'accompagnement aux démarches en ligne. Dans ${echapperHtml(perimetre.nom)}, ` +
+      `${formaterNombre(aidantsConnect.totalHabilites)} aidants et référents sont habilités Aidants Connect, ` +
+      `dont ${formaterNombre(aidantsConnect.totalDontConseillers)} conseillers numériques.</p>` +
+      `<table><thead><tr><th>Départements</th>` +
+      `<th>Aidants et référents habilités Aidants Connect</th></tr></thead>` +
+      `<tbody>${lignesAidants}</tbody></table>`
+  )
+
+  const blocsFne: Array<string> = ['<h2>France Numérique Ensemble</h2>']
+  for (const dep of franceNumerique.departements) {
+    blocsFne.push(`<h3>Gouvernance de ${echapperHtml(dep.nom)}</h3>`)
+    if (dep.gouvernance.coporteurs.length > 0) {
+      blocsFne.push(`<p><strong>Coporteurs : </strong>${echapperHtml(dep.gouvernance.coporteurs.join(', '))}</p>`)
+    }
+    if (dep.gouvernance.membres.length > 0) {
+      blocsFne.push(`<p><strong>Membres : </strong>${echapperHtml(dep.gouvernance.membres.join(', '))}</p>`)
+    }
+    for (const fdr of dep.feuillesDeRoute) {
+      blocsFne.push(`<h4>Feuille de route ${echapperHtml(fdr.nom)}</h4>`)
+      blocsFne.push(`<p>Portée par ${echapperHtml(fdr.porteur.type)} (${echapperHtml(fdr.porteur.nom)})</p>`)
+      const items = fdr.enveloppes
+        .map((env) => {
+          const recipiendaires =
+            env.beneficiaires.length > 0 ? ` (récipiendaire : ${env.beneficiaires.join(' & ')})` : ''
+          return (
+            `<li>Enveloppe ${echapperHtml(env.type)} de ${formaterMontant(env.montant)}` +
+            `${echapperHtml(recipiendaires)}${echapperHtml(formaterBesoins(env.besoins))}</li>`
+          )
+        })
+        .join('')
+      blocsFne.push(`<ul>${items}</ul>`)
+    }
+  }
+  sections.push(blocsFne.join(''))
+
+  return (
+    `<!doctype html><html lang="fr"><head><meta charset="utf-8">` +
+    `<style>` +
+    `body{font-family:Arial,Helvetica,sans-serif;color:#161616;font-size:12px;}` +
+    `h1{color:#000091;font-size:22px;}h2{color:#000091;font-size:18px;margin-top:24px;}` +
+    `h3{font-size:15px;}h4{font-size:13px;}` +
+    `table{width:100%;border-collapse:collapse;margin:8px 0;}` +
+    `th,td{text-align:left;padding:4px 8px;border-bottom:1px solid #ddd;}` +
+    `td.nb,th.nb{text-align:right;}` +
+    `</style></head><body>` +
+    `<h1>Rapports de situation de l'inclusion numérique</h1>` +
+    `<p>Périmètre : ${echapperHtml(perimetre.nom)}.</p>` +
+    sections.join('') +
+    `</body></html>`
+  )
+}
+
 function formaterNombre(nombre: number): string {
   return nombre.toLocaleString('fr-FR')
 }
@@ -268,27 +417,25 @@ function formaterBesoins(besoins: ReadonlyArray<string>): string {
   return `, fléchée sur : ${debut} et ${labels[labels.length - 1]}.`
 }
 
-function formaterEnTexte(rapport: RapportRegionReadModel): string {
+function formaterEnTexte(rapport: RapportReadModel): string {
   const lignes: Array<string> = []
-  const regionNom = rapport.region.nom
 
-  formaterSectionConseillers(lignes, rapport, regionNom)
+  formaterSectionConseillers(lignes, rapport)
   lignes.push('')
-  formaterSectionAidants(lignes, rapport, regionNom)
+  formaterSectionAidants(lignes, rapport)
   lignes.push('')
   formaterSectionFne(lignes, rapport)
 
   return lignes.join('\n')
 }
 
-function formaterSectionConseillers(lignes: Array<string>, rapport: RapportRegionReadModel, regionNom: string): void {
-  const { conseillersNumeriques } = rapport
+function formaterSectionConseillers(lignes: Array<string>, rapport: RapportReadModel): void {
+  const { conseillersNumeriques, perimetre } = rapport
 
   lignes.push('=== Conseillers numériques ===')
   lignes.push('')
   lignes.push(
-    `${formaterNombre(conseillersNumeriques.total)} conseillers numériques sont déployés` +
-      ` sur l'ensemble de la Région ${regionNom}.`
+    `${formaterNombre(conseillersNumeriques.total)} conseillers numériques sont déployés` + ` sur ${perimetre.nom}.`
   )
   lignes.push('')
 
@@ -314,15 +461,15 @@ function formaterSectionConseillers(lignes: Array<string>, rapport: RapportRegio
   }
 }
 
-function formaterSectionAidants(lignes: Array<string>, rapport: RapportRegionReadModel, regionNom: string): void {
-  const { aidantsConnect } = rapport
+function formaterSectionAidants(lignes: Array<string>, rapport: RapportReadModel): void {
+  const { aidantsConnect, perimetre } = rapport
 
   lignes.push("=== Déploiement d'Aidants Connect ===")
   lignes.push('')
   lignes.push(
     "Aidants Connect est le service public numérique qui protège l'aidant et l'usager" +
       " lors de l'accompagnement aux démarches en ligne." +
-      ` Dans l'ensemble de la Région ${regionNom},` +
+      ` Dans ${perimetre.nom},` +
       ` ${formaterNombre(aidantsConnect.totalHabilites)} aidants et référents sont habilités Aidants Connect,` +
       ` dont ${formaterNombre(aidantsConnect.totalDontConseillers)} conseillers numériques.`
   )
@@ -342,7 +489,7 @@ function formaterSectionAidants(lignes: Array<string>, rapport: RapportRegionRea
   }
 }
 
-function formaterSectionFne(lignes: Array<string>, rapport: RapportRegionReadModel): void {
+function formaterSectionFne(lignes: Array<string>, rapport: RapportReadModel): void {
   lignes.push('=== France Numérique Ensemble ===')
 
   for (const dep of rapport.franceNumerique.departements) {

--- a/src/components/Rapports/RapportsForm.test.tsx
+++ b/src/components/Rapports/RapportsForm.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import RapportsForm from './RapportsForm'
+
+describe('formulaire de génération de rapport', () => {
+  beforeEach(() => {
+    Object.defineProperty(window.URL, 'createObjectURL', { configurable: true, value: () => '' })
+    Object.defineProperty(window.URL, 'revokeObjectURL', { configurable: true, value: () => undefined })
+    vi.spyOn(window.URL, 'createObjectURL').mockReturnValue('blob:rapport')
+    vi.spyOn(window.URL, 'revokeObjectURL').mockReturnValue(undefined)
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockReturnValue(undefined)
+  })
+
+  it('quand j’affiche le formulaire, alors National et Word sont sélectionnés par défaut', () => {
+    // WHEN
+    afficherLeFormulaire()
+
+    // THEN
+    expect(screen.getByRole('heading', { name: 'Paramètres du rapport' })).toBeInTheDocument()
+    const echelon = screen.getByRole('combobox', { name: 'Échelon géographique' })
+    expect(echelon).toHaveValue('national')
+    expect(screen.getByRole('radio', { name: 'Word (.docx)' })).toBeChecked()
+    expect(screen.getByRole('radio', { name: 'PDF' })).not.toBeChecked()
+  })
+
+  it('quand je génère un rapport national au format Word, alors l’API est appelée et le fichier est téléchargé', async () => {
+    // GIVEN
+    const fetchSpy = stubFetchOk()
+    afficherLeFormulaire()
+
+    // WHEN
+    await userEvent.click(screen.getByRole('button', { name: 'Générer le rapport' }))
+
+    // THEN
+    expect(fetchSpy).toHaveBeenCalledWith('/api/rapport?format=docx&type=national')
+    expect(window.URL.createObjectURL).toHaveBeenCalledTimes(1)
+  })
+
+  it('quand je choisis une région et le format PDF, alors l’API est appelée avec le périmètre régional', async () => {
+    // GIVEN
+    const fetchSpy = stubFetchOk()
+    afficherLeFormulaire()
+
+    // WHEN
+    await userEvent.selectOptions(screen.getByRole('combobox', { name: 'Échelon géographique' }), 'region:84')
+    await userEvent.click(screen.getByRole('radio', { name: 'PDF' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Générer le rapport' }))
+
+    // THEN
+    expect(fetchSpy).toHaveBeenCalledWith('/api/rapport?format=pdf&type=region&code=84')
+  })
+
+  it('quand l’API échoue, alors un message d’erreur est affiché', async () => {
+    // GIVEN
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({ ok: false, status: 500 } as Response)
+    afficherLeFormulaire()
+
+    // WHEN
+    await userEvent.click(screen.getByRole('button', { name: 'Générer le rapport' }))
+
+    // THEN
+    const alerte = await screen.findByRole('alert')
+    expect(alerte.textContent).toBe('La génération du rapport a échoué. Veuillez réessayer.')
+  })
+})
+
+function stubFetchOk() {
+  return vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+    blob: async () => Promise.resolve(new Blob(['contenu'])),
+    headers: { get: () => 'attachment; filename="rapport-le-territoire-national.docx"' },
+    ok: true,
+    status: 200,
+  } as unknown as Response)
+}
+
+function afficherLeFormulaire(): void {
+  render(<RapportsForm departements={[{ code: '01', nom: 'Ain' }]} regions={[{ code: '84', nom: 'Auvergne' }]} />)
+}

--- a/src/components/Rapports/RapportsForm.tsx
+++ b/src/components/Rapports/RapportsForm.tsx
@@ -1,0 +1,160 @@
+'use client'
+
+import { ReactElement, SyntheticEvent, useId, useState } from 'react'
+
+import SpinnerSimple from '../shared/Spinner/SpinnerSimple'
+
+type TerritoireOption = Readonly<{
+  code: string
+  nom: string
+}>
+
+type Props = Readonly<{
+  departements: ReadonlyArray<TerritoireOption>
+  regions: ReadonlyArray<TerritoireOption>
+}>
+
+const ECHELON_NATIONAL = 'national'
+
+export default function RapportsForm({ departements, regions }: Props): ReactElement {
+  const echelonId = useId()
+  const formatDocxId = useId()
+  const formatPdfId = useId()
+  const [echelon, setEchelon] = useState(ECHELON_NATIONAL)
+  const [format, setFormat] = useState<'docx' | 'pdf'>('docx')
+  const [enCours, setEnCours] = useState(false)
+  const [erreur, setErreur] = useState<null | string>(null)
+
+  async function genererLeRapport(event: SyntheticEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault()
+    setErreur(null)
+    setEnCours(true)
+    try {
+      const params = new URLSearchParams({ format })
+      if (echelon === ECHELON_NATIONAL) {
+        params.set('type', 'national')
+      } else {
+        const [type, code] = echelon.split(':')
+        params.set('type', type)
+        params.set('code', code)
+      }
+
+      const response = await fetch(`/api/rapport?${params.toString()}`)
+      if (!response.ok) {
+        throw new Error(`Statut ${response.status}`)
+      }
+
+      const blob = await response.blob()
+      const lienTelechargement = window.URL.createObjectURL(blob)
+      const lien = document.createElement('a')
+      lien.href = lienTelechargement
+      lien.download = nomFichier(response.headers.get('content-disposition'), format)
+      document.body.appendChild(lien)
+      lien.click()
+      document.body.removeChild(lien)
+      window.URL.revokeObjectURL(lienTelechargement)
+    } catch (error) {
+      console.error('Erreur lors de la génération du rapport :', error)
+      setErreur('La génération du rapport a échoué. Veuillez réessayer.')
+    } finally {
+      setEnCours(false)
+    }
+  }
+
+  return (
+    <section
+      className="fr-p-4w fr-mt-4w"
+      style={{ border: '1px solid var(--border-default-grey)', borderRadius: '8px' }}
+    >
+      <h2 className="fr-h6">Paramètres du rapport</h2>
+      <hr />
+      <form onSubmit={genererLeRapport}>
+        <div className="fr-select-group" style={{ maxWidth: '512px' }}>
+          <label className="fr-label" htmlFor={echelonId}>
+            Échelon géographique
+          </label>
+          <select
+            className="fr-select"
+            disabled={enCours}
+            id={echelonId}
+            onChange={(event) => {
+              setEchelon(event.target.value)
+            }}
+            value={echelon}
+          >
+            <option value={ECHELON_NATIONAL}>National</option>
+            <optgroup label="Région">
+              {regions.map((region) => (
+                <option key={region.code} value={`region:${region.code}`}>
+                  {region.nom}
+                </option>
+              ))}
+            </optgroup>
+            <optgroup label="Département">
+              {departements.map((departement) => (
+                <option key={departement.code} value={`departement:${departement.code}`}>
+                  {departement.nom}
+                </option>
+              ))}
+            </optgroup>
+          </select>
+        </div>
+
+        <fieldset className="fr-fieldset" disabled={enCours}>
+          <legend className="fr-fieldset__legend fr-text--regular" id="formats-export-legend">
+            Formats d’export
+          </legend>
+          <div className="fr-fieldset__content">
+            <div className="fr-radio-group">
+              <input
+                checked={format === 'docx'}
+                id={formatDocxId}
+                name="format"
+                onChange={() => {
+                  setFormat('docx')
+                }}
+                type="radio"
+                value="docx"
+              />
+              <label className="fr-label" htmlFor={formatDocxId}>
+                Word (.docx)
+              </label>
+            </div>
+            <div className="fr-radio-group">
+              <input
+                checked={format === 'pdf'}
+                id={formatPdfId}
+                name="format"
+                onChange={() => {
+                  setFormat('pdf')
+                }}
+                type="radio"
+                value="pdf"
+              />
+              <label className="fr-label" htmlFor={formatPdfId}>
+                PDF
+              </label>
+            </div>
+          </div>
+        </fieldset>
+
+        {erreur === null ? null : (
+          <div className="fr-alert fr-alert--error fr-alert--sm fr-mb-2w" role="alert">
+            <p>{erreur}</p>
+          </div>
+        )}
+
+        <button className="fr-btn fr-btn--icon-left fr-icon-download-line" disabled={enCours} type="submit">
+          Générer le rapport
+        </button>
+
+        {enCours ? <SpinnerSimple text="Génération du rapport en cours…" /> : null}
+      </form>
+    </section>
+  )
+}
+
+function nomFichier(contentDisposition: null | string, format: string): string {
+  const correspondance = contentDisposition?.match(/filename="([^"]+)"/)
+  return correspondance ? correspondance[1] : `rapport.${format}`
+}

--- a/src/components/transverse/MenuLateral/MenuLateral.test.tsx
+++ b/src/components/transverse/MenuLateral/MenuLateral.test.tsx
@@ -157,6 +157,37 @@ describe('menu lateral', () => {
     expect(rapportsEtStatistiques).not.toBeInTheDocument()
     const lienStatistiques = within(nav).queryByRole('link', { name: 'Statistiques' })
     expect(lienStatistiques).not.toBeInTheDocument()
+    const lienRapports = within(nav).queryByRole('link', { name: 'Rapports' })
+    expect(lienRapports).not.toBeInTheDocument()
+  })
+
+  it("étant super admin, quand j'affiche le menu latéral, alors le lien Rapports s'affiche", () => {
+    // WHEN
+    render(
+      <menuActifContext.Provider value="/">
+        <MenuLateral contexte={contexteSuperAdmin} />
+      </menuActifContext.Provider>
+    )
+
+    // THEN
+    const nav = screen.getByRole('navigation', { name: 'Menu inclusion numérique' })
+    const lienRapports = within(nav).getByRole('link', { name: 'Rapports' })
+    expect(lienRapports).toHaveAttribute('href', '/rapports')
+  })
+
+  it("étant administrateur dispositif non super admin, quand j'affiche le menu latéral, alors Rapports s'affiche mais pas Statistiques", () => {
+    // WHEN
+    render(
+      <menuActifContext.Provider value="/">
+        <MenuLateral contexte={new Contexte('administrateur_dispositif', [{ type: 'france' }])} />
+      </menuActifContext.Provider>
+    )
+
+    // THEN
+    const nav = screen.getByRole('navigation', { name: 'Menu inclusion numérique' })
+    expect(within(nav).getByText('RAPPORTS ET STATISTIQUES', { selector: 'p' })).toBeInTheDocument()
+    expect(within(nav).getByRole('link', { name: 'Rapports' })).toHaveAttribute('href', '/rapports')
+    expect(within(nav).queryByRole('link', { name: 'Statistiques' })).not.toBeInTheDocument()
   })
 
   it("étant n'importe qui, quand j'affiche le menu latéral, alors la section ORGANISATION s'affiche avec Mon équipe", () => {

--- a/src/components/transverse/MenuLateral/registreMenus.ts
+++ b/src/components/transverse/MenuLateral/registreMenus.ts
@@ -69,9 +69,16 @@ const sectionAVenir: Section = {
 const sectionRapportsEtStatistiques: Section = {
   menus: [
     {
+      icon: 'file-text-line',
+      label: 'Rapports',
+      url: () => '/rapports',
+      visible: (contexte) => contexte.aCesRoles('administrateur_dispositif'),
+    },
+    {
       icon: 'line-chart-line',
       label: 'Statistiques',
       url: () => '/statistiques',
+      visible: (contexte) => contexte.estSuperAdmin(),
     },
   ],
   titre: 'RAPPORTS ET STATISTIQUES',
@@ -82,7 +89,7 @@ export function sectionsParContexte(contexte: Contexte): ReadonlyArray<Section> 
 
   sections.push(sectionPilotageParContexte(contexte))
 
-  if (contexte.estSuperAdmin()) {
+  if (contexte.estSuperAdmin() || contexte.aCesRoles('administrateur_dispositif')) {
     sections.push(sectionRapportsEtStatistiques)
   }
 

--- a/src/gateways/PrismaRapportRegionLoader.ts
+++ b/src/gateways/PrismaRapportRegionLoader.ts
@@ -1,5 +1,11 @@
+import { Prisma } from '@prisma/client'
+
 import { reportLoaderError } from './shared/sentryErrorReporter'
 import prisma from '../../prisma/prismaClient'
+
+export type RapportPerimetre =
+  | Readonly<{ code: string; type: 'departement' | 'region' }>
+  | Readonly<{ type: 'national' }>
 
 export type AidantsDepartement = Readonly<{
   code: string
@@ -15,7 +21,7 @@ export type ConseillersDepartement = Readonly<{
   nom: string
 }>
 
-export type RapportRegionReadModel = Readonly<{
+export type RapportReadModel = Readonly<{
   aidantsConnect: Readonly<{
     departements: ReadonlyArray<AidantsDepartement>
     totalDontConseillers: number
@@ -28,28 +34,24 @@ export type RapportRegionReadModel = Readonly<{
   franceNumerique: Readonly<{
     departements: ReadonlyArray<FneDepartement>
   }>
-  region: Readonly<{ code: string; nom: string }>
+  perimetre: Readonly<{ nom: string; type: 'departement' | 'national' | 'region' }>
 }>
 
 export class PrismaRapportRegionLoader {
-  async get(codeRegion: string): Promise<null | RapportRegionReadModel> {
+  async get(perimetre: RapportPerimetre): Promise<null | RapportReadModel> {
     try {
-      const regionRows = await prisma.$queryRaw<Array<RegionRow>>`
-        SELECT r.nom
-        FROM min.region r
-        WHERE r.code = ${codeRegion}
-      `
-
-      if (regionRows.length === 0) {
+      const nom = await this.#resoudreNomPerimetre(perimetre)
+      if (nom === null) {
         return null
       }
 
+      const filtreGeo = this.#filtreGeo(perimetre)
       const [conseillers, beneficiaires, aidants, fneRows, membresRows] = await Promise.all([
-        this.#queryConseillers(codeRegion),
-        this.#queryBeneficiaires(codeRegion),
-        this.#queryAidants(codeRegion),
-        this.#queryFne(codeRegion),
-        this.#queryMembresGouvernance(codeRegion),
+        this.#queryConseillers(filtreGeo),
+        this.#queryBeneficiaires(filtreGeo),
+        this.#queryAidants(filtreGeo),
+        this.#queryFne(filtreGeo),
+        this.#queryMembresGouvernance(filtreGeo),
       ])
 
       const conseillersNumeriques = this.#buildConseillers(conseillers, beneficiaires)
@@ -60,13 +62,13 @@ export class PrismaRapportRegionLoader {
         aidantsConnect,
         conseillersNumeriques,
         franceNumerique,
-        region: { code: codeRegion, nom: regionRows[0].nom },
+        perimetre: { nom, type: perimetre.type },
       }
     } catch (error) {
       console.error('[PrismaRapportRegionLoader]', error)
       reportLoaderError(error, 'PrismaRapportRegionLoader', {
-        codeRegion,
         operation: 'get',
+        perimetre: JSON.stringify(perimetre),
       })
       return null
     }
@@ -122,7 +124,7 @@ export class PrismaRapportRegionLoader {
     }
   }
 
-  #buildAidants(rows: Array<AidantsDepartementRow>): RapportRegionReadModel['aidantsConnect'] {
+  #buildAidants(rows: Array<AidantsDepartementRow>): RapportReadModel['aidantsConnect'] {
     const departements = rows.map((row) => ({
       code: row.code_departement,
       dontConseillers: Number(row.dont_conseillers),
@@ -138,7 +140,7 @@ export class PrismaRapportRegionLoader {
   #buildConseillers(
     conseillerRows: Array<ConseillersDepartementRow>,
     beneficiaireRows: Array<BeneficiairesDepartementRow>
-  ): RapportRegionReadModel['conseillersNumeriques'] {
+  ): RapportReadModel['conseillersNumeriques'] {
     const beneficiairesParDep = new Map(
       beneficiaireRows.map((row) => [row.code_departement, Number(row.nb_beneficiaires)])
     )
@@ -153,7 +155,7 @@ export class PrismaRapportRegionLoader {
     return { departements, total }
   }
 
-  #buildFne(rows: Array<FneRow>, membresRows: Array<MembreGouvernanceRow>): RapportRegionReadModel['franceNumerique'] {
+  #buildFne(rows: Array<FneRow>, membresRows: Array<MembreGouvernanceRow>): RapportReadModel['franceNumerique'] {
     const membresParDep = this.#buildGouvernanceMembres(membresRows)
     const departementsMap = new Map<string, DepartementAccumulator>()
 
@@ -215,7 +217,17 @@ export class PrismaRapportRegionLoader {
     return nom.charAt(0).toUpperCase() + nom.slice(1).toLowerCase()
   }
 
-  async #queryAidants(codeRegion: string): Promise<Array<AidantsDepartementRow>> {
+  #filtreGeo(perimetre: RapportPerimetre): Prisma.Sql {
+    if (perimetre.type === 'national') {
+      return Prisma.sql`TRUE`
+    }
+    if (perimetre.type === 'region') {
+      return Prisma.sql`d.region_code = ${perimetre.code}`
+    }
+    return Prisma.sql`d.code = ${perimetre.code}`
+  }
+
+  async #queryAidants(filtre: Prisma.Sql): Promise<Array<AidantsDepartementRow>> {
     return prisma.$queryRaw<Array<AidantsDepartementRow>>`
       SELECT
         d.code AS code_departement,
@@ -227,14 +239,14 @@ export class PrismaRapportRegionLoader {
       JOIN main.structure st ON st.id = pa.structure_id
       JOIN main.adresse a ON a.id = st.adresse_id
       JOIN min.departement d ON d.code = a.departement
-      WHERE d.region_code = ${codeRegion}
+      WHERE ${filtre}
         AND pe.labellisation_aidant_connect = true
       GROUP BY d.code, d.nom
       ORDER BY d.code
     `
   }
 
-  async #queryBeneficiaires(codeRegion: string): Promise<Array<BeneficiairesDepartementRow>> {
+  async #queryBeneficiaires(filtre: Prisma.Sql): Promise<Array<BeneficiairesDepartementRow>> {
     return prisma.$queryRaw<Array<BeneficiairesDepartementRow>>`
       SELECT
         d.code AS code_departement,
@@ -243,12 +255,12 @@ export class PrismaRapportRegionLoader {
       JOIN main.structure st ON st.id = ac.structure_id
       JOIN main.adresse a ON a.id = st.adresse_id
       JOIN min.departement d ON d.code = a.departement
-      WHERE d.region_code = ${codeRegion}
+      WHERE ${filtre}
       GROUP BY d.code
     `
   }
 
-  async #queryConseillers(codeRegion: string): Promise<Array<ConseillersDepartementRow>> {
+  async #queryConseillers(filtre: Prisma.Sql): Promise<Array<ConseillersDepartementRow>> {
     return prisma.$queryRaw<Array<ConseillersDepartementRow>>`
       SELECT
         d.code AS code_departement,
@@ -258,14 +270,14 @@ export class PrismaRapportRegionLoader {
       JOIN main.structure st ON st.id = v.structure_id
       JOIN main.adresse a ON a.id = st.adresse_id
       JOIN min.departement d ON d.code = a.departement
-      WHERE d.region_code = ${codeRegion}
+      WHERE ${filtre}
         AND v.etat = 'occupe'
       GROUP BY d.code, d.nom
       ORDER BY d.code
     `
   }
 
-  async #queryFne(codeRegion: string): Promise<Array<FneRow>> {
+  async #queryFne(filtre: Prisma.Sql): Promise<Array<FneRow>> {
     return prisma.$queryRaw<Array<FneRow>>`
       SELECT
         d.code AS departement_code,
@@ -288,14 +300,14 @@ export class PrismaRapportRegionLoader {
       LEFT JOIN min.beneficiaire_subvention bs ON bs.demande_de_subvention_id = ds.id
       LEFT JOIN min.membre benef_mb ON benef_mb.id = bs.membre_id
       LEFT JOIN main.structure benef_st ON benef_st.id = benef_mb.structure_id
-      WHERE d.region_code = ${codeRegion}
+      WHERE ${filtre}
       GROUP BY d.code, d.nom, fdr.id, fdr.nom, porteur_st.nom, porteur_mb.type,
         ef.libelle, ds.subvention_demandee, ds.statut, act.besoins
       ORDER BY d.code, fdr.id, ef.libelle
     `
   }
 
-  async #queryMembresGouvernance(codeRegion: string): Promise<Array<MembreGouvernanceRow>> {
+  async #queryMembresGouvernance(filtre: Prisma.Sql): Promise<Array<MembreGouvernanceRow>> {
     return prisma.$queryRaw<Array<MembreGouvernanceRow>>`
       SELECT
         m.gouvernance_departement_code AS departement_code,
@@ -304,10 +316,28 @@ export class PrismaRapportRegionLoader {
       FROM min.membre m
       JOIN min.departement d ON d.code = m.gouvernance_departement_code
       JOIN main.structure st ON st.id = m.structure_id
-      WHERE d.region_code = ${codeRegion}
+      WHERE ${filtre}
         AND m.statut = 'confirme'
       ORDER BY d.code, st.nom
     `
+  }
+
+  async #resoudreNomPerimetre(perimetre: RapportPerimetre): Promise<null | string> {
+    if (perimetre.type === 'national') {
+      return "l'ensemble du territoire national"
+    }
+
+    if (perimetre.type === 'region') {
+      const rows = await prisma.$queryRaw<Array<NomRow>>`
+        SELECT r.nom FROM min.region r WHERE r.code = ${perimetre.code}
+      `
+      return rows.length === 0 ? null : `l'ensemble de la Région ${rows[0].nom}`
+    }
+
+    const rows = await prisma.$queryRaw<Array<NomRow>>`
+      SELECT d.nom FROM min.departement d WHERE d.code = ${perimetre.code}
+    `
+    return rows.length === 0 ? null : `l'ensemble du Département ${rows[0].nom}`
   }
 }
 
@@ -371,7 +401,7 @@ type MembreGouvernanceRow = Readonly<{
   structure_nom: string
 }>
 
-type RegionRow = Readonly<{
+type NomRow = Readonly<{
   nom: string
 }>
 


### PR DESCRIPTION
## Contexte

Ticket #1244 — finalisation de la fonctionnalité « Rapports » (données et API régionale déjà en place). Implémentation du design Figma : page d'export des rapports de situation de l'inclusion numérique.

## Changements

- **Page `/rapports`** : fil d'Ariane, titre « Rapports de situation de l'inclusion numérique », réservée aux `administrateur_dispositif` (redirection sinon).
- **Menu** : entrée « Rapports » dans la section RAPPORTS ET STATISTIQUES, visible uniquement pour `administrateur_dispositif`.
- **Formulaire** (`RapportsForm`) : sélecteur d'échelon (National par défaut, optgroups Régions/Départements), format Word (.docx, par défaut) ou PDF, bouton « Générer le rapport », spinner de chargement, téléchargement du fichier, gestion d'erreur.
- **Loader** généralisé : périmètre `national | region | departement` (filtre SQL dynamique), libellé de périmètre dans le ReadModel.
- **Route `/api/rapport`** : params `type`/`code` (rétrocompat `codeRegion`), contrôle d'accès `administrateur_dispositif`, export **PDF via Playwright**, phrasés docx/texte/HTML neutralisés.
- **`post-install.sh`** : `NEXTAUTH_SECRET` non régénéré s'il est déjà présent (corrige l'empilement de secrets / `JWT_SESSION_ERROR`) + `playwright install chromium`.

## Tests

- `RapportsForm.test.tsx` (défauts, génération Word national, périmètre régional + PDF, erreur API).
- `MenuLateral.test.tsx` : visibilité du lien Rapports (super admin, admin non super, non admin).
- `tsc`, `eslint --max-warnings=0`, `prettier --check` OK sur les fichiers modifiés.

## Critères d'acceptation

- [x] Section « Rapports » accessible avec le bon titre
- [x] Sélection de l'échelon géographique (National / Région / Département)
- [x] Word sélectionné par défaut, choix Word/PDF
- [x] Bouton « Générer le rapport » déclenche la génération et le téléchargement
- [x] Fichier conforme au format choisi, données cohérentes avec le territoire
- [x] Indicateur de chargement
- [x] Réservé aux administrateurs

## Prérequis déploiement

`pnpm exec playwright install chromium` requis sur tout environnement servant l'export PDF (ajouté à `post-install.sh` pour le local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
