### PR TITLE
fix(tableau-de-bord): intégrer le Conum au total du donut Financements (fiche structure)

### DIFF
--- a/src/app/(connecte)/(avec-menu)/(default)/tableau-de-bord/blocs/BlocFinancements.tsx
+++ b/src/app/(connecte)/(avec-menu)/(default)/tableau-de-bord/blocs/BlocFinancements.tsx
@@ -79,16 +79,13 @@ async function financementsStructure(structureId: number): Promise<ReactElement>
     new PrismaFinancementsStructureLoader().get(structureId),
     cnLoader.getParStructure(structureId),
   ])
-  const financementsViewModel = handleReadModelOrError(financementsReadModel, financementsStructurePresenter)
-  const enveloppesConum = enveloppesConseillerNumeriquePresenter(enveloppesConumReadModel.enveloppes, new Date())
-
-  return (
-    <FinancementsStructure
-      enveloppesConseillerNumerique={enveloppesConum}
-      lienFinancements="/gouvernance/financements"
-      viewModel={financementsViewModel}
-    />
+  // Fix #1557 : on fond le Conum dans le total/ventilation du donut (plus de bloc de jauges séparé).
+  const financementsViewModel = financementsStructurePresenter(
+    financementsReadModel,
+    enveloppesConumReadModel.enveloppes
   )
+
+  return <FinancementsStructure lienFinancements="/gouvernance/financements" viewModel={financementsViewModel} />
 }
 
 type Props = Readonly<{

--- a/src/components/TableauDeBord/FinancementsStructure.tsx
+++ b/src/components/TableauDeBord/FinancementsStructure.tsx
@@ -4,22 +4,16 @@ import Link from 'next/link'
 import { ReactElement } from 'react'
 
 import BlocCard from './BlocCard'
-import EnveloppesConseillerNumerique from './EnveloppesConseillerNumerique'
 import styles from './TableauDeBord.module.css'
 import Dot from '../shared/Dot/Dot'
 import Doughnut from '../shared/Doughnut/Doughnut'
 import TitleIcon from '../shared/TitleIcon/TitleIcon'
 import { ErrorViewModel } from '@/components/shared/ErrorViewModel'
-import { EnveloppeConseillerNumeriqueViewModel } from '@/presenters/tableauDeBord/enveloppesConseillerNumeriquePresenter'
 import { FinancementsStructureViewModel } from '@/presenters/tableauDeBord/financementsStructurePresenter'
 
 const COULEUR_VIDE = '#DDDDDD'
 
-export default function FinancementsStructure({
-  enveloppesConseillerNumerique,
-  lienFinancements,
-  viewModel,
-}: Props): ReactElement {
+export default function FinancementsStructure({ lienFinancements, viewModel }: Props): ReactElement {
   if (isErrorViewModel(viewModel)) {
     return (
       <BlocCard labelledBy="financements-structure">
@@ -102,9 +96,6 @@ export default function FinancementsStructure({
               </li>
             ))}
           </ul>
-          {enveloppesConseillerNumerique !== undefined && enveloppesConseillerNumerique.length > 0 && (
-            <EnveloppesConseillerNumerique contexte="departement" enveloppes={enveloppesConseillerNumerique} />
-          )}
         </div>
       </div>
     </BlocCard>
@@ -116,7 +107,6 @@ function isErrorViewModel(viewModel: ErrorViewModel | FinancementsStructureViewM
 }
 
 type Props = Readonly<{
-  enveloppesConseillerNumerique?: ReadonlyArray<EnveloppeConseillerNumeriqueViewModel>
   lienFinancements: string
   viewModel: ErrorViewModel | FinancementsStructureViewModel
 }>

--- a/src/presenters/tableauDeBord/financementsStructurePresenter.test.ts
+++ b/src/presenters/tableauDeBord/financementsStructurePresenter.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest'
+
+import { financementsStructurePresenter, FinancementsStructureViewModel } from './financementsStructurePresenter'
+import { obtenirCouleurEnveloppe, obtenirCouleurGraphique } from '../shared/enveloppe'
+import { formatMontant } from '../shared/number'
+import { epochTime } from '@/shared/testHelper'
+import { FinancementsStructureReadModel } from '@/use-cases/queries/RecupererFinancementsStructure'
+import { EnveloppeConseillerNumeriqueReadModel } from '@/use-cases/queries/RecupererLesEnveloppesConseillerNumerique'
+
+describe('financements structure presenter', () => {
+  it("quand il n'y a que du FNE alors le total et la ventilation ne contiennent que le FNE", () => {
+    // GIVEN
+    const readModel: FinancementsStructureReadModel = {
+      nombreDeFinancementsEngagesParLEtat: 2,
+      totalFinancements: '65100',
+      ventilationSubventionsParEnveloppe: [
+        { enveloppeTotale: '0', label: 'Formation Aidant Numérique/Aidants Connect - 2024 - État', total: '20000' },
+        { enveloppeTotale: '0', label: 'Ingénierie France Numérique Ensemble - 2024 - État', total: '45100' },
+      ],
+    }
+
+    // WHEN
+    const viewModel = financementsStructurePresenter(readModel)
+
+    // THEN
+    expect(viewModel).toStrictEqual({
+      nombreDeFinancementsEngagesParLEtat: 2,
+      totalFinancements: formatMontant(65100),
+      ventilationSubventionsParEnveloppe: [
+        ventilationAttendue('Formation Aidant Numérique/Aidants Connect - 2024 - État', 20000),
+        ventilationAttendue('Ingénierie France Numérique Ensemble - 2024 - État', 45100),
+      ],
+    })
+  })
+
+  it("quand il n'y a que du Conum alors le total et la ventilation reprennent le Conum au lieu d'un total à 0", () => {
+    // GIVEN
+    const readModel: FinancementsStructureReadModel = {
+      nombreDeFinancementsEngagesParLEtat: 0,
+      totalFinancements: '0',
+      ventilationSubventionsParEnveloppe: [],
+    }
+    const enveloppesConum = [
+      enveloppeConum('Conseiller Numérique - Plan France Relance - État', 50000n),
+      enveloppeConum('Conseiller Numérique - Renouvellement - État', 37500n),
+    ]
+
+    // WHEN
+    const viewModel = financementsStructurePresenter(readModel, enveloppesConum)
+
+    // THEN
+    expect(viewModel).toStrictEqual({
+      nombreDeFinancementsEngagesParLEtat: 0,
+      totalFinancements: formatMontant(87500),
+      ventilationSubventionsParEnveloppe: [
+        ventilationAttendue('Conseiller Numérique - Plan France Relance - État', 50000),
+        ventilationAttendue('Conseiller Numérique - Renouvellement - État', 37500),
+      ],
+    })
+  })
+
+  it('quand il y a du FNE et du Conum alors le total additionne les deux et la ventilation les liste', () => {
+    // GIVEN
+    const readModel: FinancementsStructureReadModel = {
+      nombreDeFinancementsEngagesParLEtat: 1,
+      totalFinancements: '35100',
+      ventilationSubventionsParEnveloppe: [
+        { enveloppeTotale: '0', label: 'Ingénierie France Numérique Ensemble - 2024 - État', total: '35100' },
+      ],
+    }
+    const enveloppesConum = [enveloppeConum('Conseiller Numérique - Plan France Relance - État', 39999n)]
+
+    // WHEN
+    const viewModel = financementsStructurePresenter(readModel, enveloppesConum)
+
+    // THEN
+    expect(viewModel).toStrictEqual({
+      nombreDeFinancementsEngagesParLEtat: 1,
+      totalFinancements: formatMontant(75099),
+      ventilationSubventionsParEnveloppe: [
+        ventilationAttendue('Ingénierie France Numérique Ensemble - 2024 - État', 35100),
+        ventilationAttendue('Conseiller Numérique - Plan France Relance - État', 39999),
+      ],
+    })
+  })
+
+  it('quand une enveloppe Conum est à 0 alors elle est ignorée', () => {
+    // GIVEN
+    const readModel: FinancementsStructureReadModel = {
+      nombreDeFinancementsEngagesParLEtat: 0,
+      totalFinancements: '0',
+      ventilationSubventionsParEnveloppe: [],
+    }
+    const enveloppesConum = [
+      enveloppeConum('Conseiller Numérique - Plan France Relance - État', 50000n),
+      enveloppeConum('Conseiller Numérique - Renouvellement - État', 0n),
+    ]
+
+    // WHEN
+    const viewModel = financementsStructurePresenter(readModel, enveloppesConum)
+
+    // THEN
+    expect(viewModel).toStrictEqual({
+      nombreDeFinancementsEngagesParLEtat: 0,
+      totalFinancements: formatMontant(50000),
+      ventilationSubventionsParEnveloppe: [
+        ventilationAttendue('Conseiller Numérique - Plan France Relance - État', 50000),
+      ],
+    })
+  })
+
+  it('quand le read model est en erreur alors le view model est en erreur', () => {
+    // WHEN
+    const viewModel = financementsStructurePresenter({ message: 'Boom', type: 'error' })
+
+    // THEN
+    expect(viewModel).toStrictEqual({ message: 'Boom', type: 'error' })
+  })
+})
+
+function enveloppeConum(libelle: string, consommation: bigint): EnveloppeConseillerNumeriqueReadModel {
+  return { consommation, dateDeDebut: epochTime, dateDeFin: epochTime, libelle, plafond: 0 }
+}
+
+function ventilationAttendue(
+  label: string,
+  montant: number
+): FinancementsStructureViewModel['ventilationSubventionsParEnveloppe'][number] {
+  const couleur = obtenirCouleurEnveloppe(label)
+  return {
+    color: couleur,
+    couleurGraphique: obtenirCouleurGraphique(couleur),
+    label,
+    montant,
+    total: formatMontant(montant),
+  }
+}

--- a/src/presenters/tableauDeBord/financementsStructurePresenter.ts
+++ b/src/presenters/tableauDeBord/financementsStructurePresenter.ts
@@ -2,10 +2,14 @@ import { obtenirCouleurEnveloppe, obtenirCouleurGraphique } from '../shared/enve
 import { formatMontant } from '../shared/number'
 import { ErrorViewModel } from '@/components/shared/ErrorViewModel'
 import { FinancementsStructureReadModel } from '@/use-cases/queries/RecupererFinancementsStructure'
+import { EnveloppeConseillerNumeriqueReadModel } from '@/use-cases/queries/RecupererLesEnveloppesConseillerNumerique'
 import { ErrorReadModel } from '@/use-cases/queries/shared/ErrorReadModel'
 
+// Fix #1557 : le donut historique ne sommait que le FNE et affichait le Conum dans un bloc séparé.
+// On fond ici les enveloppes Conum dans la ventilation et le total pour que la somme = le total.
 export function financementsStructurePresenter(
-  readModel: ErrorReadModel | FinancementsStructureReadModel
+  readModel: ErrorReadModel | FinancementsStructureReadModel,
+  enveloppesConseillerNumerique: ReadonlyArray<EnveloppeConseillerNumeriqueReadModel> = []
 ): ErrorViewModel | FinancementsStructureViewModel {
   if (isErrorReadModel(readModel)) {
     return {
@@ -14,13 +18,19 @@ export function financementsStructurePresenter(
     }
   }
 
-  const totalFinancements = Number(readModel.totalFinancements)
+  const ventilation = [
+    ...readModel.ventilationSubventionsParEnveloppe.map(({ label, total }) => ({ label, montant: Number(total) })),
+    ...enveloppesConseillerNumerique
+      .filter((enveloppe) => Number(enveloppe.consommation) > 0)
+      .map((enveloppe) => ({ label: enveloppe.libelle, montant: Number(enveloppe.consommation) })),
+  ]
+
+  const totalFinancements = ventilation.reduce((accumulateur, { montant }) => accumulateur + montant, 0)
 
   return {
     nombreDeFinancementsEngagesParLEtat: readModel.nombreDeFinancementsEngagesParLEtat,
     totalFinancements: formatMontant(totalFinancements),
-    ventilationSubventionsParEnveloppe: readModel.ventilationSubventionsParEnveloppe.map(({ label, total }) => {
-      const montant = Number(total)
+    ventilationSubventionsParEnveloppe: ventilation.map(({ label, montant }) => {
       const couleur = obtenirCouleurEnveloppe(label)
       return {
         color: couleur,


### PR DESCRIPTION
## Contexte

Sur le donut « Financements » de la fiche structure, le total « Financements engagés par l'État » ne sommait que le **FNE** et affichait le **Conum** dans un bloc de jauges séparé en dessous. Une structure sans FNE mais avec du Conum (ex. **4901**) affichait **0 €** alors que des enveloppes Conum apparaissaient juste en dessous → **somme ≠ total**.

## Changement

On fond les enveloppes Conum (déjà chargées via `getParStructure`) dans le **total** et la **ventilation « Dont »** du donut, dans `financementsStructurePresenter`. Le bloc de jauges Conum séparé est retiré (redondant).

- 4901 (Conum seul) → **87 500 €** au lieu de 0 €.
- Somme des parts = total dans tous les cas (FNE seul / Conum seul / mixte).
- Enveloppes Conum à 0 € filtrées.
- Tests presenter ajoutés (5 cas ✓).

Fix d'attente avant la refonte de fond #1557 (affichage piloté par le type de financement).

Closes #1558