### PR TITLE
fix(tableau-de-bord): charger les chiffres Coop côté client pour ne plus figer l'UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,20 +2,41 @@
 
 ## Commandes
 
-- `yarn db:start` — Démarrer la base de données PostgreSQL locale (Docker)
-- `yarn dev` — Serveur de développement (Turbo)
-- `yarn test` — Migrations + vitest run
-- `yarn test:watch` — Tests en mode watch
-- `yarn test:coverage` — Tests avec couverture (seuil 90%)
-- `yarn typecheck` — Vérification TypeScript
-- `yarn lint:ts` — ESLint (max 0 warnings)
-- `yarn lint:css` — Stylelint
-- `yarn format` — Formatage Prettier
-- `yarn check` — Tous les contrôles qualité (dedupe, deadcode, typecheck, prisma format, format, lint, test:coverage)
-- `yarn deadcode` — Détection de code mort (Knip)
-- `yarn prisma:migrate` — Migrations Prisma
-- `yarn prisma:generate` — Regénérer le client Prisma après modification du schéma
-- `yarn storybook` — Lancer Storybook
+> ⚠️ Le gestionnaire de paquets est **pnpm** (`packageManager: pnpm@10.12.1`, `pnpm-lock.yaml`),
+> imposé par corepack — `yarn` est refusé. Toujours utiliser `pnpm <script>`.
+
+- `pnpm install` — Installer les dépendances (le `postinstall` n'exécute PAS `prisma:generate`)
+- `pnpm db:start` — Démarrer la base de données PostgreSQL locale (Docker)
+- `pnpm dev` — Serveur de développement (Turbo)
+- `pnpm test` — Migrations + vitest run
+- `pnpm test:watch` — Tests en mode watch
+- `pnpm test:coverage` — Tests avec couverture (seuil 90%)
+- `pnpm typecheck` — Vérification TypeScript
+- `pnpm lint:ts` — ESLint (max 0 warnings)
+- `pnpm lint:css` — Stylelint
+- `pnpm format` — Formatage Prettier
+- `pnpm check` — Tous les contrôles qualité (dedupe, deadcode, typecheck, prisma format, format, lint, test:coverage)
+- `pnpm deadcode` — Détection de code mort (Knip)
+- `pnpm prisma:migrate` — Migrations Prisma
+- `pnpm prisma:generate` — Regénérer le client Prisma. **Indispensable après `pnpm install`**
+  (le client n'est pas généré par le postinstall) et après toute modification de `prisma/schema.prisma`.
+  Sans lui, l'app ne démarre pas (`next dev` plante : import du client Prisma manquant).
+- `pnpm storybook` — Lancer Storybook
+
+### Travailler dans un git worktree
+
+Les `git worktree` ne partagent pas `node_modules` (ignoré par git). Dans un nouveau worktree :
+
+```bash
+git worktree add -b <n°issue>-<desc> ../min-<desc> main
+cd ../min-<desc>
+pnpm install            # vrai install — ne PAS symlinker node_modules vers le checkout principal
+                        # (Turbopack ne résout plus Next.js, et `pnpm install` proposerait
+                        #  d'effacer le node_modules du repo principal)
+pnpm prisma:generate    # le client Prisma n'est pas généré par le postinstall
+cp ../min/.env.local .  # variables d'env locales (non suivies par git)
+pnpm dev
+```
 
 ## Architecture
 
@@ -113,7 +134,7 @@ Pattern strict dans `src/app/api/actions/` :
 - `it.each([...])` avec `$intention` pour les tests paramétrés
 - Factories de test data : `createDefaultXxxViewModel()` dans `src/stories/`
 - Constantes de date : `epochTime`, `epochTimePlusOneDay` (jamais `new Date()`)
-- Pre-push hook (`husky`) : exécute `yarn check` complet
+- Pre-push hook (`husky`) : exécute `pnpm check` complet
 
 ## Base de données
 

--- a/src/app/(connecte)/(avec-menu)/(default)/tableau-de-bord/blocs/BlocEtatDesLieux.tsx
+++ b/src/app/(connecte)/(avec-menu)/(default)/tableau-de-bord/blocs/BlocEtatDesLieux.tsx
@@ -13,7 +13,6 @@ import {
 } from '@/presenters/tableauDeBord/indicesPresenter'
 import { lieuxInclusionNumeriquePresenter } from '@/presenters/tableauDeBord/lieuxInclusionNumeriquePresenter'
 import { mediateursEtAidantsPresenter } from '@/presenters/tableauDeBord/mediateursEtAidantsPresenter'
-import { fetchAccompagnementsRealises } from '@/use-cases/queries/fetchAccompagnementsRealises'
 import { Scope } from '@/use-cases/queries/ResoudreContexte'
 
 export default async function BlocEtatDesLieux({ scope }: Props): Promise<ReactElement> {
@@ -22,8 +21,6 @@ export default async function BlocEtatDesLieux({ scope }: Props): Promise<ReactE
   const lieuxInclusionLoader = new PrismaLieuxInclusionNumeriqueLoader()
   const mediateursEtAidantsLoader = new PrismaMediateursEtAidantsLoader()
   const indicesLoader = new PrismaIndicesDeFragiliteLoader()
-
-  const accompagnementsRealisesPromise = fetchAccompagnementsRealises(code)
 
   const lieuxInclusionReadModel = await lieuxInclusionLoader.get(code)
   const lieuxInclusionViewModel = handleReadModelOrError(lieuxInclusionReadModel, lieuxInclusionNumeriquePresenter)
@@ -39,7 +36,7 @@ export default async function BlocEtatDesLieux({ scope }: Props): Promise<ReactE
 
   return (
     <EtatDesLieux
-      accompagnementsRealisesPromise={accompagnementsRealisesPromise}
+      accompagnementsTerritoire={code}
       carte={carte}
       lieuxInclusionViewModel={lieuxInclusionViewModel}
       mediateursEtAidantsViewModel={mediateursEtAidantsViewModel}

--- a/src/app/api/tableau-de-bord/accompagnements-realises/route.test.ts
+++ b/src/app/api/tableau-de-bord/accompagnements-realises/route.test.ts
@@ -1,0 +1,53 @@
+import { NextRequest } from 'next/server'
+import { describe, expect, it, vi } from 'vitest'
+
+import { GET } from './route'
+import * as ssoGateway from '@/gateways/NextAuthAuthentificationGateway'
+import * as fetchAccompagnementsRealisesModule from '@/use-cases/queries/fetchAccompagnementsRealises'
+
+describe('route /api/tableau-de-bord/accompagnements-realises', () => {
+  it('retourne une erreur 403 quand l’utilisateur n’est pas authentifié', async () => {
+    // GIVEN
+    vi.spyOn(ssoGateway, 'getSession').mockResolvedValueOnce(null)
+    const req = { nextUrl: { searchParams: new Map() } } as unknown as NextRequest
+
+    // WHEN
+    const result = await GET(req)
+
+    // THEN
+    expect(result.status).toBe(403)
+  })
+
+  it('retourne les accompagnements du territoire demandé', async () => {
+    // GIVEN
+    vi.spyOn(ssoGateway, 'getSession').mockResolvedValueOnce({ user: {} as ssoGateway.Profile })
+    const resultat = { nombreTotal: 42, repartitionMensuelle: [{ mois: 'Jan.', nombre: 7 }] }
+    const spy = vi
+      .spyOn(fetchAccompagnementsRealisesModule, 'fetchAccompagnementsRealises')
+      .mockResolvedValueOnce(resultat)
+    const req = { nextUrl: { searchParams: new Map([['territoire', '06']]) } } as unknown as NextRequest
+
+    // WHEN
+    const result = await GET(req)
+
+    // THEN
+    expect(spy).toHaveBeenCalledWith('06')
+    expect(result.status).toBe(200)
+    expect(await result.json()).toStrictEqual(resultat)
+  })
+
+  it('utilise France par défaut quand le territoire n’est pas précisé', async () => {
+    // GIVEN
+    vi.spyOn(ssoGateway, 'getSession').mockResolvedValueOnce({ user: {} as ssoGateway.Profile })
+    const spy = vi
+      .spyOn(fetchAccompagnementsRealisesModule, 'fetchAccompagnementsRealises')
+      .mockResolvedValueOnce({ nombreTotal: 0, repartitionMensuelle: [] })
+    const req = { nextUrl: { searchParams: new Map() } } as unknown as NextRequest
+
+    // WHEN
+    await GET(req)
+
+    // THEN
+    expect(spy).toHaveBeenCalledWith('France')
+  })
+})

--- a/src/app/api/tableau-de-bord/accompagnements-realises/route.ts
+++ b/src/app/api/tableau-de-bord/accompagnements-realises/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { ErrorViewModel } from '@/components/shared/ErrorViewModel'
+import { getSession } from '@/gateways/NextAuthAuthentificationGateway'
+import {
+  AccompagnementsRealisesResult,
+  fetchAccompagnementsRealises,
+} from '@/use-cases/queries/fetchAccompagnementsRealises'
+
+export async function GET(
+  request: NextRequest
+): Promise<NextResponse<AccompagnementsRealisesResult | ErrorViewModel | null>> {
+  const session = await getSession()
+  if (!session) {
+    return NextResponse.json(null, { status: 403 })
+  }
+
+  const territoire = request.nextUrl.searchParams.get('territoire') ?? 'France'
+  const resultat = await fetchAccompagnementsRealises(territoire)
+
+  return NextResponse.json(resultat)
+}

--- a/src/components/TableauDeBord/EtatDesLieux/AccompagnementsRealises.tsx
+++ b/src/components/TableauDeBord/EtatDesLieux/AccompagnementsRealises.tsx
@@ -3,50 +3,15 @@
 import { ReactElement, Suspense } from 'react'
 
 import AccompagnementsRealisesAsyncLoader from './AccompagnementsRealisesAsyncLoader'
-import TitleIcon from '../../shared/TitleIcon/TitleIcon'
-import styles from '../TableauDeBord.module.css'
+import AccompagnementsRealisesView from './AccompagnementsRealisesView'
 import { ErrorViewModel } from '@/components/shared/ErrorViewModel'
-import Information from '@/components/shared/Information/Information'
 import { AccompagnementsRealisesResult } from '@/use-cases/queries/fetchAccompagnementsRealises'
 
 export default function AccompagnementsRealises({ accompagnementsRealisesPromise }: Props): ReactElement {
   return (
-    <Suspense fallback={<AccompagnementsRealisesSkeleton />}>
+    <Suspense fallback={<AccompagnementsRealisesView etat={{ statut: 'chargement' }} />}>
       <AccompagnementsRealisesAsyncLoader accompagnementsRealisesPromise={accompagnementsRealisesPromise} />
     </Suspense>
-  )
-}
-
-function AccompagnementsRealisesSkeleton(): ReactElement {
-  return (
-    <>
-      <div className="background-blue-france fr-p-3w fr-ml-1w">
-        <div className={`${styles.indicateurValeur} fr-m-0`}>
-          <TitleIcon background="white" icon="compass-3-line" />
-          <span className="color-grey">...</span>
-        </div>
-        <div className="font-weight-500">
-          <span> Accompagnements réalisés</span>
-          <Information>
-            <p className="fr-mb-0">
-              Depuis <strong>2021</strong>, avec les dispositifs <strong>Conseillers Numériques</strong> et
-              <strong>Aidants Connect.</strong>
-            </p>
-          </Information>
-        </div>
-      </div>
-      <div className="background-blue-france fr-p-3w fr-ml-1w fr-mt-1w">
-        <div className="font-weight-500">
-          <span> Accompagnements des 6 derniers mois</span>
-          <Information>
-            <p className="fr-mb-0">
-              Accompagnements saisis sur <strong>La Coop.</strong>
-            </p>
-          </Information>
-        </div>
-        <div className="fr-text--sm color-grey fr-mt-2w">Chargement...</div>
-      </div>
-    </>
   )
 }
 

--- a/src/components/TableauDeBord/EtatDesLieux/AccompagnementsRealisesAsyncLoader.tsx
+++ b/src/components/TableauDeBord/EtatDesLieux/AccompagnementsRealisesAsyncLoader.tsx
@@ -2,86 +2,18 @@
 
 import { ReactElement, use } from 'react'
 
-import Bar from '../../shared/Bar/Bar'
-import TitleIcon from '../../shared/TitleIcon/TitleIcon'
-import styles from '../TableauDeBord.module.css'
+import AccompagnementsRealisesView from './AccompagnementsRealisesView'
 import { ErrorViewModel, isErrorViewModel } from '@/components/shared/ErrorViewModel'
-import Information from '@/components/shared/Information/Information'
-import { formaterEnNombreFrancais } from '@/presenters/shared/number'
 import { AccompagnementsRealisesResult } from '@/use-cases/queries/fetchAccompagnementsRealises'
 
 export default function AccompagnementsRealisesAsyncLoader({ accompagnementsRealisesPromise }: Props): ReactElement {
   const result = use(accompagnementsRealisesPromise)
 
   if (isErrorViewModel(result)) {
-    return (
-      <>
-        <div className="background-blue-france fr-p-3w fr-ml-1w">
-          <div className={`${styles.indicateurValeur} fr-m-0`}>
-            <TitleIcon background="white" icon="error-warning-line" />—
-          </div>
-          <div className="font-weight-500">
-            <span> Accompagnements réalisés</span>
-            <Information>
-              <p className="fr-mb-0">
-                Depuis <strong>2021</strong>, avec les dispositifs <strong>Conseillers Numériques</strong> et
-                <strong>Aidants Connect.</strong>
-              </p>
-            </Information>
-          </div>
-          <div className="fr-text--xs color-blue-france fr-mb-0">{result.message}</div>
-        </div>
-        <div className="background-blue-france fr-p-3w fr-ml-1w fr-mt-1w">
-          <div className="font-weight-500">
-            <span> Accompagnements des 6 derniers mois</span>
-            <Information>
-              <p className="fr-mb-0">Accompagnements saisis sur La Coop</p>
-            </Information>
-          </div>
-          <div className="fr-text--xs color-blue-france fr-mb-0">{result.message}</div>
-        </div>
-      </>
-    )
+    return <AccompagnementsRealisesView etat={{ message: result.message, statut: 'erreur' }} />
   }
 
-  const backgroundColor = ['#CACAFB', '#CACAFB', '#CACAFB', '#CACAFB', '#CACAFB', '#6A6AF4']
-
-  return (
-    <>
-      <div className="background-blue-france fr-p-3w fr-ml-1w">
-        <div className={`${styles.indicateurValeur} fr-m-0`}>
-          <TitleIcon background="white" icon="compass-3-line" />
-          {formaterEnNombreFrancais(result.nombreTotal)}
-        </div>
-        <div className="font-weight-500">
-          <span> Accompagnements réalisés</span>
-          <Information>
-            <p className="fr-mb-0">
-              Depuis 2021, avec les dispositifs <strong>Conseillers Numériques</strong> et{' '}
-              <strong>Aidants Connect</strong>
-            </p>
-          </Information>
-        </div>
-      </div>
-      <div className="background-blue-france fr-p-3w fr-ml-1w fr-mt-1w">
-        <Bar
-          backgroundColor={backgroundColor}
-          data={result.repartitionMensuelle.map((item) => item.nombre)}
-          header={
-            <div className="font-weight-500">
-              <span> Accompagnements des 6 derniers mois</span>
-              <Information>
-                <p className="fr-mb-0">
-                  Accompagnements saisis sur <strong>La Coop.</strong>
-                </p>
-              </Information>
-            </div>
-          }
-          labels={result.repartitionMensuelle.map((item) => item.mois)}
-        />
-      </div>
-    </>
-  )
+  return <AccompagnementsRealisesView etat={{ resultat: result, statut: 'charge' }} />
 }
 
 type Props = Readonly<{

--- a/src/components/TableauDeBord/EtatDesLieux/AccompagnementsRealisesClient.test.tsx
+++ b/src/components/TableauDeBord/EtatDesLieux/AccompagnementsRealisesClient.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import AccompagnementsRealisesClient from './AccompagnementsRealisesClient'
+import { AccompagnementsRealisesResult } from '@/use-cases/queries/fetchAccompagnementsRealises'
+
+describe('AccompagnementsRealisesClient', () => {
+  it('affiche l’état de chargement avant la réponse de l’API', () => {
+    // GIVEN
+    vi.spyOn(globalThis, 'fetch').mockReturnValueOnce(new Promise(() => {}))
+
+    // WHEN
+    render(<AccompagnementsRealisesClient territoire="France" />)
+
+    // THEN
+    expect(screen.getByText('Chargement...').textContent).toBe('Chargement...')
+  })
+
+  it('récupère les accompagnements du territoire puis affiche le résultat', async () => {
+    // GIVEN
+    const resultat: AccompagnementsRealisesResult = {
+      nombreTotal: 1234,
+      repartitionMensuelle: [{ mois: 'Jan.', nombre: 10 }],
+    }
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      json: async () => Promise.resolve(resultat),
+    } as unknown as Response)
+
+    // WHEN
+    render(<AccompagnementsRealisesClient territoire="06" />)
+
+    // THEN
+    expect(await screen.findByText('Bar Chart Mock')).toBeDefined()
+    expect(fetchSpy).toHaveBeenCalledWith('/api/tableau-de-bord/accompagnements-realises?territoire=06')
+  })
+
+  it('affiche le message d’erreur quand l’API renvoie une erreur métier', async () => {
+    // GIVEN
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      json: async () => Promise.resolve({ message: 'Erreur Coop', type: 'error' }),
+    } as unknown as Response)
+
+    // WHEN
+    render(<AccompagnementsRealisesClient territoire="France" />)
+
+    // THEN
+    expect((await screen.findAllByText('Erreur Coop')).length).toBeGreaterThan(0)
+  })
+
+  it('affiche un message d’erreur générique quand la requête échoue', async () => {
+    // GIVEN
+    vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(new Error('réseau indisponible'))
+
+    // WHEN
+    render(<AccompagnementsRealisesClient territoire="France" />)
+
+    // THEN
+    expect((await screen.findAllByText('Erreur de récupération des données')).length).toBeGreaterThan(0)
+  })
+})

--- a/src/components/TableauDeBord/EtatDesLieux/AccompagnementsRealisesClient.tsx
+++ b/src/components/TableauDeBord/EtatDesLieux/AccompagnementsRealisesClient.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { ReactElement, useEffect, useState } from 'react'
+
+import AccompagnementsRealisesView, { AccompagnementsRealisesEtat } from './AccompagnementsRealisesView'
+import { ErrorViewModel, isErrorViewModel } from '@/components/shared/ErrorViewModel'
+import { AccompagnementsRealisesResult } from '@/use-cases/queries/fetchAccompagnementsRealises'
+
+export default function AccompagnementsRealisesClient({ territoire }: Props): ReactElement {
+  const [etat, setEtat] = useState<AccompagnementsRealisesEtat>({ statut: 'chargement' })
+
+  useEffect(() => {
+    let annule = false
+    setEtat({ statut: 'chargement' })
+
+    void fetch(`/api/tableau-de-bord/accompagnements-realises?territoire=${encodeURIComponent(territoire)}`)
+      .then((reponse) => reponse.json() as Promise<AccompagnementsRealisesResult | ErrorViewModel>)
+      .then((donnees) => {
+        if (annule) {
+          return
+        }
+        if (isErrorViewModel(donnees)) {
+          setEtat({ message: donnees.message, statut: 'erreur' })
+        } else {
+          setEtat({ resultat: donnees, statut: 'charge' })
+        }
+      })
+      .catch(() => {
+        if (annule) {
+          return
+        }
+        setEtat({ message: 'Erreur de récupération des données', statut: 'erreur' })
+      })
+
+    return () => {
+      annule = true
+    }
+  }, [territoire])
+
+  return <AccompagnementsRealisesView etat={etat} />
+}
+
+type Props = Readonly<{
+  territoire: string
+}>

--- a/src/components/TableauDeBord/EtatDesLieux/AccompagnementsRealisesView.tsx
+++ b/src/components/TableauDeBord/EtatDesLieux/AccompagnementsRealisesView.tsx
@@ -1,0 +1,123 @@
+import { ReactElement } from 'react'
+
+import Bar from '../../shared/Bar/Bar'
+import TitleIcon from '../../shared/TitleIcon/TitleIcon'
+import styles from '../TableauDeBord.module.css'
+import Information from '@/components/shared/Information/Information'
+import { formaterEnNombreFrancais } from '@/presenters/shared/number'
+import { AccompagnementsRealisesResult } from '@/use-cases/queries/fetchAccompagnementsRealises'
+
+export type AccompagnementsRealisesEtat =
+  | Readonly<{ message: string; statut: 'erreur' }>
+  | Readonly<{ resultat: AccompagnementsRealisesResult; statut: 'charge' }>
+  | Readonly<{ statut: 'chargement' }>
+
+export default function AccompagnementsRealisesView({ etat }: Props): ReactElement {
+  if (etat.statut === 'chargement') {
+    return (
+      <>
+        <div className="background-blue-france fr-p-3w fr-ml-1w">
+          <div className={`${styles.indicateurValeur} fr-m-0`}>
+            <TitleIcon background="white" icon="compass-3-line" />
+            <span className="color-grey">...</span>
+          </div>
+          <div className="font-weight-500">
+            <span> Accompagnements réalisés</span>
+            <Information>
+              <p className="fr-mb-0">
+                Depuis <strong>2021</strong>, avec les dispositifs <strong>Conseillers Numériques</strong> et
+                <strong>Aidants Connect.</strong>
+              </p>
+            </Information>
+          </div>
+        </div>
+        <div className="background-blue-france fr-p-3w fr-ml-1w fr-mt-1w">
+          <div className="font-weight-500">
+            <span> Accompagnements des 6 derniers mois</span>
+            <Information>
+              <p className="fr-mb-0">
+                Accompagnements saisis sur <strong>La Coop.</strong>
+              </p>
+            </Information>
+          </div>
+          <div className="fr-text--sm color-grey fr-mt-2w">Chargement...</div>
+        </div>
+      </>
+    )
+  }
+
+  if (etat.statut === 'erreur') {
+    return (
+      <>
+        <div className="background-blue-france fr-p-3w fr-ml-1w">
+          <div className={`${styles.indicateurValeur} fr-m-0`}>
+            <TitleIcon background="white" icon="error-warning-line" />—
+          </div>
+          <div className="font-weight-500">
+            <span> Accompagnements réalisés</span>
+            <Information>
+              <p className="fr-mb-0">
+                Depuis <strong>2021</strong>, avec les dispositifs <strong>Conseillers Numériques</strong> et
+                <strong>Aidants Connect.</strong>
+              </p>
+            </Information>
+          </div>
+          <div className="fr-text--xs color-blue-france fr-mb-0">{etat.message}</div>
+        </div>
+        <div className="background-blue-france fr-p-3w fr-ml-1w fr-mt-1w">
+          <div className="font-weight-500">
+            <span> Accompagnements des 6 derniers mois</span>
+            <Information>
+              <p className="fr-mb-0">Accompagnements saisis sur La Coop</p>
+            </Information>
+          </div>
+          <div className="fr-text--xs color-blue-france fr-mb-0">{etat.message}</div>
+        </div>
+      </>
+    )
+  }
+
+  const { resultat } = etat
+  const backgroundColor = ['#CACAFB', '#CACAFB', '#CACAFB', '#CACAFB', '#CACAFB', '#6A6AF4']
+
+  return (
+    <>
+      <div className="background-blue-france fr-p-3w fr-ml-1w">
+        <div className={`${styles.indicateurValeur} fr-m-0`}>
+          <TitleIcon background="white" icon="compass-3-line" />
+          {formaterEnNombreFrancais(resultat.nombreTotal)}
+        </div>
+        <div className="font-weight-500">
+          <span> Accompagnements réalisés</span>
+          <Information>
+            <p className="fr-mb-0">
+              Depuis 2021, avec les dispositifs <strong>Conseillers Numériques</strong> et{' '}
+              <strong>Aidants Connect</strong>
+            </p>
+          </Information>
+        </div>
+      </div>
+      <div className="background-blue-france fr-p-3w fr-ml-1w fr-mt-1w">
+        <Bar
+          backgroundColor={backgroundColor}
+          data={resultat.repartitionMensuelle.map((item) => item.nombre)}
+          header={
+            <div className="font-weight-500">
+              <span> Accompagnements des 6 derniers mois</span>
+              <Information>
+                <p className="fr-mb-0">
+                  Accompagnements saisis sur <strong>La Coop.</strong>
+                </p>
+              </Information>
+            </div>
+          }
+          labels={resultat.repartitionMensuelle.map((item) => item.mois)}
+        />
+      </div>
+    </>
+  )
+}
+
+type Props = Readonly<{
+  etat: AccompagnementsRealisesEtat
+}>

--- a/src/components/TableauDeBord/EtatDesLieux/EtatDesLieux.tsx
+++ b/src/components/TableauDeBord/EtatDesLieux/EtatDesLieux.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { ReactElement } from 'react'
 
 import AccompagnementsRealises from './AccompagnementsRealises'
+import AccompagnementsRealisesClient from './AccompagnementsRealisesClient'
 import styles from './CarteFragilite.module.css'
 import LieuxInclusionNumerique from './LieuxInclusionNumerique'
 import MediateursEtAidants from './MediateursEtAidants'
@@ -13,13 +14,15 @@ import { LieuxInclusionNumeriqueViewModel } from '@/presenters/tableauDeBord/lie
 import { MediateursEtAidantsViewModel } from '@/presenters/tableauDeBord/mediateursEtAidantsPresenter'
 import { AccompagnementsRealisesResult } from '@/use-cases/queries/fetchAccompagnementsRealises'
 
-export default function EtatDesLieux({
-  accompagnementsRealisesPromise,
-  afficherLienLieux = true,
-  carte,
-  lieuxInclusionViewModel,
-  mediateursEtAidantsViewModel,
-}: EtatDesLieuxProps): ReactElement {
+export default function EtatDesLieux(props: EtatDesLieuxProps): ReactElement {
+  const { afficherLienLieux = true, carte, lieuxInclusionViewModel, mediateursEtAidantsViewModel } = props
+  const accompagnements =
+    'accompagnementsTerritoire' in props ? (
+      <AccompagnementsRealisesClient territoire={props.accompagnementsTerritoire} />
+    ) : (
+      <AccompagnementsRealises accompagnementsRealisesPromise={props.accompagnementsRealisesPromise} />
+    )
+
   return (
     <section aria-labelledby="etatDesLieux" className="fr-mb-4w ">
       <div className="fr-grid-row fr-grid-row--middle fr-pb-2w">
@@ -57,17 +60,20 @@ export default function EtatDesLieux({
         <div className={`fr-col-12 fr-col-xl-4 ${styles.cardsColumn}`}>
           <LieuxInclusionNumerique viewModel={lieuxInclusionViewModel} />
           <MediateursEtAidants viewModel={mediateursEtAidantsViewModel} />
-          <AccompagnementsRealises accompagnementsRealisesPromise={accompagnementsRealisesPromise} />
+          {accompagnements}
         </div>
       </div>
     </section>
   )
 }
 
-type EtatDesLieuxProps = Readonly<{
-  accompagnementsRealisesPromise: Promise<AccompagnementsRealisesResult | ErrorViewModel>
-  afficherLienLieux?: boolean
-  carte: ReactElement
-  lieuxInclusionViewModel: ErrorViewModel | LieuxInclusionNumeriqueViewModel
-  mediateursEtAidantsViewModel: ErrorViewModel | MediateursEtAidantsViewModel
-}>
+type EtatDesLieuxProps = (
+  | Readonly<{ accompagnementsRealisesPromise: Promise<AccompagnementsRealisesResult | ErrorViewModel> }>
+  | Readonly<{ accompagnementsTerritoire: string }>
+) &
+  Readonly<{
+    afficherLienLieux?: boolean
+    carte: ReactElement
+    lieuxInclusionViewModel: ErrorViewModel | LieuxInclusionNumeriqueViewModel
+    mediateursEtAidantsViewModel: ErrorViewModel | MediateursEtAidantsViewModel
+  }>


### PR DESCRIPTION
## Problème

Sur le tableau de bord, les accompagnements réalisés (API Coop) du bloc « État des lieux » étaient récupérés **côté serveur** et sérialisés dans le payload RSC. La navigation et l'hydratation restaient donc liées à la réponse de l'API : pendant tout le chargement l'UI était **figée** — impossible d'ouvrir le menu compte en cliquant sur son nom. Reproductible en dev avec `COOP_TOKEN=FAKE_TOKEN_OK_15` (~15 s de gel).

## Solution

Les chiffres Coop du dashboard sont désormais récupérés **côté client** après montage, via une route handler dédiée :
- `GET /api/tableau-de-bord/accompagnements-realises` (auth) → `fetchAccompagnementsRealises`
- `AccompagnementsRealisesClient` (`useEffect` + `fetch`) → skeleton, puis valeurs ou erreur
- `AccompagnementsRealisesView` présentationnel partagé (chargement / erreur / chargé)
- `EtatDesLieux` : props en union — `accompagnementsTerritoire` (dashboard, client) **ou** `accompagnementsRealisesPromise` (vitrine, inchangée)

Résultat : shell et actions immédiatement réactifs, les chiffres se chargeant en arrière-plan. Le chemin **vitrine** (rendu serveur + Suspense, pour le SEO) est préservé.

## Tests

- typecheck, ESLint (0 warning), prettier OK
- nouveaux tests : composant client (chargement / chargé / erreur métier / échec réseau) + route handler (403 / territoire / France par défaut)
- la logique d'affichage est désormais portée par `AccompagnementsRealisesView` (couverte par les tests), au lieu d'être dans `AsyncLoader`/wrapper non testés

Closes #1563