### PR TITLE
feat(menu): masquer Rapports + Statistiques du menu superadmin (démo)

### DIFF
--- a/src/components/transverse/MenuLateral/MenuLateral.test.tsx
+++ b/src/components/transverse/MenuLateral/MenuLateral.test.tsx
@@ -136,7 +136,7 @@ describe('menu lateral', () => {
     }
   )
 
-  it("étant super admin, quand j'affiche le menu latéral, alors la section RAPPORTS ET STATISTIQUES s'affiche avec le lien Statistiques", () => {
+  it("étant super admin, quand j'affiche le menu latéral, alors la section RAPPORTS ET STATISTIQUES est masquée (démo)", () => {
     // WHEN
     render(
       <menuActifContext.Provider value="/">
@@ -146,10 +146,9 @@ describe('menu lateral', () => {
 
     // THEN
     const nav = screen.getByRole('navigation', { name: 'Menu inclusion numérique' })
-    const rapportsEtStatistiques = within(nav).getByText('RAPPORTS ET STATISTIQUES', { selector: 'p' })
-    expect(rapportsEtStatistiques).toBeInTheDocument()
-    const lienStatistiques = screen.getByRole('link', { name: 'Statistiques' })
-    expect(lienStatistiques).toHaveAttribute('href', '/statistiques')
+    expect(within(nav).queryByText('RAPPORTS ET STATISTIQUES', { selector: 'p' })).not.toBeInTheDocument()
+    expect(within(nav).queryByRole('link', { name: 'Statistiques' })).not.toBeInTheDocument()
+    expect(within(nav).queryByRole('link', { name: 'Rapports' })).not.toBeInTheDocument()
   })
 
   it("étant un utilisateur non super admin, quand j'affiche le menu latéral, alors la section RAPPORTS ET STATISTIQUES n'est pas visible", () => {
@@ -164,20 +163,6 @@ describe('menu lateral', () => {
     expect(lienStatistiques).not.toBeInTheDocument()
     const lienRapports = within(nav).queryByRole('link', { name: 'Rapports' })
     expect(lienRapports).not.toBeInTheDocument()
-  })
-
-  it("étant super admin, quand j'affiche le menu latéral, alors le lien Rapports s'affiche", () => {
-    // WHEN
-    render(
-      <menuActifContext.Provider value="/">
-        <MenuLateral contexte={contexteSuperAdmin} />
-      </menuActifContext.Provider>
-    )
-
-    // THEN
-    const nav = screen.getByRole('navigation', { name: 'Menu inclusion numérique' })
-    const lienRapports = within(nav).getByRole('link', { name: 'Rapports' })
-    expect(lienRapports).toHaveAttribute('href', '/rapports')
   })
 
   it("étant administrateur dispositif non super admin, quand j'affiche le menu latéral, alors Rapports s'affiche mais pas Statistiques", () => {

--- a/src/components/transverse/MenuLateral/registreMenus.ts
+++ b/src/components/transverse/MenuLateral/registreMenus.ts
@@ -89,7 +89,8 @@ export function sectionsParContexte(contexte: Contexte): ReadonlyArray<Section> 
 
   sections.push(sectionPilotageParContexte(contexte))
 
-  if (contexte.estSuperAdmin() || contexte.aCesRoles('administrateur_dispositif')) {
+  // Masquage temporaire pour démo : Rapports + Statistiques cachés au superadmin (revert à la demande)
+  if (contexte.aCesRoles('administrateur_dispositif') && !contexte.estSuperAdmin()) {
     sections.push(sectionRapportsEtStatistiques)
   }
 


### PR DESCRIPTION
## Contexte

Pour une démo, on masque du **menu latéral** les entrées « Rapports » et « Statistiques » quand on est connecté en **superadmin**.

## Changement

Dans `registreMenus.ts`, la section « RAPPORTS ET STATISTIQUES » n'est plus poussée pour un superadmin (condition `aCesRoles('administrateur_dispositif') && !estSuperAdmin()`).

- **Superadmin** : section masquée (ni Rapports, ni Statistiques).
- **`administrateur_dispositif` non-superadmin** : voit toujours « Rapports » (inchangé).
- Masquage **menu uniquement**, les routes ne sont pas bloquées.

## Revert

Masquage temporaire pour démo. Le commit est isolé et balisé par un commentaire dans `registreMenus.ts` → revert à la demande via `git revert`.

Tests `MenuLateral.test.tsx` mis à jour (31/31 ✓).

Closes #1553

🤖 Generated with [Claude Code](https://claude.com/claude-code)