### PR TITLE
fix(tableau-de-bord): corriger la couleur de l'enveloppe Conum Plan F…

### DIFF
--- a/src/components/TableauDeBord/EnveloppesConseillerNumerique.tsx
+++ b/src/components/TableauDeBord/EnveloppesConseillerNumerique.tsx
@@ -39,7 +39,7 @@ export default function EnveloppesConseillerNumerique({ contexte, enveloppes }: 
                 >
                   <div
                     style={{
-                      backgroundColor: 'var(--blue-france-main-525)',
+                      backgroundColor: enveloppe.couleurGraphique,
                       borderRadius: '4px',
                       height: '8px',
                       transition: 'width 0.3s ease',

--- a/src/components/TableauDeBord/FinancementsAdmin.test.tsx
+++ b/src/components/TableauDeBord/FinancementsAdmin.test.tsx
@@ -52,7 +52,8 @@ function financementAdminViewModelFactory(): FinancementAdminViewModel {
     nombreDeFinancementsEngagesParLEtat: 7,
     ventilationSubventionsParEnveloppe: [
       {
-        color: '#000091',
+        color: 'dot-orange-terre-battue-850-200',
+        couleurGraphique: '#fcc0b0',
         label: 'Ingénierie France Numérique Ensemble - 2024 - État',
         pourcentageConsomme: 64,
         total: '3,20 M€',

--- a/src/components/TableauDeBord/FinancementsPref.test.tsx
+++ b/src/components/TableauDeBord/FinancementsPref.test.tsx
@@ -48,7 +48,8 @@ function financementViewModelFactory(): FinancementViewModel {
     nombreDeFinancementsEngagesParLEtat: 3,
     ventilationSubventionsParEnveloppe: [
       {
-        color: '#000091',
+        color: 'dot-orange-terre-battue-850-200',
+        couleurGraphique: '#fcc0b0',
         label: 'Ingénierie France Numérique Ensemble - 2024 - État',
         pourcentageConsomme: 45,
         total: '450 000 €',

--- a/src/components/TableauDeBord/VentilationFinancements.tsx
+++ b/src/components/TableauDeBord/VentilationFinancements.tsx
@@ -57,7 +57,7 @@ export default function VentilationFinancements({
                   >
                     <div
                       style={{
-                        backgroundColor: 'var(--blue-france-main-525)',
+                        backgroundColor: detail.couleurGraphique,
                         borderRadius: '4px',
                         height: '8px',
                         transition: 'width 0.3s ease',
@@ -82,6 +82,7 @@ type Props = Readonly<{
   nombreDeFinancementsEngagesParLEtat: number
   ventilationSubventionsParEnveloppe: ReadonlyArray<{
     color: string
+    couleurGraphique: string
     label: string
     pourcentageConsomme: number
     total: string

--- a/src/presenters/shared/enveloppe.ts
+++ b/src/presenters/shared/enveloppe.ts
@@ -6,7 +6,7 @@ export type Enveloppe =
 
 export const couleursEnveloppes = {
   'Conseiller Numérique - initiale - État': 'dot-purple-glycine-850-200',
-  'Conseiller Numérique - Plan France Relance - État': 'dot-blue-france-main-525',
+  'Conseiller Numérique - Plan France Relance - État': 'dot-purple-glycine-850-200',
   'Conseiller Numérique - Renouvellement - État': 'dot-purple-glycine-main-494',
   'Formation Aidant Numérique/Aidants Connect - 2024 - État': 'dot-green-tilleul-verveine-925',
   'Ingénierie France Numérique Ensemble - 2024 - État': 'dot-orange-terre-battue-850-200',

--- a/src/presenters/tableauDeBord/enveloppesConseillerNumeriquePresenter.test.ts
+++ b/src/presenters/tableauDeBord/enveloppesConseillerNumeriquePresenter.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { enveloppesConseillerNumeriquePresenter } from './enveloppesConseillerNumeriquePresenter'
+import { obtenirCouleurEnveloppe, obtenirCouleurGraphique } from '../shared/enveloppe'
 import { EnveloppeConseillerNumeriqueReadModel } from '@/use-cases/queries/RecupererLesEnveloppesConseillerNumerique'
 
 describe(enveloppesConseillerNumeriquePresenter, () => {
@@ -23,7 +24,8 @@ describe(enveloppesConseillerNumeriquePresenter, () => {
     // THEN
     expect(result).toStrictEqual([
       {
-        color: 'dot-purple-glycine-850-200',
+        color: obtenirCouleurEnveloppe('Conseiller Numérique - initiale - État'),
+        couleurGraphique: obtenirCouleurGraphique(obtenirCouleurEnveloppe('Conseiller Numérique - initiale - État')),
         disponible: true,
         label: 'Conseiller Numérique - initiale - État',
         pourcentageConsomme: 50,

--- a/src/presenters/tableauDeBord/enveloppesConseillerNumeriquePresenter.ts
+++ b/src/presenters/tableauDeBord/enveloppesConseillerNumeriquePresenter.ts
@@ -1,4 +1,4 @@
-import { obtenirCouleurEnveloppe } from '../shared/enveloppe'
+import { obtenirCouleurEnveloppe, obtenirCouleurGraphique } from '../shared/enveloppe'
 import { formatMontantEnMillions } from '../shared/number'
 import { EnveloppeConseillerNumeriqueReadModel } from '@/use-cases/queries/RecupererLesEnveloppesConseillerNumerique'
 
@@ -11,8 +11,11 @@ export function enveloppesConseillerNumeriquePresenter(
     const plafond = enveloppe.plafond
     const pourcentageConsomme = plafond > 0 ? Math.round((consommation / plafond) * 100) : 0
 
+    const couleur = obtenirCouleurEnveloppe(enveloppe.libelle)
+
     return {
-      color: obtenirCouleurEnveloppe(enveloppe.libelle),
+      color: couleur,
+      couleurGraphique: obtenirCouleurGraphique(couleur),
       disponible: now >= enveloppe.dateDeDebut && now <= enveloppe.dateDeFin,
       label: enveloppe.libelle,
       pourcentageConsomme,
@@ -23,6 +26,7 @@ export function enveloppesConseillerNumeriquePresenter(
 
 export type EnveloppeConseillerNumeriqueViewModel = Readonly<{
   color: string
+  couleurGraphique: string
   disponible: boolean
   label: string
   pourcentageConsomme: number

--- a/src/presenters/tableauDeBord/financementAdminPresenter.test.ts
+++ b/src/presenters/tableauDeBord/financementAdminPresenter.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { financementAdminPresenter } from './financementAdminPresenter'
-import { obtenirCouleurEnveloppe } from '../shared/enveloppe'
+import { obtenirCouleurEnveloppe, obtenirCouleurGraphique } from '../shared/enveloppe'
 import { formatMontantEnMillions } from '../shared/number'
 import { TableauDeBordLoaderFinancementsAdmin } from '@/use-cases/queries/RecuperFinancements'
 import { ErrorReadModel } from '@/use-cases/queries/shared/ErrorReadModel'
@@ -41,6 +41,9 @@ describe('financement admin presenter', () => {
       ventilationSubventionsParEnveloppe: [
         {
           color: obtenirCouleurEnveloppe('Ingénierie France Numérique Ensemble - 2024 - État'),
+          couleurGraphique: obtenirCouleurGraphique(
+            obtenirCouleurEnveloppe('Ingénierie France Numérique Ensemble - 2024 - État')
+          ),
           label: 'Ingénierie France Numérique Ensemble - 2024 - État',
           pourcentageConsomme: 64,
           total: formatMontantEnMillions(3_200_000),

--- a/src/presenters/tableauDeBord/financementAdminPresenter.ts
+++ b/src/presenters/tableauDeBord/financementAdminPresenter.ts
@@ -1,4 +1,4 @@
-import { obtenirCouleurEnveloppe } from '../shared/enveloppe'
+import { obtenirCouleurEnveloppe, obtenirCouleurGraphique } from '../shared/enveloppe'
 import { formatMontantEnMillions } from '../shared/number'
 import { ErrorViewModel } from '@/components/shared/ErrorViewModel'
 import { TableauDeBordLoaderFinancementsAdmin } from '@/use-cases/queries/RecuperFinancements'
@@ -28,8 +28,11 @@ export function financementAdminPresenter(
         const montantTotal = Number(enveloppeTotale)
         const pourcentageConsomme = montantTotal > 0 ? Math.round((montantUtilise / montantTotal) * 100) : 0
 
+        const couleur = obtenirCouleurEnveloppe(label)
+
         return {
-          color: obtenirCouleurEnveloppe(label),
+          color: couleur,
+          couleurGraphique: obtenirCouleurGraphique(couleur),
           label,
           pourcentageConsomme,
           total: formatMontantEnMillions(montantUtilise),
@@ -49,6 +52,7 @@ export type FinancementAdminViewModel = Readonly<{
   nombreDeFinancementsEngagesParLEtat: number
   ventilationSubventionsParEnveloppe: ReadonlyArray<{
     color: string
+    couleurGraphique: string
     label: string
     pourcentageConsomme: number
     total: string

--- a/src/presenters/tableauDeBord/financementPrefPresenter.test.ts
+++ b/src/presenters/tableauDeBord/financementPrefPresenter.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { financementsPrefPresenter } from './financementPrefPresenter'
-import { obtenirCouleurEnveloppe } from '../shared/enveloppe'
+import { obtenirCouleurEnveloppe, obtenirCouleurGraphique } from '../shared/enveloppe'
 import { formatMontant } from '../shared/number'
 import { TableauDeBordLoaderFinancements } from '@/use-cases/queries/RecuperFinancements'
 import { ErrorReadModel } from '@/use-cases/queries/shared/ErrorReadModel'
@@ -41,6 +41,9 @@ describe('financements pref presenter', () => {
       ventilationSubventionsParEnveloppe: [
         {
           color: obtenirCouleurEnveloppe('Ingénierie France Numérique Ensemble - 2024 - État'),
+          couleurGraphique: obtenirCouleurGraphique(
+            obtenirCouleurEnveloppe('Ingénierie France Numérique Ensemble - 2024 - État')
+          ),
           label: 'Ingénierie France Numérique Ensemble - 2024 - État',
           pourcentageConsomme: 45,
           total: formatMontant(450_000),
@@ -83,6 +86,9 @@ describe('financements pref presenter', () => {
       ventilationSubventionsParEnveloppe: [
         {
           color: obtenirCouleurEnveloppe('Formation Aidant Numérique/Aidants Connect - 2024 - État'),
+          couleurGraphique: obtenirCouleurGraphique(
+            obtenirCouleurEnveloppe('Formation Aidant Numérique/Aidants Connect - 2024 - État')
+          ),
           label: 'Formation Aidant Numérique/Aidants Connect - 2024 - État',
           pourcentageConsomme: 0,
           total: formatMontant(0),

--- a/src/presenters/tableauDeBord/financementPrefPresenter.ts
+++ b/src/presenters/tableauDeBord/financementPrefPresenter.ts
@@ -1,4 +1,4 @@
-import { obtenirCouleurEnveloppe } from '../shared/enveloppe'
+import { obtenirCouleurEnveloppe, obtenirCouleurGraphique } from '../shared/enveloppe'
 import { formatMontant } from '../shared/number'
 import { ErrorViewModel } from '@/components/shared/ErrorViewModel'
 import { TableauDeBordLoaderFinancements } from '@/use-cases/queries/RecuperFinancements'
@@ -28,8 +28,11 @@ export function financementsPrefPresenter(
         const montantTotal = Number(enveloppeTotale)
         const pourcentageConsomme = montantTotal > 0 ? Math.round((montantUtilise / montantTotal) * 100) : 0
 
+        const couleur = obtenirCouleurEnveloppe(label)
+
         return {
-          color: obtenirCouleurEnveloppe(label),
+          color: couleur,
+          couleurGraphique: obtenirCouleurGraphique(couleur),
           label,
           pourcentageConsomme,
           total: formatMontant(montantUtilise),
@@ -49,6 +52,7 @@ export type FinancementViewModel = Readonly<{
   nombreDeFinancementsEngagesParLEtat: number
   ventilationSubventionsParEnveloppe: ReadonlyArray<{
     color: string
+    couleurGraphique: string
     label: string
     pourcentageConsomme: number
     total: string


### PR DESCRIPTION
…rance Relance

  La couleur de l'enveloppe "Conseiller Numérique - Plan France Relance - État"
  était dot-blue-france-main-525 (#000091) au lieu de dot-purple-glycine-850-200
  (#FBB8F6) défini dans le Figma.

  Les barres de progression des ventilations utilisent désormais la couleur
  propre à chaque enveloppe (couleurGraphique) plutôt qu'un bleu fixe.

# Contrat du dev

## Qualité

- [x] Relire le code
- [x] Relire le ticket
- [x] [Relire les critères d'acceptation](https://github.com/anct-cnum/suite-gestionnaire-numerique/discussions/252)

> **Et n'oublie pas de vérifier ce que tu as fait en production !**
