### PR TITLE
feat(tableau-de-bord): refondre les encarts Financements FNE et Conse…

### DIFF
--- a/src/components/TableauDeBord/FinancementsAdmin.test.tsx
+++ b/src/components/TableauDeBord/FinancementsAdmin.test.tsx
@@ -1,0 +1,62 @@
+import { screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import FinancementsAdmin from './FinancementsAdmin'
+import { renderComponent } from '../testHelper'
+import { FinancementAdminViewModel } from '@/presenters/tableauDeBord/financementAdminPresenter'
+
+describe('financements admin', () => {
+  it('quand le view model est valide alors les deux encarts FNE et Conseiller Numérique sont affichés', () => {
+    // GIVEN
+    const viewModel = financementAdminViewModelFactory()
+
+    // WHEN
+    renderComponent(
+      <FinancementsAdmin financementViewModel={viewModel} lienFinancements="/gouvernance/01/beneficiaires" />
+    )
+
+    // THEN
+    expect(screen.getByText("Financements FNE engagés par l'État")).toBeInTheDocument()
+    expect(screen.getByText('Financements Conseiller Numérique versés')).toBeInTheDocument()
+    const sousTexteFne = screen.getByText('disponible', { exact: false })
+    expect(sousTexteFne.textContent).toBe('sur 5,00 M€ disponible')
+    const sousTexteConum = screen.getByText('conventionnés sur les postes liés à la gouvernance', { exact: false })
+    expect(sousTexteConum.textContent).toBe('sur 12,00 M€ conventionnés sur les postes liés à la gouvernance')
+  })
+
+  it('quand le view model est en erreur alors le message d’erreur est affiché', () => {
+    // GIVEN
+    const viewModel = {
+      message: 'Impossible de récupérer les données de financement admin',
+      type: 'error',
+    } as const
+
+    // WHEN
+    renderComponent(
+      <FinancementsAdmin financementViewModel={viewModel} lienFinancements="/gouvernance/01/beneficiaires" />
+    )
+
+    // THEN
+    expect(screen.getByText('Impossible de récupérer les données de financement admin')).toBeInTheDocument()
+  })
+})
+
+function financementAdminViewModelFactory(): FinancementAdminViewModel {
+  return {
+    conseillerNumerique: {
+      conventionne: '12,00 M€',
+      verse: '9,00 M€',
+    },
+    fneDisponible: '5,00 M€',
+    fneEngage: '3,20 M€',
+    nombreDeFinancementsEngagesParLEtat: 7,
+    ventilationSubventionsParEnveloppe: [
+      {
+        color: '#000091',
+        label: 'Ingénierie France Numérique Ensemble - 2024 - État',
+        pourcentageConsomme: 64,
+        total: '3,20 M€',
+      },
+    ],
+  }
+}

--- a/src/components/TableauDeBord/FinancementsAdmin.tsx
+++ b/src/components/TableauDeBord/FinancementsAdmin.tsx
@@ -66,25 +66,26 @@ export default function FinancementsAdmin({
         <div className="fr-col background-blue-france fr-p-4w fr-mr-4w">
           <div className={`${styles.indicateurValeur} fr-m-0`}>
             <TitleIcon background="white" icon="download-line" />
-            {financementViewModel.montantTotalEnveloppes}
+            {financementViewModel.fneEngage}
           </div>
           <div className="fr-text--md fr-mb-0 fr-grid-row fr-grid-row--middle" style={{ fontWeight: 500 }}>
-            Montant global des enveloppes
+            Financements FNE engagés par l&apos;État
           </div>
           <div className="fr-text--xs color-blue-france fr-mb-0">
-            Sur {financementViewModel.nombreEnveloppes} enveloppes de financement
+            sur <span style={{ fontWeight: 700 }}>{financementViewModel.fneDisponible}</span> disponible
           </div>
         </div>
         <div className="fr-col background-blue-france fr-p-4w">
           <div className={`${styles.indicateurValeur} fr-m-0`}>
-            <TitleIcon background="white" icon="upload-line" />
-            {financementViewModel.creditsEngages}
+            <TitleIcon background="white" icon="money-euro-circle-line" />
+            {financementViewModel.conseillerNumerique.verse}
           </div>
           <div className="fr-text--md fr-mb-0 fr-grid-row fr-grid-row--middle" style={{ fontWeight: 500 }}>
-            Crédits engagés par l&apos;État
+            Financements Conseiller Numérique versés
           </div>
           <div className="fr-text--xs color-blue-france fr-mb-0">
-            Sur {financementViewModel.nombreEnveloppesUtilisees} enveloppes de financement
+            sur <span style={{ fontWeight: 700 }}>{financementViewModel.conseillerNumerique.conventionne}</span>{' '}
+            conventionnés sur les postes liés à la gouvernance
           </div>
         </div>
       </div>

--- a/src/components/TableauDeBord/FinancementsPref.test.tsx
+++ b/src/components/TableauDeBord/FinancementsPref.test.tsx
@@ -1,0 +1,58 @@
+import { screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import FinancementsPref from './FinancementsPref'
+import { renderComponent } from '../testHelper'
+import { FinancementViewModel } from '@/presenters/tableauDeBord/financementPrefPresenter'
+
+describe('financements pref', () => {
+  it('quand le view model est valide alors les deux encarts FNE et Conseiller Numérique sont affichés', () => {
+    // GIVEN
+    const viewModel = financementViewModelFactory()
+
+    // WHEN
+    renderComponent(<FinancementsPref conventionnement={viewModel} lienFinancements="/gouvernance/69/financements" />)
+
+    // THEN
+    expect(screen.getByText("Financements FNE engagés par l'État")).toBeInTheDocument()
+    expect(screen.getByText('Financements Conseiller Numérique versés')).toBeInTheDocument()
+    const sousTexteFne = screen.getByText('de votre budget global renseigné', { exact: false })
+    expect(sousTexteFne.textContent).toBe('sur 1 500 000 € de votre budget global renseigné')
+    const sousTexteConum = screen.getByText('conventionnés sur les postes liés à la gouvernance', { exact: false })
+    expect(sousTexteConum.textContent).toBe('sur 800 000 € conventionnés sur les postes liés à la gouvernance')
+  })
+
+  it('quand le view model est en erreur alors le message d’erreur est affiché', () => {
+    // GIVEN
+    const viewModel = {
+      message: 'Impossible de récupérer les données de financement',
+      type: 'error',
+    } as const
+
+    // WHEN
+    renderComponent(<FinancementsPref conventionnement={viewModel} lienFinancements="/gouvernance/69/financements" />)
+
+    // THEN
+    expect(screen.getByText('Impossible de récupérer les données de financement')).toBeInTheDocument()
+  })
+})
+
+function financementViewModelFactory(): FinancementViewModel {
+  return {
+    budgetGlobalRenseigne: '1 500 000 €',
+    conseillerNumerique: {
+      conventionne: '800 000 €',
+      verse: '600 000 €',
+    },
+    fneEngage: '450 000 €',
+    nombreDeFinancementsEngagesParLEtat: 3,
+    ventilationSubventionsParEnveloppe: [
+      {
+        color: '#000091',
+        label: 'Ingénierie France Numérique Ensemble - 2024 - État',
+        pourcentageConsomme: 45,
+        total: '450 000 €',
+      },
+    ],
+  }
+}

--- a/src/components/TableauDeBord/FinancementsPref.tsx
+++ b/src/components/TableauDeBord/FinancementsPref.tsx
@@ -65,29 +65,28 @@ export default function FinancementsPref({
       <div className="fr-grid-row fr-mb-4w">
         <div className="fr-col background-blue-france fr-p-4w fr-mr-4w">
           <div className={`${styles.indicateurValeur} fr-m-0`}>
-            <TitleIcon background="white" icon="money-euro-circle-line" />
-            {conventionnement.budget.total}
+            <TitleIcon background="white" icon="download-line" />
+            {conventionnement.fneEngage}
           </div>
           <div className="fr-text--md fr-mb-0 fr-grid-row fr-grid-row--middle" style={{ fontWeight: 500 }}>
-            Budget global renseigné
+            Financements FNE engagés par l&apos;État
           </div>
           <div className="fr-text--xs color-blue-france fr-mb-0">
-            pour <span style={{ fontWeight: 700 }}>{conventionnement.budget.feuillesDeRouteWording}</span>
+            sur <span style={{ fontWeight: 700 }}>{conventionnement.budgetGlobalRenseigne}</span> de votre budget global
+            renseigné
           </div>
         </div>
         <div className="fr-col background-blue-france fr-p-4w">
           <div className={`${styles.indicateurValeur} fr-m-0`}>
-            <TitleIcon background="white" icon="download-line" />
-            {conventionnement.credit.total}
+            <TitleIcon background="white" icon="money-euro-circle-line" />
+            {conventionnement.conseillerNumerique.verse}
           </div>
           <div className="fr-text--md fr-mb-0 fr-grid-row fr-grid-row--middle" style={{ fontWeight: 500 }}>
-            Financements engagés par l&apos;État
+            Financements Conseiller Numérique versés
           </div>
           <div className="fr-text--xs color-blue-france fr-mb-0">
-            Soit{' '}
-            <span style={{ fontWeight: 700 }}>
-              {conventionnement.credit.pourcentage} % de votre budget global renseigné
-            </span>
+            sur <span style={{ fontWeight: 700 }}>{conventionnement.conseillerNumerique.conventionne}</span>{' '}
+            conventionnés sur les postes liés à la gouvernance
           </div>
         </div>
       </div>

--- a/src/gateways/tableauDeBord/PrismaFinancementsAdminLoader.ts
+++ b/src/gateways/tableauDeBord/PrismaFinancementsAdminLoader.ts
@@ -1,6 +1,7 @@
 import prisma from '../../../prisma/prismaClient'
 import { reportLoaderError } from '../shared/sentryErrorReporter'
 import { StatutSubvention } from '@/domain/DemandeDeSubvention'
+import { classifierTypeEnveloppe } from '@/shared/enveloppeFinancement'
 import { FinancementAdminLoader, TableauDeBordLoaderFinancementsAdmin } from '@/use-cases/queries/RecuperFinancements'
 import { ErrorReadModel } from '@/use-cases/queries/shared/ErrorReadModel'
 
@@ -10,7 +11,7 @@ export class PrismaFinancementsAdminLoader implements FinancementAdminLoader {
 
   async get(): Promise<ErrorReadModel | TableauDeBordLoaderFinancementsAdmin> {
     try {
-      const [enveloppes, demandesAcceptees, cnConsomme] = await Promise.all([
+      const [enveloppes, demandesAcceptees, conseillerNumerique] = await Promise.all([
         this.#enveloppeDao.findMany(),
         // Récupérer toutes les demandes de subvention acceptées (en excluant zzz)
         this.#demandeDeSubventionDao.findMany({
@@ -28,21 +29,21 @@ export class PrismaFinancementsAdminLoader implements FinancementAdminLoader {
             statut: StatutSubvention.ACCEPTEE,
           },
         }),
-        prisma.$queryRaw<[{ total: bigint }]>`
-          SELECT (COALESCE(SUM(montant_subvention_v1), 0) + COALESCE(SUM(montant_subvention_v2), 0))::bigint AS total
-          FROM main.subvention
-        `,
+        this.#chargerConseillerNumerique(),
       ])
 
-      const montantTotalEnveloppes = enveloppes.reduce((acc, env) => acc + env.montant, 0)
-      const nombreEnveloppes = enveloppes.length
+      // Disponible FNE : somme des valeurs absolues du montant des enveloppes FNE.
+      const fneDisponible = enveloppes
+        .filter((enveloppe) => classifierTypeEnveloppe(enveloppe.libelle) === 'fne')
+        .reduce((acc, enveloppe) => acc + Math.abs(enveloppe.montant), 0)
 
-      // Calculer les crédits engagés et la ventilation par enveloppe (hors CN)
+      // Engagé FNE et ventilation par enveloppe : demandes de subvention acceptées
+      // (rattachées à une feuille de route, donc exclusivement FNE).
       const subventionsParEnveloppe = new Map<string, { enveloppeTotale: number; total: number }>()
-      let creditsEngagesTotal = Number(cnConsomme[0].total)
+      let fneEngage = 0
 
       demandesAcceptees.forEach((demande) => {
-        creditsEngagesTotal += demande.subventionDemandee
+        fneEngage += demande.subventionDemandee
         const label = demande.enveloppe.libelle
         const enveloppeTotale = demande.enveloppe.montant
 
@@ -53,15 +54,11 @@ export class PrismaFinancementsAdminLoader implements FinancementAdminLoader {
         })
       })
 
-      // Compter le nombre d'enveloppes utilisées
-      const nombreEnveloppesUtilisees = subventionsParEnveloppe.size
-
       return {
-        creditsEngages: creditsEngagesTotal.toString(),
-        montantTotalEnveloppes: montantTotalEnveloppes.toString(),
+        conseillerNumerique,
+        fneDisponible: fneDisponible.toString(),
+        fneEngage: fneEngage.toString(),
         nombreDeFinancementsEngagesParLEtat: demandesAcceptees.length,
-        nombreEnveloppes,
-        nombreEnveloppesUtilisees,
         ventilationSubventionsParEnveloppe: Array.from(subventionsParEnveloppe.entries()).map(([label, data]) => ({
           enveloppeTotale: data.enveloppeTotale.toString(),
           label,
@@ -76,6 +73,22 @@ export class PrismaFinancementsAdminLoader implements FinancementAdminLoader {
         message: 'Impossible de récupérer les données de financement admin',
         type: 'error',
       }
+    }
+  }
+
+  // Montants versé / conventionné de tous les postes Conseiller Numérique (niveau national).
+  // Source canonique : vue min.postes_conseiller_numerique_synthese.
+  async #chargerConseillerNumerique(): Promise<{ conventionne: string; verse: string }> {
+    const rows = await prisma.$queryRaw<Array<{ conventionne: bigint; verse: bigint }>>`
+      SELECT
+        COALESCE(SUM(v.montant_subvention_cumule), 0)::bigint AS conventionne,
+        COALESCE(SUM(v.montant_versement_cumule), 0)::bigint AS verse
+      FROM min.postes_conseiller_numerique_synthese v
+    `
+
+    return {
+      conventionne: rows[0].conventionne.toString(),
+      verse: rows[0].verse.toString(),
     }
   }
 }

--- a/src/gateways/tableauDeBord/PrismaFinancementsLoader.ts
+++ b/src/gateways/tableauDeBord/PrismaFinancementsLoader.ts
@@ -1,3 +1,5 @@
+import { Prisma } from '@prisma/client'
+
 import prisma from '../../../prisma/prismaClient'
 import { reportLoaderError } from '../shared/sentryErrorReporter'
 import { StatutSubvention } from '@/domain/DemandeDeSubvention'
@@ -9,29 +11,32 @@ export class PrismaFinancementsLoader implements FinancementLoader {
 
   async get(territoire: string): Promise<ErrorReadModel | TableauDeBordLoaderFinancements> {
     try {
-      const feuillesDeRoute = await this.#feuilleDeRouteDao.findMany({
-        include: {
-          action: {
-            include: {
-              demandesDeSubvention: {
-                include: {
-                  enveloppe: true,
+      const [feuillesDeRoute, conseillerNumerique] = await Promise.all([
+        this.#feuilleDeRouteDao.findMany({
+          include: {
+            action: {
+              include: {
+                demandesDeSubvention: {
+                  include: {
+                    enveloppe: true,
+                  },
                 },
               },
             },
           },
-        },
-        where:
-          territoire === 'France'
-            ? {
-                gouvernanceDepartementCode: {
-                  not: 'zzz',
+          where:
+            territoire === 'France'
+              ? {
+                  gouvernanceDepartementCode: {
+                    not: 'zzz',
+                  },
+                }
+              : {
+                  gouvernanceDepartementCode: territoire,
                 },
-              }
-            : {
-                gouvernanceDepartementCode: territoire,
-              },
-      })
+        }),
+        this.#chargerConseillerNumerique(territoire),
+      ])
 
       const totalBudget = feuillesDeRoute.reduce((acc, feuille) => {
         return acc + feuille.action.reduce((accAction, action) => accAction + action.budgetGlobal, 0)
@@ -59,17 +64,11 @@ export class PrismaFinancementsLoader implements FinancementLoader {
       })
 
       const totalSubventions = Array.from(subventionsParEnveloppe.values()).reduce((acc, val) => acc + val.total, 0)
-      const pourcentageCredit = totalBudget > 0 ? (totalSubventions / totalBudget) * 100 : 0
 
       return {
-        budget: {
-          feuillesDeRoute: feuillesDeRoute.length,
-          total: totalBudget.toString(),
-        },
-        credit: {
-          pourcentage: Math.round(pourcentageCredit),
-          total: totalSubventions.toString(),
-        },
+        budgetGlobalRenseigne: totalBudget.toString(),
+        conseillerNumerique,
+        fneEngage: totalSubventions.toString(),
         nombreDeFinancementsEngagesParLEtat: nombreDeFinancementsEngages,
         ventilationSubventionsParEnveloppe: Array.from(subventionsParEnveloppe.entries()).map(([label, data]) => ({
           enveloppeTotale: data.enveloppeTotale.toString(),
@@ -86,6 +85,29 @@ export class PrismaFinancementsLoader implements FinancementLoader {
         message: 'Impossible de récupérer les données de financement',
         type: 'error',
       }
+    }
+  }
+
+  // Montants versé / conventionné des postes Conseiller Numérique liés au territoire.
+  // Source canonique : vue min.postes_conseiller_numerique_synthese (dédoublonnage de
+  // l'historique des postes et cumul V1/V2 déjà gérés par la vue). Filtre territoire
+  // identique à la liste des postes conum (structure -> adresse.departement).
+  async #chargerConseillerNumerique(territoire: string): Promise<{ conventionne: string; verse: string }> {
+    const filtreTerritoire = territoire === 'France' ? Prisma.empty : Prisma.sql`WHERE a.departement = ${territoire}`
+
+    const rows = await prisma.$queryRaw<Array<{ conventionne: bigint; verse: bigint }>>`
+      SELECT
+        COALESCE(SUM(v.montant_subvention_cumule), 0)::bigint AS conventionne,
+        COALESCE(SUM(v.montant_versement_cumule), 0)::bigint AS verse
+      FROM min.postes_conseiller_numerique_synthese v
+      LEFT JOIN main.structure st ON st.id = v.structure_id
+      LEFT JOIN main.adresse a ON a.id = st.adresse_id
+      ${filtreTerritoire}
+    `
+
+    return {
+      conventionne: rows[0].conventionne.toString(),
+      verse: rows[0].verse.toString(),
     }
   }
 }

--- a/src/presenters/tableauDeBord/financementAdminPresenter.test.ts
+++ b/src/presenters/tableauDeBord/financementAdminPresenter.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+
+import { financementAdminPresenter } from './financementAdminPresenter'
+import { obtenirCouleurEnveloppe } from '../shared/enveloppe'
+import { formatMontantEnMillions } from '../shared/number'
+import { TableauDeBordLoaderFinancementsAdmin } from '@/use-cases/queries/RecuperFinancements'
+import { ErrorReadModel } from '@/use-cases/queries/shared/ErrorReadModel'
+
+describe('financement admin presenter', () => {
+  it('quand le read model est valide alors il expose le FNE engagé/disponible et le Conseiller Numérique versé/conventionné en millions', () => {
+    // GIVEN
+    const readModel: TableauDeBordLoaderFinancementsAdmin = {
+      conseillerNumerique: {
+        conventionne: '12000000',
+        verse: '9000000',
+      },
+      fneDisponible: '5000000',
+      fneEngage: '3200000',
+      nombreDeFinancementsEngagesParLEtat: 7,
+      ventilationSubventionsParEnveloppe: [
+        {
+          enveloppeTotale: '5000000',
+          label: 'Ingénierie France Numérique Ensemble - 2024 - État',
+          total: '3200000',
+        },
+      ],
+    }
+
+    // WHEN
+    const viewModel = financementAdminPresenter(readModel)
+
+    // THEN
+    expect(viewModel).toStrictEqual({
+      conseillerNumerique: {
+        conventionne: formatMontantEnMillions(12_000_000),
+        verse: formatMontantEnMillions(9_000_000),
+      },
+      fneDisponible: formatMontantEnMillions(5_000_000),
+      fneEngage: formatMontantEnMillions(3_200_000),
+      nombreDeFinancementsEngagesParLEtat: 7,
+      ventilationSubventionsParEnveloppe: [
+        {
+          color: obtenirCouleurEnveloppe('Ingénierie France Numérique Ensemble - 2024 - État'),
+          label: 'Ingénierie France Numérique Ensemble - 2024 - État',
+          pourcentageConsomme: 64,
+          total: formatMontantEnMillions(3_200_000),
+        },
+      ],
+    })
+  })
+
+  it('quand le read model est en erreur alors il retourne le view model d’erreur', () => {
+    // GIVEN
+    const readModel: ErrorReadModel = {
+      message: 'Impossible de récupérer les données de financement admin',
+      type: 'error',
+    }
+
+    // WHEN
+    const viewModel = financementAdminPresenter(readModel)
+
+    // THEN
+    expect(viewModel).toStrictEqual({
+      message: 'Impossible de récupérer les données de financement admin',
+      type: 'error',
+    })
+  })
+})

--- a/src/presenters/tableauDeBord/financementAdminPresenter.ts
+++ b/src/presenters/tableauDeBord/financementAdminPresenter.ts
@@ -15,11 +15,13 @@ export function financementAdminPresenter(
   }
 
   return {
-    creditsEngages: formatMontantEnMillions(Number(readModel.creditsEngages)),
-    montantTotalEnveloppes: formatMontantEnMillions(Number(readModel.montantTotalEnveloppes)),
+    conseillerNumerique: {
+      conventionne: formatMontantEnMillions(Number(readModel.conseillerNumerique.conventionne)),
+      verse: formatMontantEnMillions(Number(readModel.conseillerNumerique.verse)),
+    },
+    fneDisponible: formatMontantEnMillions(Number(readModel.fneDisponible)),
+    fneEngage: formatMontantEnMillions(Number(readModel.fneEngage)),
     nombreDeFinancementsEngagesParLEtat: readModel.nombreDeFinancementsEngagesParLEtat,
-    nombreEnveloppes: readModel.nombreEnveloppes,
-    nombreEnveloppesUtilisees: readModel.nombreEnveloppesUtilisees,
     ventilationSubventionsParEnveloppe: readModel.ventilationSubventionsParEnveloppe.map(
       ({ enveloppeTotale, label, total }) => {
         const montantUtilise = Number(total)
@@ -38,11 +40,13 @@ export function financementAdminPresenter(
 }
 
 export type FinancementAdminViewModel = Readonly<{
-  creditsEngages: string
-  montantTotalEnveloppes: string
+  conseillerNumerique: Readonly<{
+    conventionne: string
+    verse: string
+  }>
+  fneDisponible: string
+  fneEngage: string
   nombreDeFinancementsEngagesParLEtat: number
-  nombreEnveloppes: number
-  nombreEnveloppesUtilisees: number
   ventilationSubventionsParEnveloppe: ReadonlyArray<{
     color: string
     label: string

--- a/src/presenters/tableauDeBord/financementPrefPresenter.test.ts
+++ b/src/presenters/tableauDeBord/financementPrefPresenter.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+
+import { financementsPrefPresenter } from './financementPrefPresenter'
+import { obtenirCouleurEnveloppe } from '../shared/enveloppe'
+import { formatMontant } from '../shared/number'
+import { TableauDeBordLoaderFinancements } from '@/use-cases/queries/RecuperFinancements'
+import { ErrorReadModel } from '@/use-cases/queries/shared/ErrorReadModel'
+
+describe('financements pref presenter', () => {
+  it('quand le read model est valide alors il expose les financements FNE engagés et Conseiller Numérique versés', () => {
+    // GIVEN
+    const readModel: TableauDeBordLoaderFinancements = {
+      budgetGlobalRenseigne: '1500000',
+      conseillerNumerique: {
+        conventionne: '800000',
+        verse: '600000',
+      },
+      fneEngage: '450000',
+      nombreDeFinancementsEngagesParLEtat: 3,
+      ventilationSubventionsParEnveloppe: [
+        {
+          enveloppeTotale: '1000000',
+          label: 'Ingénierie France Numérique Ensemble - 2024 - État',
+          total: '450000',
+        },
+      ],
+    }
+
+    // WHEN
+    const viewModel = financementsPrefPresenter(readModel)
+
+    // THEN
+    expect(viewModel).toStrictEqual({
+      budgetGlobalRenseigne: formatMontant(1_500_000),
+      conseillerNumerique: {
+        conventionne: formatMontant(800_000),
+        verse: formatMontant(600_000),
+      },
+      fneEngage: formatMontant(450_000),
+      nombreDeFinancementsEngagesParLEtat: 3,
+      ventilationSubventionsParEnveloppe: [
+        {
+          color: obtenirCouleurEnveloppe('Ingénierie France Numérique Ensemble - 2024 - État'),
+          label: 'Ingénierie France Numérique Ensemble - 2024 - État',
+          pourcentageConsomme: 45,
+          total: formatMontant(450_000),
+        },
+      ],
+    })
+  })
+
+  it('quand une enveloppe a un total nul alors le pourcentage consommé est zéro', () => {
+    // GIVEN
+    const readModel: TableauDeBordLoaderFinancements = {
+      budgetGlobalRenseigne: '0',
+      conseillerNumerique: {
+        conventionne: '0',
+        verse: '0',
+      },
+      fneEngage: '0',
+      nombreDeFinancementsEngagesParLEtat: 0,
+      ventilationSubventionsParEnveloppe: [
+        {
+          enveloppeTotale: '0',
+          label: 'Formation Aidant Numérique/Aidants Connect - 2024 - État',
+          total: '0',
+        },
+      ],
+    }
+
+    // WHEN
+    const viewModel = financementsPrefPresenter(readModel)
+
+    // THEN
+    expect(viewModel).toStrictEqual({
+      budgetGlobalRenseigne: formatMontant(0),
+      conseillerNumerique: {
+        conventionne: formatMontant(0),
+        verse: formatMontant(0),
+      },
+      fneEngage: formatMontant(0),
+      nombreDeFinancementsEngagesParLEtat: 0,
+      ventilationSubventionsParEnveloppe: [
+        {
+          color: obtenirCouleurEnveloppe('Formation Aidant Numérique/Aidants Connect - 2024 - État'),
+          label: 'Formation Aidant Numérique/Aidants Connect - 2024 - État',
+          pourcentageConsomme: 0,
+          total: formatMontant(0),
+        },
+      ],
+    })
+  })
+
+  it('quand le read model est en erreur alors il retourne le view model d’erreur', () => {
+    // GIVEN
+    const readModel: ErrorReadModel = {
+      message: 'Impossible de récupérer les données de financement',
+      type: 'error',
+    }
+
+    // WHEN
+    const viewModel = financementsPrefPresenter(readModel)
+
+    // THEN
+    expect(viewModel).toStrictEqual({
+      message: 'Impossible de récupérer les données de financement',
+      type: 'error',
+    })
+  })
+})

--- a/src/presenters/tableauDeBord/financementPrefPresenter.ts
+++ b/src/presenters/tableauDeBord/financementPrefPresenter.ts
@@ -15,14 +15,12 @@ export function financementsPrefPresenter(
   }
 
   return {
-    budget: {
-      feuillesDeRouteWording: `${readModel.budget.feuillesDeRoute} feuille${readModel.budget.feuillesDeRoute > 1 ? 's' : ''} de route`,
-      total: formatMontant(Number(readModel.budget.total)),
+    budgetGlobalRenseigne: formatMontant(Number(readModel.budgetGlobalRenseigne)),
+    conseillerNumerique: {
+      conventionne: formatMontant(Number(readModel.conseillerNumerique.conventionne)),
+      verse: formatMontant(Number(readModel.conseillerNumerique.verse)),
     },
-    credit: {
-      pourcentage: readModel.credit.pourcentage,
-      total: formatMontant(Number(readModel.credit.total)),
-    },
+    fneEngage: formatMontant(Number(readModel.fneEngage)),
     nombreDeFinancementsEngagesParLEtat: readModel.nombreDeFinancementsEngagesParLEtat,
     ventilationSubventionsParEnveloppe: readModel.ventilationSubventionsParEnveloppe.map(
       ({ enveloppeTotale, label, total }) => {
@@ -42,14 +40,12 @@ export function financementsPrefPresenter(
 }
 
 export type FinancementViewModel = Readonly<{
-  budget: Readonly<{
-    feuillesDeRouteWording: string
-    total: string
+  budgetGlobalRenseigne: string
+  conseillerNumerique: Readonly<{
+    conventionne: string
+    verse: string
   }>
-  credit: Readonly<{
-    pourcentage: number
-    total: string
-  }>
+  fneEngage: string
   nombreDeFinancementsEngagesParLEtat: number
   ventilationSubventionsParEnveloppe: ReadonlyArray<{
     color: string

--- a/src/use-cases/queries/RecuperFinancements.ts
+++ b/src/use-cases/queries/RecuperFinancements.ts
@@ -9,31 +9,28 @@ export interface FinancementAdminLoader {
 }
 
 export interface TableauDeBordLoaderFinancements {
-  budget: Readonly<{
-    feuillesDeRoute: number
-    total: string
-  }>
-  credit: Readonly<{
-    pourcentage: number
-    total: string
-  }>
+  budgetGlobalRenseigne: string
+  conseillerNumerique: ConseillerNumeriqueFinancement
+  fneEngage: string
   nombreDeFinancementsEngagesParLEtat: number
-  ventilationSubventionsParEnveloppe: ReadonlyArray<{
-    enveloppeTotale: string
-    label: string
-    total: string
-  }>
+  ventilationSubventionsParEnveloppe: ReadonlyArray<VentilationEnveloppe>
 }
 
 export interface TableauDeBordLoaderFinancementsAdmin {
-  creditsEngages: string
-  montantTotalEnveloppes: string
+  conseillerNumerique: ConseillerNumeriqueFinancement
+  fneDisponible: string
+  fneEngage: string
   nombreDeFinancementsEngagesParLEtat: number
-  nombreEnveloppes: number
-  nombreEnveloppesUtilisees: number
-  ventilationSubventionsParEnveloppe: ReadonlyArray<{
-    enveloppeTotale: string
-    label: string
-    total: string
-  }>
+  ventilationSubventionsParEnveloppe: ReadonlyArray<VentilationEnveloppe>
 }
+
+type ConseillerNumeriqueFinancement = Readonly<{
+  conventionne: string
+  verse: string
+}>
+
+type VentilationEnveloppe = Readonly<{
+  enveloppeTotale: string
+  label: string
+  total: string
+}>


### PR DESCRIPTION
…iller Numérique (#1360)

Encarts du haut admin + pref repensés :
- FNE engagé par l'État (somme des subventions FNE acceptées) pref : sur le budget global renseigné · admin : sur le disponible (somme des |montant| des enveloppes FNE)
- Conseiller Numérique versé / conventionné sur les postes liés à la gouvernance, calculés via la vue canonique min.postes_conseiller_numerique_synthese (montant_versement_cumule / montant_subvention_cumule), filtre territoire pour le pref.

Détail du bas (ventilation + jauges) et fiche structure inchangés. Tests presenters + composants ajoutés. Validation empirique localhost (scopes national et départemental).

