### PR TITLE
fix(superadmin): baser l'indicateur FNE du sélecteur de structure sur min.membre confirmé

### DIFF
--- a/src/gateways/PrismaStructureLoader.test.ts
+++ b/src/gateways/PrismaStructureLoader.test.ts
@@ -1,14 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { PrismaStructureLoader } from './PrismaStructureLoader'
-import {
-  creerUnContact,
-  creerUnDepartement,
-  creerUneGouvernance,
-  creerUneRegion,
-  creerUneStructure,
-  creerUnMembre,
-} from './testHelper'
+import { creerUnDepartement, creerUneGouvernance, creerUneRegion, creerUneStructure, creerUnMembre } from './testHelper'
 import prisma from '../../prisma/prismaClient'
 
 describe('structures loader', () => {
@@ -216,7 +209,7 @@ describe('structures loader', () => {
       expect(structureReadModel).toStrictEqual([])
     })
 
-    it("indique si une structure est membre d'une gouvernance", async () => {
+    it("indique si une structure est membre d'une gouvernance sans être FNE quand le membre n'est pas confirmé", async () => {
       // GIVEN
       await creerUneRegion()
       await creerUnDepartement({ code: '10', nom: 'Aube' })
@@ -227,10 +220,10 @@ describe('structures loader', () => {
         nom: "Conseil départemental de l'Aube",
       })
       await creerUneGouvernance({ departementCode: '10' })
-      await creerUnContact({ email: 'contact@aube.fr' })
       await creerUnMembre({
         gouvernanceDepartementCode: '10',
         id: 'membre-100',
+        statut: 'candidat',
         structureId: 100,
       })
 
@@ -249,7 +242,7 @@ describe('structures loader', () => {
       ])
     })
 
-    it('indique si une structure a un contact référent FNE', async () => {
+    it('indique si une structure est FNE quand elle a un membre confirmé', async () => {
       // GIVEN
       await creerUneRegion()
       await creerUnDepartement({ code: '10', nom: 'Aube' })
@@ -259,9 +252,12 @@ describe('structures loader', () => {
         id: 100,
         nom: "Conseil départemental de l'Aube",
       })
-      const contactId = await creerUnContact({ email: 'referent-fne@aube.fr', est_referent_fne: true })
-      await prisma.contact_structure_administrative.create({
-        data: { contact_id: contactId, structure_administrative_id: 100 },
+      await creerUneGouvernance({ departementCode: '10' })
+      await creerUnMembre({
+        gouvernanceDepartementCode: '10',
+        id: 'membre-100',
+        statut: 'confirme',
+        structureId: 100,
       })
 
       // WHEN
@@ -272,7 +268,7 @@ describe('structures loader', () => {
         {
           commune: 'TROYES',
           isFne: true,
-          isMembre: false,
+          isMembre: true,
           nom: "Conseil départemental de l'Aube",
           uid: '100',
         },

--- a/src/gateways/PrismaStructureLoader.ts
+++ b/src/gateways/PrismaStructureLoader.ts
@@ -42,8 +42,9 @@ export class PrismaStructureLoader implements StructureLoader {
     // Refonte 2026 : recherche sur COALESCE(denomination_antenne, denomination_sirene)
     // de main.structure_administrative. denomination_antenne permet de distinguer
     // les antennes d'un grand reseau partageant le SIRET du siege (Emmaüs
-    // Connect, Reconnect Groupe SOS, …). Les contacts referents FNE sont
-    // desormais dans main.contact_structure_administrative.
+    // Connect, Reconnect Groupe SOS, …). L'indicateur FNE est determine par la
+    // presence d'un membre confirme (min.membre au statut « confirme ») pour la
+    // structure.
     const conditionsMots = mots
       .map(
         (_, index) =>
@@ -72,9 +73,8 @@ export class PrismaStructureLoader implements StructureLoader {
         a.nom_commune as commune,
         EXISTS(SELECT 1 FROM min.membre m WHERE m.structure_id = sa.id) as is_membre,
         EXISTS(
-          SELECT 1 FROM main.contact_structure_administrative csa
-          JOIN main.contact c ON csa.contact_id = c.id
-          WHERE csa.structure_administrative_id = sa.id AND c.est_referent_fne = true
+          SELECT 1 FROM min.membre m
+          WHERE m.structure_id = sa.id AND m.statut = 'confirme'
         ) as is_fne
       FROM main.structure_administrative sa
       LEFT JOIN main.adresse a ON sa.adresse_id = a.id


### PR DESCRIPTION
## Contexte

Dans le sélecteur de structure (en-tête à droite, contexte superadmin / dépersonification), un badge **« FNE »** indique si la structure sélectionnée est FNE ou non.

## Changement

L'indicateur `is_fne` ne dépend **plus des contacts** de la structure (`main.contact.est_referent_fne`). Une structure est désormais FNE si son `structure_id` est référencé dans `min.membre` **avec le statut `confirme`**.

```diff
- EXISTS(
-   SELECT 1 FROM main.contact_structure_administrative csa
-   JOIN main.contact c ON csa.contact_id = c.id
-   WHERE csa.structure_administrative_id = sa.id AND c.est_referent_fne = true
- ) as is_fne
+ EXISTS(
+   SELECT 1 FROM min.membre m
+   WHERE m.structure_id = sa.id AND m.statut = 'confirme'
+ ) as is_fne
```

📄 `src/gateways/PrismaStructureLoader.ts`

## Tests

`src/gateways/PrismaStructureLoader.test.ts` : les deux scénarios FNE ont été réécrits
- membre **non** confirmé (`candidat`) → `isMembre: true`, `isFne: false`
- membre **confirmé** → `isMembre: true`, `isFne: true`

✅ 12/12 tests passent. Le composant `SelecteurStructure.tsx` est inchangé (consomme toujours `isFne`).

Closes #1479
