### PR TITLE
feat(db): script local pour resynchroniser la migration dataspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Application de gestion de la gouvernance de l'inclusion num√©rique en France, d√
 - [A propos](#a-propos)
 - [Environnements](#environnements)
 - [Design et prototype](#design-et-prototype)
+- [Base de donnees](#base-de-donnees)
 - [Contribution](#contribution)
 - [Licence](#licence)
 
@@ -29,6 +30,16 @@ Pour en savoir plus : [Fiche beta.gouv.fr](https://beta.gouv.fr/startups/france-
 | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Figma - Outil gestionnaire | [Ouvrir](https://www.figma.com/design/IFH80doDOEvJvbMlUnQIOC/%E2%AD%90%EF%B8%8F-Outil-gestionnaire-FNE?node-id=2679-17716&p=f&t=gwvYEe3U5xoWkbX3-0)  |
 | Figma - Site vitrine       | [Ouvrir](https://www.figma.com/design/IFH80doDOEvJvbMlUnQIOC/%E2%AD%90%EF%B8%8F-Outil-gestionnaire-FNE?node-id=10484-10380&p=f&t=gwvYEe3U5xoWkbX3-0) |
+
+## Base de donnees
+
+MIN partage sa base PostgreSQL avec [dataspace](https://gitlab.com/incubateur-territoires/startups/data-inclusion-numerique/dataspace) : MIN possede le schema `min`, dataspace possede `admin`, `main`, `reference`, `audit` (gestion via Flyway). Voir [docs/integration-dataspace.md](docs/integration-dataspace.md) pour le detail du partage et le workflow de resynchronisation des schemas dataspace en local.
+
+Commande utile :
+
+```bash
+pnpm db:sync-dataspace   # regenerer la migration "dataspace_integration" depuis la base dataspace locale
+```
 
 ## Contribution
 

--- a/docs/integration-dataspace.md
+++ b/docs/integration-dataspace.md
@@ -1,0 +1,119 @@
+# Intégration MIN ↔ Dataspace
+
+## Contexte
+
+MIN partage sa base PostgreSQL avec [dataspace](https://gitlab.com/incubateur-territoires/startups/data-inclusion-numerique/dataspace), l'agrégateur de données ETL de l'inclusion numérique. Les deux projets cohabitent dans la même base mais avec des responsabilités distinctes :
+
+| Schéma                           | Propriétaire | Outil de migration         |
+| -------------------------------- | ------------ | -------------------------- |
+| `admin`, `main`, `reference`, `audit` | dataspace    | Flyway (`database/migrations/`) |
+| `min`                            | MIN          | Prisma (`prisma/migrations/`)   |
+| `api`, `auth`, `dataviz`, `import`, `public`, `pseudonymisation` | dataspace | Flyway (non utilisé côté MIN)   |
+
+En production, **MIN ne joue plus ses migrations Prisma** : `prisma migrate deploy` est désactivé. Les schémas non-`min` sont entièrement gérés par Flyway côté dataspace. MIN n'a la main que sur le schéma `min`.
+
+Côté développement et test en revanche, MIN doit pouvoir initialiser une base complète depuis zéro pour faire tourner `prisma migrate reset` (utilisé par la suite de tests). C'est le rôle des deux migrations Prisma spéciales :
+
+- `20250619151605_1_dataspace_integration_create_roles_and_schema/` — provisionne les rôles PostgreSQL (`sonum`, `app_python`, `min_dev`, `min_scalingo`) et crée les schémas `admin`, `main`, `reference`, `audit`. Stable, écrite à la main.
+- `20250619151605_2_dataspace_integration/` — reproduit la structure (tables, vues, fonctions, séquences, contraintes, index, triggers) des schémas non-`min` tels qu'ils existent en dataspace. **Régénérée à chaque évolution du schéma dataspace.**
+
+## Workflow de synchronisation
+
+Quand le schéma dataspace évolue (nouvelle migration Flyway sur une branche dataspace) :
+
+```bash
+# 1. Appliquer les nouvelles migrations Flyway en local
+cd ~/Dev/dataspace && ./scripts-dev/run-flyway.sh migrate
+
+# 2. Régénérer la migration "2" depuis la base dataspace locale
+cd ~/Dev/min && pnpm db:sync-dataspace
+
+# 3. Vérifier que prisma migrate reset passe sur la base de test
+pnpm dotenv:test -- pnpm prisma:reset
+```
+
+Le script `scripts/sync-dataspace-migration.sh` :
+- attaque la base locale `postgres-dataspace:5532/dataspace_dev` via `docker exec` (pas besoin de pseudonymisation puisque c'est du dev)
+- reproduit l'esprit des tâches `export`, `clean`, `functions` du DAG `database_pseudonym_export` côté dataspace
+- écrit directement dans `prisma/migrations/20250619151605_2_dataspace_integration/migration.sql`
+
+Variables d'override (rarement utiles) : `DATASPACE_CONTAINER`, `DATASPACE_DB`, `DATASPACE_USER`, `MIGRATION_FILE`.
+
+## Avant l'automatisation
+
+L'ancien workflow nécessitait :
+1. déclencher le DAG `database_pseudonym_export` côté Airflow,
+2. récupérer l'archive pseudonymisée sur Nextcloud,
+3. concaténer manuellement les fichiers `*-structure-pre-data-*.sql` et `*-structure-post-data-*.sql`,
+4. coller le résultat dans la migration "2",
+5. sauvegarder `schema.prisma`, lancer `pnpm db:pull`, puis restaurer manuellement la portion `min` du schéma.
+
+Tout cela parce qu'on n'avait pas de raccourci local. C'est désormais une seule commande.
+
+## Pièges identifiés lors de la mise en place du script
+
+Ces points sont gérés par le script ; ils sont documentés ici pour qu'on puisse les retrouver si quelqu'un doit retoucher la logique.
+
+### `SELECT pg_catalog.set_config('search_path', '', false);`
+
+`pg_dump` émet cette ligne en tête de chaque dump. Elle vide le `search_path` de la session. Quand Prisma applique ensuite la migration, il tente d'écrire `finished_at` dans `min._prisma_migrations` mais ne la trouve plus sans search_path qualifié. Erreur trompeuse :
+
+```
+Error: P1014
+The underlying table for model `_prisma_migrations` does not exist.
+```
+
+→ Le script supprime cette ligne.
+
+### `CREATE SCHEMA` dupliqués
+
+`pg_dump` inclut `CREATE SCHEMA admin;` (sans `IF NOT EXISTS`) pour tous les schémas non exclus. Or la migration "1" provisionne déjà les schémas. Le second `CREATE SCHEMA` plante avec :
+
+```
+ERROR: schema "admin" already exists (42P06)
+```
+
+→ Le script supprime les `CREATE SCHEMA` et `ALTER SCHEMA ... OWNER TO` pour `admin`, `main`, `reference`, `audit`.
+
+### `CREATE SCHEMA min` à ne PAS insérer
+
+Le DAG dataspace insère un `CREATE SCHEMA min;` avant l'extension `citext WITH SCHEMA min`. Côté Prisma, c'est inutile (et nocif) : Prisma crée automatiquement tous les schémas listés dans `schemas = ["admin","main","min","reference"]` de `schema.prisma` avant de jouer les migrations. L'ajouter manuellement déclenche la même erreur 42P06 que ci-dessus.
+
+→ Contrairement au DAG, le script local n'insère **pas** `CREATE SCHEMA min;`.
+
+### `OWNER TO dataspace` vs `OWNER TO sonum`
+
+En prod, tous les objets dataspace sont owned par `sonum`. En local, certaines tables récentes (refonte phase 5 : `lieu_inclusion`, `structure_administrative`, etc.) sont owned par `dataspace`, le rôle de connexion Flyway local. Le rôle `dataspace` n'existe pas en test, le `ALTER TABLE ... OWNER TO dataspace` plante.
+
+→ Le script normalise `OWNER TO dataspace` → `OWNER TO sonum` à la régénération.
+
+→ **Cause racine côté dataspace, à corriger là-bas** : les migrations Flyway `V073` → `V092` créent des objets sans `ALTER ... OWNER TO sonum` (ou sans `SET ROLE sonum` en tête de migration). Le sed du script est un compromis, pas une vraie correction.
+
+### Schémas exclus du dump
+
+Liste reprise du DAG `database_pseudonym_export`, complétée :
+- `min`, `api`, `auth`, `cache`, `dataviz`, `import`, `public`, `pseudonymisation` (exclusion du DAG)
+- `opendata` (présent en local seulement, pas en prod)
+
+`audit` n'est **pas** exclu : il est référencé en prod via les tables `audit.personne_merge_log` et `audit.structure_merge_log`.
+
+## Actions futures
+
+Le script résout le problème opérationnel mais ne corrige pas la cause architecturale. Pistes par ordre de coût croissant :
+
+1. **Côté dataspace** : ajouter `SET ROLE sonum;` en tête des migrations Flyway, ou bien `ALTER ... OWNER TO sonum` après chaque `CREATE TABLE`. Une fois fait, on peut retirer le sed `OWNER TO dataspace → sonum` du script.
+
+2. **`prisma.schema` multi-fichiers** : depuis Prisma 5.15, on peut éclater `schema.prisma` en plusieurs fichiers via `prismaSchemaFolder`. On pourrait isoler la partie dataspace dans `prisma/dataspace.prisma` marquée read-only, et garder `prisma/min.prisma` pour ce que MIN possède réellement. Plus clair, mais le générateur Prisma reste mono-base.
+
+3. **`schema.prisma` publié par dataspace** : faire de dataspace un producteur de schéma Prisma (`prisma db pull` côté dataspace, commit, publication en artefact npm/git), et MIN le consomme. Élimine la dérive, mais introduit un cycle CI inter-projets.
+
+4. **Lecture via PostgREST** : remplacer l'accès Prisma direct aux schémas non-`min` par des appels à l'API PostgREST (`api.*`) déjà exposée par dataspace. MIN n'aurait alors plus à modéliser admin/main/reference côté Prisma du tout. Refactor lourd mais c'est l'architecture la plus propre.
+
+À court terme, (1) est la victoire la plus rapide et la plus utile (corrige une vraie bizarrerie locale). (2) à (4) restent ouvertes selon l'évolution de l'organisation autour des deux projets.
+
+## Fichiers concernés
+
+- `scripts/sync-dataspace-migration.sh` — le script de régénération
+- `prisma/migrations/20250619151605_1_dataspace_integration_create_roles_and_schema/migration.sql` — rôles + schémas (écrite à la main, stable)
+- `prisma/migrations/20250619151605_2_dataspace_integration/migration.sql` — structure dataspace (régénérée par le script)
+- `~/Dev/dataspace/db_pseudonym_export.py` — DAG dont le script s'inspire pour la pseudonymisation distante

--- a/docs/integration-dataspace.md
+++ b/docs/integration-dataspace.md
@@ -4,11 +4,11 @@
 
 MIN partage sa base PostgreSQL avec [dataspace](https://gitlab.com/incubateur-territoires/startups/data-inclusion-numerique/dataspace), l'agrégateur de données ETL de l'inclusion numérique. Les deux projets cohabitent dans la même base mais avec des responsabilités distinctes :
 
-| Schéma                           | Propriétaire | Outil de migration         |
-| -------------------------------- | ------------ | -------------------------- |
-| `admin`, `main`, `reference`, `audit` | dataspace    | Flyway (`database/migrations/`) |
-| `min`                            | MIN          | Prisma (`prisma/migrations/`)   |
-| `api`, `auth`, `dataviz`, `import`, `public`, `pseudonymisation` | dataspace | Flyway (non utilisé côté MIN)   |
+| Schéma                                                           | Propriétaire | Outil de migration              |
+| ---------------------------------------------------------------- | ------------ | ------------------------------- |
+| `admin`, `main`, `reference`, `audit`                            | dataspace    | Flyway (`database/migrations/`) |
+| `min`                                                            | MIN          | Prisma (`prisma/migrations/`)   |
+| `api`, `auth`, `dataviz`, `import`, `public`, `pseudonymisation` | dataspace    | Flyway (non utilisé côté MIN)   |
 
 En production, **MIN ne joue plus ses migrations Prisma** : `prisma migrate deploy` est désactivé. Les schémas non-`min` sont entièrement gérés par Flyway côté dataspace. MIN n'a la main que sur le schéma `min`.
 
@@ -33,6 +33,7 @@ pnpm dotenv:test -- pnpm prisma:reset
 ```
 
 Le script `scripts/sync-dataspace-migration.sh` :
+
 - attaque la base locale `postgres-dataspace:5532/dataspace_dev` via `docker exec` (pas besoin de pseudonymisation puisque c'est du dev)
 - reproduit l'esprit des tâches `export`, `clean`, `functions` du DAG `database_pseudonym_export` côté dataspace
 - écrit directement dans `prisma/migrations/20250619151605_2_dataspace_integration/migration.sql`
@@ -42,6 +43,7 @@ Variables d'override (rarement utiles) : `DATASPACE_CONTAINER`, `DATASPACE_DB`, 
 ## Avant l'automatisation
 
 L'ancien workflow nécessitait :
+
 1. déclencher le DAG `database_pseudonym_export` côté Airflow,
 2. récupérer l'archive pseudonymisée sur Nextcloud,
 3. concaténer manuellement les fichiers `*-structure-pre-data-*.sql` et `*-structure-post-data-*.sql`,
@@ -92,6 +94,7 @@ En prod, tous les objets dataspace sont owned par `sonum`. En local, certaines t
 ### Schémas exclus du dump
 
 Liste reprise du DAG `database_pseudonym_export`, complétée :
+
 - `min`, `api`, `auth`, `cache`, `dataviz`, `import`, `public`, `pseudonymisation` (exclusion du DAG)
 - `opendata` (présent en local seulement, pas en prod)
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "prisma:migrate": "prisma migrate dev",
     "prisma:generate": "prisma generate",
     "prisma:reset": "prisma migrate reset -f ",
+    "db:sync-dataspace": "bash scripts/sync-dataspace-migration.sh",
     "psql:local": "docker compose up -d postgres-dev && docker exec -it min_db_dev psql -U min min",
     "psql:init": "bash scripts/psql-init.sh",
     "psql:test": "docker compose up -d postgres-test && docker exec -it min_db_test psql -U min min",

--- a/scripts/sync-dataspace-migration.sh
+++ b/scripts/sync-dataspace-migration.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Régénère la migration Prisma "dataspace_integration" à partir de la base
+# dataspace locale, sans passer par le backup pseudonymisé distant.
+#
+# Reproduit l'esprit des tâches `export` / `clean` / `functions` du DAG
+# database_pseudonym_export (dataspace/db_pseudonym_export.py), section
+# structure uniquement (pas de données).
+#
+# Usage :
+#   ./scripts/sync-dataspace-migration.sh
+#
+# Variables (override possible) :
+#   DATASPACE_CONTAINER  nom du container postgres dataspace (default: postgres-dataspace)
+#   DATASPACE_DB         base à dumper                       (default: dataspace_dev)
+#   DATASPACE_USER       utilisateur psql                    (default: dataspace)
+#   MIGRATION_FILE       fichier de sortie                   (default: prisma/migrations/20250619151605_2_dataspace_integration/migration.sql)
+
+set -euo pipefail
+
+CONTAINER="${DATASPACE_CONTAINER:-postgres-dataspace}"
+DB="${DATASPACE_DB:-dataspace_dev}"
+USER="${DATASPACE_USER:-dataspace}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+MIGRATION_FILE="${MIGRATION_FILE:-$MIN_ROOT/prisma/migrations/20250619151605_2_dataspace_integration/migration.sql}"
+
+# Schémas à exclure : on reprend la liste du DAG database_pseudonym_export.
+# `audit` n'est PAS exclu : la migration "1" provisionne le schéma, et le dump
+# en prod l'inclut (cf tables audit.personne_merge_log / structure_merge_log).
+# `opendata` est exclu : présent en local seulement, pas en prod.
+EXCLUDE_SCHEMAS=(min api auth cache dataviz import public pseudonymisation opendata)
+EXCLUDE_ARGS=()
+for s in "${EXCLUDE_SCHEMAS[@]}"; do
+  EXCLUDE_ARGS+=(-N "$s")
+done
+
+if ! docker ps --format '{{.Names}}' | grep -qx "$CONTAINER"; then
+  echo "Le container '$CONTAINER' n'est pas démarré." >&2
+  echo "Lance d'abord la stack dataspace (docker compose -f docker-compose.dev.yml up -d postgres-dataspace)." >&2
+  exit 1
+fi
+
+if [[ ! -d "$(dirname "$MIGRATION_FILE")" ]]; then
+  echo "Dossier de migration introuvable : $(dirname "$MIGRATION_FILE")" >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+PRE="$TMP_DIR/pre.sql"
+POST="$TMP_DIR/post.sql"
+
+echo "→ pg_dump pre-data ($DB sur $CONTAINER)…"
+docker exec "$CONTAINER" pg_dump -U "$USER" -d "$DB" --section=pre-data "${EXCLUDE_ARGS[@]}" > "$PRE"
+
+echo "→ pg_dump post-data…"
+docker exec "$CONTAINER" pg_dump -U "$USER" -d "$DB" --section=post-data "${EXCLUDE_ARGS[@]}" > "$POST"
+
+# Transformations équivalentes à la tâche `clean` du DAG :
+# - retirer les directives pgcrypto (extension non utilisée côté Prisma)
+# - retirer les lignes de commentaires "--" isolées (bruit du pg_dump)
+# - retirer les "SET transaction_timeout" et "\restrict" (incompatibles selon version client/server)
+# - retirer le `SELECT pg_catalog.set_config('search_path', '', false);`
+#   émis en tête du dump : il vide le search_path de la session, ce qui fait
+#   ensuite échouer Prisma quand il tente d'écrire finished_at dans
+#   min._prisma_migrations (erreur P1014 trompeuse "table does not exist")
+# - retirer les CREATE SCHEMA admin/main/reference/audit (déjà créés par la
+#   migration "1_dataspace_integration_create_roles_and_schema") ainsi que
+#   les ALTER SCHEMA OWNER associés (idem)
+# - normaliser OWNER TO dataspace -> OWNER TO sonum (alignement avec la prod ;
+#   l'ownership "dataspace" en local vient des migrations Flyway qui ne
+#   réalignent pas vers sonum)
+#
+# Note : on n'insère PAS de CREATE SCHEMA min; ici (contrairement au DAG).
+# Prisma crée automatiquement tous les schémas listés dans schema.prisma
+# (`schemas = ["admin","main","min","reference"]`) avant de jouer les
+# migrations — l'ajouter manuellement ferait planter le reset avec 42P06.
+echo "→ nettoyage…"
+sed -i \
+  -e '/pgcrypto/d' \
+  -e '/^--$/d' \
+  -e '/transaction_timeout/d' \
+  -e "/^SELECT pg_catalog.set_config('search_path'/d" \
+  -e '/^\\restrict/d' \
+  -e '/^\\unrestrict/d' \
+  -e '/^CREATE SCHEMA \(admin\|main\|reference\|audit\);$/d' \
+  -e '/^ALTER SCHEMA \(admin\|main\|reference\|audit\) OWNER TO /d' \
+  -e 's/OWNER TO dataspace;$/OWNER TO sonum;/' \
+  "$PRE"
+
+sed -i \
+  -e '/^--$/d' \
+  -e '/transaction_timeout/d' \
+  -e "/^SELECT pg_catalog.set_config('search_path'/d" \
+  -e '/^\\restrict/d' \
+  -e '/^\\unrestrict/d' \
+  -e 's/OWNER TO dataspace;$/OWNER TO sonum;/' \
+  "$POST"
+
+# Tâche `functions` du DAG : ces fonctions vivent dans le schéma public et
+# sont référencées par des triggers dans la post-data ; il faut donc qu'elles
+# soient définies avant.
+cat >> "$PRE" <<'SQL'
+CREATE OR REPLACE FUNCTION public.updated_at_column() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN NEW.updated_at = now(); RETURN NEW; END; $$;
+CREATE OR REPLACE FUNCTION public.edited_by_column() RETURNS TRIGGER AS $$ BEGIN IF NEW.edited_by IS NULL THEN NEW.edited_by = current_user; END IF; RETURN NEW; END; $$ LANGUAGE plpgsql;
+SQL
+
+echo "→ écriture de $MIGRATION_FILE"
+cat "$PRE" "$POST" > "$MIGRATION_FILE"
+
+LINES=$(wc -l < "$MIGRATION_FILE")
+echo "OK — $LINES lignes écrites."
+echo
+echo "Vérifie ensuite que tout passe :"
+echo "  pnpm dotenv:test -- pnpm prisma:reset"


### PR DESCRIPTION
## Summary

- Nouveau script `pnpm db:sync-dataspace` qui régénère la migration Prisma `20250619151605_2_dataspace_integration/migration.sql` depuis la base dataspace locale (container `postgres-dataspace:5532/dataspace_dev`).
- Documente l'architecture du partage de base entre MIN et dataspace dans `docs/integration-dataspace.md` (workflow de sync, pièges identifiés, pistes d'évolution).
- Le README pointe vers la nouvelle doc et mentionne la commande.

## Pourquoi

Avant ce PR : pour resynchroniser la migration dataspace côté MIN (par exemple quand le schéma dataspace évolue sur une branche), il fallait déclencher le DAG `database_pseudonym_export` côté Airflow, récupérer l'archive sur Nextcloud, concaténer manuellement les fichiers de structure, coller dans la migration, faire un `db:pull` puis restaurer manuellement la partie `min`. Lourd et facile à rater.

Maintenant : `pnpm db:sync-dataspace` fait tout en une commande contre la base dataspace locale.

## Pièges traités par le script (documentés dans `docs/integration-dataspace.md`)

- `SELECT pg_catalog.set_config('search_path', '', false);` émis par `pg_dump` casse Prisma (erreur P1014 trompeuse "_prisma_migrations does not exist").
- `CREATE SCHEMA admin/main/reference/audit` dupliqués entre la migration "1" et le dump.
- Normalisation `OWNER TO dataspace` → `OWNER TO sonum` (les migrations Flyway récentes côté dataspace ne réalignent pas vers `sonum` — à corriger côté dataspace, voir doc).
- Pas d'insertion de `CREATE SCHEMA min;` (Prisma le crée automatiquement via `schemas = [...]`).

## Test plan

- [ ] `cd ~/Dev/dataspace && ./scripts-dev/run-flyway.sh migrate`
- [ ] `cd ~/Dev/min && pnpm db:sync-dataspace`
- [ ] `pnpm dotenv:test -- pnpm prisma:reset` passe sans erreur
- [ ] Vérifier que `docs/integration-dataspace.md` rend bien sur GitHub
- [ ] Vérifier que la TOC du README pointe vers la nouvelle section

🤖 Generated with [Claude Code](https://claude.com/claude-code)