### PR TITLE
fix(tableau-de-bord): ajuster taille des icônes et padding des cards

### DIFF
--- a/src/components/TableauDeBord/EtatDesLieux/AccompagnementsRealises.tsx
+++ b/src/components/TableauDeBord/EtatDesLieux/AccompagnementsRealises.tsx
@@ -20,7 +20,7 @@ export default function AccompagnementsRealises({ accompagnementsRealisesPromise
 function AccompagnementsRealisesSkeleton(): ReactElement {
   return (
     <>
-      <div className="background-blue-france fr-p-4w fr-ml-1w">
+      <div className="background-blue-france fr-p-3w fr-ml-1w">
         <div className={`${styles.indicateurValeur} fr-m-0`}>
           <TitleIcon background="white" icon="compass-3-line" />
           <span className="color-grey">...</span>
@@ -35,7 +35,7 @@ function AccompagnementsRealisesSkeleton(): ReactElement {
           </Information>
         </div>
       </div>
-      <div className="background-blue-france fr-p-4w fr-ml-1w fr-mt-1w">
+      <div className="background-blue-france fr-p-3w fr-ml-1w fr-mt-1w">
         <div className="font-weight-500">
           <span> Accompagnements des 6 derniers mois</span>
           <Information>

--- a/src/components/TableauDeBord/EtatDesLieux/AccompagnementsRealisesAsyncLoader.tsx
+++ b/src/components/TableauDeBord/EtatDesLieux/AccompagnementsRealisesAsyncLoader.tsx
@@ -16,7 +16,7 @@ export default function AccompagnementsRealisesAsyncLoader({ accompagnementsReal
   if (isErrorViewModel(result)) {
     return (
       <>
-        <div className="background-blue-france fr-p-4w fr-ml-1w">
+        <div className="background-blue-france fr-p-3w fr-ml-1w">
           <div className={`${styles.indicateurValeur} fr-m-0`}>
             <TitleIcon background="white" icon="error-warning-line" />—
           </div>
@@ -31,7 +31,7 @@ export default function AccompagnementsRealisesAsyncLoader({ accompagnementsReal
           </div>
           <div className="fr-text--xs color-blue-france fr-mb-0">{result.message}</div>
         </div>
-        <div className="background-blue-france fr-p-4w fr-ml-1w fr-mt-1w">
+        <div className="background-blue-france fr-p-3w fr-ml-1w fr-mt-1w">
           <div className="font-weight-500">
             <span> Accompagnements des 6 derniers mois</span>
             <Information>
@@ -48,7 +48,7 @@ export default function AccompagnementsRealisesAsyncLoader({ accompagnementsReal
 
   return (
     <>
-      <div className="background-blue-france fr-p-4w fr-ml-1w">
+      <div className="background-blue-france fr-p-3w fr-ml-1w">
         <div className={`${styles.indicateurValeur} fr-m-0`}>
           <TitleIcon background="white" icon="compass-3-line" />
           {formaterEnNombreFrancais(result.nombreTotal)}
@@ -63,7 +63,7 @@ export default function AccompagnementsRealisesAsyncLoader({ accompagnementsReal
           </Information>
         </div>
       </div>
-      <div className="background-blue-france fr-p-4w fr-ml-1w fr-mt-1w">
+      <div className="background-blue-france fr-p-3w fr-ml-1w fr-mt-1w">
         <Bar
           backgroundColor={backgroundColor}
           data={result.repartitionMensuelle.map((item) => item.nombre)}

--- a/src/components/TableauDeBord/EtatDesLieux/EtatDesLieux.tsx
+++ b/src/components/TableauDeBord/EtatDesLieux/EtatDesLieux.tsx
@@ -24,7 +24,7 @@ export default function EtatDesLieux({
     <section aria-labelledby="etatDesLieux" className="fr-mb-4w ">
       <div className="fr-grid-row fr-grid-row--middle fr-pb-2w">
         <div className="fr-col-auto" style={{ alignItems: 'stretch', display: 'flex' }}>
-          <TitleIcon icon="france-line" />
+          <TitleIcon icon="france-line" size="medium-large" />
         </div>
         <div className="fr-col">
           <div

--- a/src/components/TableauDeBord/EtatDesLieux/LieuxInclusionNumerique.tsx
+++ b/src/components/TableauDeBord/EtatDesLieux/LieuxInclusionNumerique.tsx
@@ -9,7 +9,7 @@ import { LieuxInclusionNumeriqueViewModel } from '@/presenters/tableauDeBord/lie
 export default function LieuxInclusionNumerique({ viewModel }: Props): ReactElement {
   if (isErrorViewModel(viewModel)) {
     return (
-      <div className="background-blue-france fr-p-4w fr-mb-1w fr-ml-1w">
+      <div className="background-blue-france fr-p-3w fr-mb-1w fr-ml-1w">
         <div className={`${styles.indicateurValeur} fr-m-0`}>
           <TitleIcon background="white" icon="error-warning-line" />—
         </div>
@@ -20,7 +20,7 @@ export default function LieuxInclusionNumerique({ viewModel }: Props): ReactElem
   }
 
   return (
-    <div className="background-blue-france fr-p-4w fr-mb-1w fr-ml-1w">
+    <div className="background-blue-france fr-p-3w fr-mb-1w fr-ml-1w">
       <div className={`${styles.indicateurValeur} fr-m-0`}>
         <TitleIcon background="white" icon="map-pin-2-line" />
         {viewModel.nombreLieux}

--- a/src/components/TableauDeBord/EtatDesLieux/MediateursEtAidants.tsx
+++ b/src/components/TableauDeBord/EtatDesLieux/MediateursEtAidants.tsx
@@ -9,7 +9,7 @@ import { MediateursEtAidantsViewModel } from '@/presenters/tableauDeBord/mediate
 export default function MediateursEtAidants({ viewModel }: Props): ReactElement {
   if (isErrorViewModel(viewModel)) {
     return (
-      <div className="background-blue-france fr-p-4w fr-mb-1w fr-ml-1w">
+      <div className="background-blue-france fr-p-3w fr-mb-1w fr-ml-1w">
         <div className={`${styles.indicateurValeur} fr-m-0`}>
           <TitleIcon background="white" icon="error-warning-line" />—
         </div>
@@ -27,7 +27,7 @@ export default function MediateursEtAidants({ viewModel }: Props): ReactElement 
   }
 
   return (
-    <div className="background-blue-france fr-p-4w fr-mb-1w fr-ml-1w">
+    <div className="background-blue-france fr-p-3w fr-mb-1w fr-ml-1w">
       <div className={`${styles.indicateurValeur} fr-m-0`}>
         <TitleIcon background="white" icon="map-pin-user-line" />
         {viewModel.total}

--- a/src/components/TableauDeBord/FinancementsAdmin.tsx
+++ b/src/components/TableauDeBord/FinancementsAdmin.tsx
@@ -20,7 +20,7 @@ export default function FinancementsAdmin({
       <BlocCard labelledBy="financements">
         <div className="fr-grid-row fr-grid-row--middle space-between fr-pb-2w">
           <div className="fr-grid-row fr-grid-row--middle">
-            <TitleIcon icon="pen-nib-line" />
+            <TitleIcon icon="pen-nib-line" size="medium-large" />
             <div>
               <h2 className="fr-h4 color-blue-france fr-m-0" id="financements">
                 Financements
@@ -63,7 +63,7 @@ export default function FinancementsAdmin({
         </Link>
       </div>
       <div className="fr-grid-row fr-mb-4w">
-        <div className="fr-col background-blue-france fr-p-4w fr-mr-4w">
+        <div className="fr-col background-blue-france fr-p-3w fr-mr-4w">
           <div className={`${styles.indicateurValeur} fr-m-0`}>
             <TitleIcon background="white" icon="download-line" />
             {financementViewModel.fneEngage}
@@ -75,9 +75,9 @@ export default function FinancementsAdmin({
             sur <span style={{ fontWeight: 700 }}>{financementViewModel.fneDisponible}</span> disponible
           </div>
         </div>
-        <div className="fr-col background-blue-france fr-p-4w">
+        <div className="fr-col background-blue-france fr-p-3w">
           <div className={`${styles.indicateurValeur} fr-m-0`}>
-            <TitleIcon background="white" icon="money-euro-circle-line" />
+            <TitleIcon background="white" icon="upload-line" />
             {financementViewModel.conseillerNumerique.verse}
           </div>
           <div className="fr-text--md fr-mb-0 fr-grid-row fr-grid-row--middle" style={{ fontWeight: 500 }}>

--- a/src/components/TableauDeBord/FinancementsPref.tsx
+++ b/src/components/TableauDeBord/FinancementsPref.tsx
@@ -20,7 +20,7 @@ export default function FinancementsPref({
       <BlocCard labelledBy="conventionnements">
         <div className="fr-grid-row fr-grid-row--middle space-between fr-pb-2w">
           <div className="fr-grid-row fr-grid-row--middle">
-            <TitleIcon icon="pen-nib-line" />
+            <TitleIcon icon="pen-nib-line" size="medium-large" />
             <div>
               <h2 className="fr-h4 color-blue-france fr-m-0" id="conventionnements">
                 Financements
@@ -63,7 +63,7 @@ export default function FinancementsPref({
         </Link>
       </div>
       <div className="fr-grid-row fr-mb-4w">
-        <div className="fr-col background-blue-france fr-p-4w fr-mr-4w">
+        <div className="fr-col background-blue-france fr-p-3w fr-mr-4w">
           <div className={`${styles.indicateurValeur} fr-m-0`}>
             <TitleIcon background="white" icon="download-line" />
             {conventionnement.fneEngage}
@@ -76,9 +76,9 @@ export default function FinancementsPref({
             renseigné
           </div>
         </div>
-        <div className="fr-col background-blue-france fr-p-4w">
+        <div className="fr-col background-blue-france fr-p-3w">
           <div className={`${styles.indicateurValeur} fr-m-0`}>
-            <TitleIcon background="white" icon="money-euro-circle-line" />
+            <TitleIcon background="white" icon="upload-line" />
             {conventionnement.conseillerNumerique.verse}
           </div>
           <div className="fr-text--md fr-mb-0 fr-grid-row fr-grid-row--middle" style={{ fontWeight: 500 }}>

--- a/src/components/TableauDeBord/Gouvernance/GouvernanceAdmin.tsx
+++ b/src/components/TableauDeBord/Gouvernance/GouvernanceAdmin.tsx
@@ -15,7 +15,7 @@ export default function GouvernanceAdmin({ gouvernanceViewModel, lienGouvernance
       <BlocCard labelledBy="gouvernance">
         <div className="fr-grid-row fr-grid-row--middle space-between fr-pb-2w">
           <div className="fr-grid-row fr-grid-row--middle">
-            <TitleIcon icon="compass-3-line" />
+            <TitleIcon icon="compass-3-line" size="medium-large" />
             <div>
               <h2 className="fr-h4 color-blue-france fr-m-0" id="gouvernance">
                 Gouvernances
@@ -30,7 +30,7 @@ export default function GouvernanceAdmin({ gouvernanceViewModel, lienGouvernance
           </Link>
         </div>
         <div className="fr-grid-row">
-          <div className="fr-col background-blue-france fr-p-4w fr-mr-4w">
+          <div className="fr-col background-blue-france fr-p-3w fr-mr-4w">
             <div className={`${styles.indicateurValeur} fr-m-0`}>
               <TitleIcon background="white" icon="bank-line" />-
             </div>
@@ -39,7 +39,7 @@ export default function GouvernanceAdmin({ gouvernanceViewModel, lienGouvernance
             </div>
             <div className="fr-text--xs color-blue-france fr-mb-0">Erreur lors du chargement des données</div>
           </div>
-          <div className="fr-col background-blue-france fr-p-4w">
+          <div className="fr-col background-blue-france fr-p-3w">
             <div className={`${styles.indicateurValeur} fr-m-0`}>
               <TitleIcon background="white" icon="file-download-line" />-
             </div>
@@ -72,7 +72,7 @@ export default function GouvernanceAdmin({ gouvernanceViewModel, lienGouvernance
         </Link>
       </div>
       <div className="fr-grid-row">
-        <div className="fr-col background-blue-france fr-p-4w fr-mr-4w">
+        <div className="fr-col background-blue-france fr-p-3w fr-mr-4w">
           <div className={`${styles.indicateurValeur} fr-m-0`}>
             <TitleIcon background="white" icon="bank-line" />
             {gouvernanceViewModel.nombreGouvernances}
@@ -87,7 +87,7 @@ export default function GouvernanceAdmin({ gouvernanceViewModel, lienGouvernance
             </span>
           </div>
         </div>
-        <div className="fr-col background-blue-france fr-p-4w">
+        <div className="fr-col background-blue-france fr-p-3w">
           <div className={`${styles.indicateurValeur} fr-m-0`}>
             <TitleIcon background="white" icon="file-download-line" />
             {gouvernanceViewModel.feuilleDeRoute.total}

--- a/src/components/TableauDeBord/Gouvernance/GouvernancePref.tsx
+++ b/src/components/TableauDeBord/Gouvernance/GouvernancePref.tsx
@@ -16,7 +16,7 @@ export default function GouvernancePref({ gouvernanceViewModel, lienGouvernance 
       <BlocCard labelledBy="gouvernance">
         <div className="fr-grid-row fr-grid-row--middle space-between fr-pb-2w">
           <div className="fr-grid-row fr-grid-row--middle">
-            <TitleIcon icon="compass-3-line" />
+            <TitleIcon icon="compass-3-line" size="medium-large" />
             <div>
               <h2 className="fr-h4 color-blue-france fr-m-0" id="gouvernance">
                 Gouvernances
@@ -33,7 +33,7 @@ export default function GouvernancePref({ gouvernanceViewModel, lienGouvernance 
           )}
         </div>
         <div className={styles.cartesContainer}>
-          <div className={`${styles.carte} background-blue-france fr-p-4w`}>
+          <div className={`${styles.carte} background-blue-france fr-p-3w`}>
             <div className={`${tableauDeBordStyles.indicateurValeur} fr-m-0`}>
               <TitleIcon background="white" icon="bank-line" />-
             </div>
@@ -42,14 +42,14 @@ export default function GouvernancePref({ gouvernanceViewModel, lienGouvernance 
             </div>
             <div className="fr-text--xs color-blue-france fr-mb-0">Erreur lors du chargement des données</div>
           </div>
-          <div className={`${styles.carte} background-blue-france fr-p-4w`}>
+          <div className={`${styles.carte} background-blue-france fr-p-3w`}>
             <div className={`${tableauDeBordStyles.indicateurValeur} fr-m-0`}>
               <TitleIcon background="white" icon="community-line" />-
             </div>
             <div className="font-weight-500">Collectivité impliquées</div>
             <div className="fr-text--xs color-blue-france fr-mb-0">Erreur lors du chargement des données</div>
           </div>
-          <div className={`${styles.carte} background-blue-france fr-p-4w`}>
+          <div className={`${styles.carte} background-blue-france fr-p-3w`}>
             <div className={`${tableauDeBordStyles.indicateurValeur} fr-m-0`}>
               <TitleIcon background="white" icon="file-download-line" />-
             </div>
@@ -79,7 +79,7 @@ export default function GouvernancePref({ gouvernanceViewModel, lienGouvernance 
         )}
       </div>
       <div className={styles.cartesContainer}>
-        <div className={`${styles.carte} background-blue-france fr-p-4w`}>
+        <div className={`${styles.carte} background-blue-france fr-p-3w`}>
           <div className={`${tableauDeBordStyles.indicateurValeur} fr-m-0`}>
             <TitleIcon background="white" icon="bank-line" />
             {gouvernanceViewModel.membre.total}
@@ -91,7 +91,7 @@ export default function GouvernancePref({ gouvernanceViewModel, lienGouvernance 
             dont <span style={{ fontWeight: 700 }}>{gouvernanceViewModel.membre.coporteur} coporteurs</span>
           </div>
         </div>
-        <div className={`${styles.carte} background-blue-france fr-p-4w`}>
+        <div className={`${styles.carte} background-blue-france fr-p-3w`}>
           <div className={`${tableauDeBordStyles.indicateurValeur} fr-m-0`}>
             <TitleIcon background="white" icon="file-download-line" />
             {gouvernanceViewModel.feuilleDeRoute.total}

--- a/src/components/TableauDeBord/MediateursAidants.tsx
+++ b/src/components/TableauDeBord/MediateursAidants.tsx
@@ -14,7 +14,7 @@ export default function MediateursAidants({ viewModel }: Props): ReactElement {
     <BlocCard labelledBy="mediateursAidants">
       <div className="fr-grid-row fr-grid-row--middle space-between fr-pb-3w fr-mb-3w separator">
         <div className="fr-grid-row fr-grid-row--middle">
-          <TitleIcon icon="group-line" />
+          <TitleIcon icon="group-line" size="medium-large" />
           <div>
             <h2 className="fr-h4 color-blue-france fr-m-0" id="mediateursAidants">
               Médiateurs numériques et Aidants Connect


### PR DESCRIPTION
  - Icônes des en-têtes de section : medium → medium-large (48px → 68px) pour EtatDesLieux, MediateursAidants, Gouvernance et Financements
  - Padding des cards de métriques : fr-p-4w → fr-p-3w (32px → 24px)
  - Icône card "CN versés" : money-euro-circle-line → upload-line

# Contrat du dev

## Qualité

- [x] Relire le code
- [x] Relire le ticket
- [x] [Relire les critères d'acceptation](https://github.com/anct-cnum/suite-gestionnaire-numerique/discussions/252)


> **Et n'oublie pas de vérifier ce que tu as fait en production !**
