### PR TITLE
fix(aidants-mediateurs): corriger la typographie des métriques et for…

### DIFF
--- a/src/components/AidantsMediateurs/AccompagnementsEtMediateurs.tsx
+++ b/src/components/AidantsMediateurs/AccompagnementsEtMediateurs.tsx
@@ -68,7 +68,7 @@ export default function AccompagnementsEtMediateurs({
     <section aria-labelledby="accompagnements-et-mediateurs" className="fr-mb-4w grey-border border-radius fr-p-4w">
       <div className="fr-grid-row fr-grid-row--middle separator fr-pb-3w fr-mb-3w">
         <div>
-          <h2 className="fr-h4 color-blue-france fr-m-0" id="accompagnements-et-mediateurs">
+          <h2 className="fr-h5 color-blue-france fr-m-0" id="accompagnements-et-mediateurs">
             Accompagnements et médiateurs numériques
             <Information>
               <p className="fr-mb-0">
@@ -97,9 +97,9 @@ export default function AccompagnementsEtMediateurs({
               <AsyncLoaderErrorBoundary
                 fallback={
                   <div>
-                    <div className="fr-display--xs fr-mb-0">-</div>
+                    <div className="metrique-nombre-grand fr-mb-0">-</div>
                     <div className="fr-text--lg font-weight-700 fr-m-0">Bénéficiaires accompagnés</div>
-                    <div className="color-blue-france fr-pb-4w">
+                    <div className="color-blue-france fr-text--xs fr-m-0 fr-pb-4w">
                       Soit <strong>- accompagnements réalisés</strong>
                     </div>
                   </div>
@@ -108,9 +108,9 @@ export default function AccompagnementsEtMediateurs({
                 <Suspense
                   fallback={
                     <div>
-                      <div className="fr-display--xs fr-mb-0 color-grey">...</div>
+                      <div className="metrique-nombre-grand fr-mb-0 color-grey">...</div>
                       <div className="fr-text--lg font-weight-700 fr-m-0">Bénéficiaires accompagnés</div>
-                      <div className="color-blue-france fr-pb-4w">
+                      <div className="color-blue-france fr-text--xs fr-m-0 fr-pb-4w">
                         Soit <strong>... accompagnements réalisés</strong>
                       </div>
                     </div>

--- a/src/components/AidantsMediateurs/BeneficiairesEtAccompagnementsAsyncLoader.tsx
+++ b/src/components/AidantsMediateurs/BeneficiairesEtAccompagnementsAsyncLoader.tsx
@@ -3,6 +3,7 @@
 import { ReactElement, use } from 'react'
 
 import { ErrorViewModel, isErrorViewModel } from '@/components/shared/ErrorViewModel'
+import { formaterEnNombreAvecK } from '@/presenters/shared/number'
 import { BeneficiairesEtAccompagnementsResult } from '@/use-cases/queries/fetchBeneficiaires'
 
 export default function BeneficiairesEtAccompagnementsAsyncLoader({
@@ -13,9 +14,9 @@ export default function BeneficiairesEtAccompagnementsAsyncLoader({
   if (isErrorViewModel(result)) {
     return (
       <div>
-        <div className="fr-display--xs fr-mb-0 color-orange">-</div>
+        <div className="metrique-nombre-grand fr-mb-0 color-orange">-</div>
         <div className="fr-text--lg font-weight-700 fr-m-0">Bénéficiaires accompagnés</div>
-        <div className="color-blue-france fr-pb-4w">
+        <div className="color-blue-france fr-text--xs fr-m-0 fr-pb-4w">
           Soit <strong>- accompagnements réalisés</strong>
         </div>
       </div>
@@ -24,10 +25,10 @@ export default function BeneficiairesEtAccompagnementsAsyncLoader({
 
   return (
     <div>
-      <div className="fr-display--xs fr-mb-0">{result.beneficiaires.toLocaleString('fr-FR')}</div>
+      <div className="metrique-nombre-grand fr-mb-0">{formaterEnNombreAvecK(result.beneficiaires)}</div>
       <div className="fr-text--lg font-weight-700 fr-m-0">Bénéficiaires accompagnés</div>
-      <div className="color-blue-france fr-pb-4w">
-        Soit <strong>{result.accompagnements.toLocaleString('fr-FR')} accompagnements réalisés</strong>
+      <div className="color-blue-france fr-text--xs fr-m-0 fr-pb-4w">
+        Soit <strong>{formaterEnNombreAvecK(result.accompagnements)} accompagnements réalisés</strong>
       </div>
     </div>
   )

--- a/src/components/AidantsMediateurs/NiveauDeFormation.tsx
+++ b/src/components/AidantsMediateurs/NiveauDeFormation.tsx
@@ -60,7 +60,7 @@ export default function NiveauDeFormation({ dateGeneration, niveauDeFormation }:
     <section aria-labelledby="niveau-de-formation" className="fr-mb-4w grey-border border-radius fr-p-4w">
       <div className="fr-grid-row fr-grid-row--middle separator fr-pb-3w fr-mb-3w">
         <div>
-          <h2 className="fr-h4 color-blue-france fr-m-0" id="niveau-de-formation">
+          <h2 className="fr-h5 color-blue-france fr-m-0" id="niveau-de-formation">
             Niveau de formation des aidants et médiateurs numériques
             <Information>
               <p className="fr-mb-0">
@@ -83,7 +83,7 @@ export default function NiveauDeFormation({ dateGeneration, niveauDeFormation }:
             />
           </div>
           <div
-            className="fr-display--sm fr-mb-0"
+            className="metrique-nombre-grand fr-mb-0"
             style={{ marginTop: '-3vw', pointerEvents: 'none', position: 'relative', zIndex: -1 }}
           >
             {niveauDeFormation.aidantsEtMediateursFormes}
@@ -93,7 +93,7 @@ export default function NiveauDeFormation({ dateGeneration, niveauDeFormation }:
             <br />
             formés ou certifiés
           </div>
-          <div className="color-blue-france fr-pb-4w">
+          <div className="color-blue-france fr-text--xs fr-m-0 fr-pb-4w">
             Sur <strong>{niveauDeFormation.totalAidantsEtMediateurs} aidants et médiateurs</strong>
           </div>
         </div>

--- a/src/components/shared/Metric/Metric.tsx
+++ b/src/components/shared/Metric/Metric.tsx
@@ -3,13 +3,13 @@ import { ReactElement } from 'react'
 export default function Metric({ chiffre, prefix = '', sousTitre, suffix = '', titre }: Props): ReactElement {
   return (
     <div className="fr-mb-3w">
-      <div className="fr-display--xs fr-mb-1w">
+      <div className="metrique-nombre fr-mb-1w">
         {prefix}
         {chiffre}
         {suffix}
       </div>
       <div className="fr-text--lg font-weight-700 fr-mb-1w">{titre}</div>
-      <div className="color-blue-france fr-pb-4w">{sousTitre}</div>
+      <div className="color-blue-france fr-text--xs fr-m-0 fr-pb-4w">{sousTitre}</div>
     </div>
   )
 }

--- a/src/global.css
+++ b/src/global.css
@@ -219,3 +219,15 @@ address {
 .blue-background {
   background-color: var(--blue-france-975-75);
 }
+
+.metrique-nombre {
+  font-size: 1.875rem;
+  font-weight: 700;
+  line-height: 2.25rem;
+}
+
+.metrique-nombre-grand {
+  font-size: 2.25rem;
+  font-weight: 700;
+  line-height: 2.5rem;
+}

--- a/src/presenters/shared/number.ts
+++ b/src/presenters/shared/number.ts
@@ -12,8 +12,22 @@ export function formatMontantEnMillions(montant: number): string {
   }
 
   if (montant >= 10_000) {
-    return `${(montant / 1_000).toLocaleString('fr-FR', { maximumFractionDigits: 2, minimumFractionDigits: 2 })} K€`
+    return `${enMilliers(montant, 2, 2)} K€`
   }
 
   return `${formaterEnNombreFrancais(montant)} €`
+}
+
+export function formaterEnNombreAvecK(nombre: number): string {
+  if (nombre >= 100_000) {
+    return `${enMilliers(nombre, 1)} K`
+  }
+  return formaterEnNombreFrancais(nombre)
+}
+
+function enMilliers(nombre: number, maximumDecimales: number, minimumDecimales = 0): string {
+  return (nombre / 1_000).toLocaleString('fr-FR', {
+    maximumFractionDigits: maximumDecimales,
+    minimumFractionDigits: minimumDecimales,
+  })
 }


### PR DESCRIPTION
…mater les grands nombres en K

  - Réduire la taille des chiffres : fr-display--xs/sm (40-56px) → 30px (métriques) et 36px (grand nombre central)
  - Ajouter fr-text--xs sur les sous-titres pour les rendre plus petits
  - Passer les titres de section de fr-h4 à fr-h5 (plus proche du design)
  - Formater les nombres ≥ 100 000 en "X,Y K" (ex: 490 520 → 490,5 K)
  - Ajouter formaterEnNombreAvecK dans number.ts en réutilisant le helper enMilliers

# Contrat du dev

## Qualité

- [x] Relire le code
- [x] Relire le ticket
- [x] [Relire les critères d'acceptation](https://github.com/anct-cnum/suite-gestionnaire-numerique/discussions/252)


> **Et n'oublie pas de vérifier ce que tu as fait en production !**
