### PR TITLE
  fix(structure): aligner une structure membre FNE sur une structure …

### DIFF
--- a/src/app/(connecte)/(avec-menu)/(default)/tableau-de-bord/blocs/BlocAccueil.tsx
+++ b/src/app/(connecte)/(avec-menu)/(default)/tableau-de-bord/blocs/BlocAccueil.tsx
@@ -6,7 +6,7 @@ import { Contexte, Scope } from '@/use-cases/queries/ResoudreContexte'
 
 export default function BlocAccueil({ contexte, prenom, scope }: Props): ReactElement {
   const suffixScope = scope.type === 'departement' ? ` · ${scope.code}` : ''
-  const sousTitre = contexte.estGestionnaireStructureSansGouvernance()
+  const sousTitre = contexte.estGestionnaireStructureSansCoportage()
     ? "Bienvenue sur votre espace structure de l'inclusion numérique"
     : `Bienvenue sur l'outil de pilotage de l'Inclusion Numérique${suffixScope}`
   const options = gouvernancesSelecteurPresenteur(contexte)

--- a/src/app/(connecte)/(avec-menu)/(default)/tableau-de-bord/page.tsx
+++ b/src/app/(connecte)/(avec-menu)/(default)/tableau-de-bord/page.tsx
@@ -12,7 +12,6 @@ import BlocGouvernance from './blocs/BlocGouvernance'
 import BlocMediateurs from './blocs/BlocMediateurs'
 import BlocRejoindreGouvernance from './blocs/BlocRejoindreGouvernance'
 import { blocsParContexte, IdentifiantBloc } from './registreBlocs'
-import FilAriane from '@/components/vitrine/FilAriane/FilAriane'
 import { getSession, getSessionSub } from '@/gateways/NextAuthAuthentificationGateway'
 import { PrismaMembreLoader } from '@/gateways/PrismaMembreLoader'
 import { PrismaUtilisateurLoader } from '@/gateways/PrismaUtilisateurLoader'
@@ -47,6 +46,8 @@ export default async function TableauDeBordController(): Promise<ReactElement> {
     scope = contexte.scopes.find((scope) => scope.type === 'france')
   } else if (contexte.aCesRoles('gestionnaire_departement')) {
     scope = contexte.scopes.find((scope) => scope.type === 'departement')
+  } else if (contexte.estGestionnaireStructureSansCoportage()) {
+    scope = contexte.scopes.find((scope) => scope.type === 'structure')
   } else if (options.length === 1 && options[0].value !== 'France') {
     scope = { code: options[0].value, type: 'departement' }
   } else {
@@ -69,10 +70,5 @@ export default async function TableauDeBordController(): Promise<ReactElement> {
     rejoindreGouvernance: <BlocRejoindreGouvernance key="rejoindreGouvernance" />,
   }
 
-  return (
-    <>
-      <FilAriane items={[{ label: 'Tableau de bord' }]} />
-      {blocs.map((bloc) => blocsElements[bloc])}
-    </>
-  )
+  return <>{blocs.map((bloc) => blocsElements[bloc])}</>
 }

--- a/src/app/(connecte)/(avec-menu)/(default)/tableau-de-bord/registreBlocs.ts
+++ b/src/app/(connecte)/(avec-menu)/(default)/tableau-de-bord/registreBlocs.ts
@@ -12,17 +12,15 @@ export type IdentifiantBloc =
   | 'rejoindreGouvernance'
 
 export function blocsParContexte(contexte: Contexte): ReadonlyArray<IdentifiantBloc> {
-  const estGestionnaireStructure = contexte.aCesRoles('gestionnaire_structure') && !contexte.estDansGouvernance()
-
   const blocs: Array<IdentifiantBloc> = ['accueil']
 
-  if (estGestionnaireStructure) {
+  if (contexte.estGestionnaireStructureSansCoportage()) {
     blocs.push('donneesStructure')
   }
 
   if (
     contexte.aCesRoles('administrateur_dispositif', 'gestionnaire_departement', 'gestionnaire_region') ||
-    contexte.estDansGouvernance()
+    contexte.estCoporteur()
   ) {
     blocs.push('etatDesLieux', 'gouvernance')
   }
@@ -42,7 +40,7 @@ export function blocsParContexte(contexte: Contexte): ReadonlyArray<IdentifiantB
     blocs.push('beneficiaires')
   }
 
-  if (estGestionnaireStructure && !contexte.aCesRoles('administrateur_dispositif', 'gestionnaire_departement')) {
+  if (contexte.estGestionnaireStructureHorsGouvernance()) {
     blocs.push('rejoindreGouvernance', 'cartographie')
   }
 

--- a/src/components/transverse/MenuLateral/MenuLateral.test.tsx
+++ b/src/components/transverse/MenuLateral/MenuLateral.test.tsx
@@ -13,6 +13,11 @@ const contexteGouvernance = new Contexte('gestionnaire_structure', [
   { code: '93', type: 'coporteur' },
 ])
 
+const contexteMembreFne = new Contexte('gestionnaire_structure', [
+  { code: '42', type: 'structure' },
+  { code: '93', type: 'membre' },
+])
+
 const contexteSuperAdmin = new Contexte('administrateur_dispositif', [{ type: 'france' }], true)
 
 describe('menu lateral', () => {
@@ -231,6 +236,39 @@ describe('menu lateral', () => {
     // THEN
     const maStructure = screen.queryByRole('link', { name: 'Ma structure' })
     expect(maStructure).not.toBeInTheDocument()
+  })
+
+  it.each([
+    { name: 'Aidants et médiateurs', url: '/liste-aidants-mediateurs' },
+    { name: "Lieux d'inclusion", url: '/liste-lieux-inclusion' },
+  ])(
+    "étant un gestionnaire de structure membre simple FNE, quand j'affiche le menu latéral, alors le listing $name est limité à sa structure",
+    ({ name, url }) => {
+      // WHEN
+      render(
+        <menuActifContext.Provider value="/">
+          <MenuLateral contexte={contexteMembreFne} />
+        </menuActifContext.Provider>
+      )
+
+      // THEN
+      const element = screen.getByRole('link', { name })
+      expect(element).toHaveAttribute('href', url)
+    }
+  )
+
+  it("étant un gestionnaire de structure membre simple FNE, quand j'affiche le menu latéral, alors le menu Gouvernance reste visible", () => {
+    // WHEN
+    render(
+      <menuActifContext.Provider value="/">
+        <MenuLateral contexte={contexteMembreFne} />
+      </menuActifContext.Provider>
+    )
+
+    // THEN
+    const nav = screen.getByRole('navigation', { name: 'Menu inclusion numérique' })
+    const gouvernance = within(nav).getByRole('link', { name: 'Gouvernance' })
+    expect(gouvernance).toHaveAttribute('href', '/gouvernance/93')
   })
 
   it("étant un utilisateur autre que gestionnaire de département, quand j'affiche le menu latéral, alors il ne s'affiche pas avec le lien de la gouvernance", () => {

--- a/src/components/transverse/MenuLateral/registreMenus.ts
+++ b/src/components/transverse/MenuLateral/registreMenus.ts
@@ -167,7 +167,7 @@ function sectionPilotageParContexte(contexte: Contexte): Section {
       label: "Lieux d'inclusion",
       url: () => '/lieux-inclusion',
     })
-  } else if (nb === 1) {
+  } else if (nb === 1 && !contexte.estGestionnaireStructureSansCoportage()) {
     menus.push({
       icon: 'group-line',
       label: 'Aidants et médiateurs',

--- a/src/use-cases/queries/ResoudreContexte.test.ts
+++ b/src/use-cases/queries/ResoudreContexte.test.ts
@@ -282,7 +282,7 @@ describe('résoudre contexte - scopes', () => {
     expect(contexte.scopeFiltre()).toStrictEqual({ codes: ['69'], type: 'departemental' })
   })
 
-  it('scopeFiltre — gestionnaire structure retourne les codes de ses gouvernances', async () => {
+  it('scopeFiltre — gestionnaire structure coporteur retourne les codes de ses gouvernances', async () => {
     // GIVEN
     const utilisateur = utilisateurAvecRole('gestionnaire_structure', { structureId: 42 })
     const loader = loaderStub({
@@ -297,6 +297,20 @@ describe('résoudre contexte - scopes', () => {
 
     // THEN
     expect(contexte.scopeFiltre()).toStrictEqual({ codes: ['64', '75'], type: 'departemental' })
+  })
+
+  it('scopeFiltre — gestionnaire structure membre simple retourne son id de structure', async () => {
+    // GIVEN
+    const utilisateur = utilisateurAvecRole('gestionnaire_structure', { structureId: 42 })
+    const loader = loaderStub({
+      appartenances: [{ codeDepartement: '64', estCoporteur: false }],
+    })
+
+    // WHEN
+    const contexte = await resoudreContexte(utilisateur, loader)
+
+    // THEN
+    expect(contexte.scopeFiltre()).toStrictEqual({ id: 42, type: 'structure' })
   })
 
   it('scopeFiltre — gestionnaire structure sans gouvernance retourne son id de structure', async () => {

--- a/src/use-cases/queries/ResoudreContexte.ts
+++ b/src/use-cases/queries/ResoudreContexte.ts
@@ -71,8 +71,12 @@ export class Contexte {
     return this.scopes.some((scope) => scope.type === 'coporteur' || scope.type === 'membre')
   }
 
-  estGestionnaireStructureSansGouvernance(): boolean {
+  estGestionnaireStructureHorsGouvernance(): boolean {
     return this.role === 'gestionnaire_structure' && !this.estDansGouvernance()
+  }
+
+  estGestionnaireStructureSansCoportage(): boolean {
+    return this.role === 'gestionnaire_structure' && !this.estCoporteur()
   }
 
   estNational(): boolean {
@@ -136,7 +140,7 @@ export class Contexte {
     if (this.estNational()) {
       return { type: 'national' }
     }
-    if (this.estGestionnaireStructureSansGouvernance()) {
+    if (this.estGestionnaireStructureSansCoportage()) {
       return { id: this.idStructure(), type: 'structure' }
     }
     return { codes: this.codesDepartements(), type: 'departemental' }


### PR DESCRIPTION
…hors FNE

  Une structure gestionnaire membre simple (non co-porteur) d'une gouvernance
  voit désormais ses listings (aidants, lieux) et son tableau de bord limités à
  sa propre structure, comme une structure hors FNE. Seul le menu Gouvernance
  reste accessible.

  - ResoudreContexte: distingue estGestionnaireStructureSansCoportage (périmètre structure) de estGestionnaireStructureHorsGouvernance (non membre)
  - tableau de bord: scope structure pour le membre FNE ; bloc « rejoindre une gouvernance » réservé aux structures hors gouvernance
  - menu latéral: listings aidants/lieux limités à la structure

# Contrat du dev

## Qualité

- [x] Relire le code
- [x] Relire le ticket
- [x] [Relire les critères d'acceptation](https://github.com/anct-cnum/suite-gestionnaire-numerique/discussions/252)


> **Et n'oublie pas de vérifier ce que tu as fait en production !**
