### PR TITLE
fix(dashboard): supprimer le libellé "comprenant X financements" sur la vue structure FNE

### DIFF
--- a/src/components/TableauDeBord/FinancementsStructure.tsx
+++ b/src/components/TableauDeBord/FinancementsStructure.tsx
@@ -55,7 +55,6 @@ export default function FinancementsStructure({
     : [COULEUR_VIDE]
   const data = aDesFinancements ? viewModel.ventilationSubventionsParEnveloppe.map((detail) => detail.montant) : [1]
   const labels = viewModel.ventilationSubventionsParEnveloppe.map((detail) => detail.label)
-  const { nombreDeFinancementsEngagesParLEtat } = viewModel
 
   return (
     <BlocCard labelledBy="financements-structure">
@@ -85,13 +84,6 @@ export default function FinancementsStructure({
           </div>
           <div className="fr-text--sm fr-mb-0" style={{ fontWeight: 500 }}>
             Financements engagés par l&apos;État
-          </div>
-          <div className="fr-text--xs color-blue-france fr-mb-0">
-            comprenant{' '}
-            <span style={{ fontWeight: 700 }}>
-              {nombreDeFinancementsEngagesParLEtat} financement
-              {nombreDeFinancementsEngagesParLEtat > 1 ? 's' : ''}
-            </span>
           </div>
         </div>
         <div className="fr-col">


### PR DESCRIPTION
## Contexte

Sur le dashboard, en tant que structure FNE, l'encart « Financements » affichait sous le total un sous-libellé « comprenant **X** financements ».

## Problème

Ce chiffre ne sera jamais juste : on compte les **actions**, et on n'est pas capable de compter les **postes financés**. Le libellé induisait en erreur.

## Changement

Suppression du libellé « comprenant X financements » sous le total de l'encart Financements (vue structure FNE uniquement) + retrait de la variable locale devenue inutilisée. Le total et la ventilation « Dont » sont inchangés.

Les libellés cousins « comprenant X actions enregistrées » (dashboards Préfecture/Admin) ne sont **pas** concernés.

Closes #1551

🤖 Generated with [Claude Code](https://claude.com/claude-code)