### PR TITLE
fix(vitrine): corriger la collision code département / code région sur les stats médiateurs

### DIFF
--- a/src/app/(connecte)/(avec-menu)/(default)/tableau-de-bord/blocs/BlocMediateurs.tsx
+++ b/src/app/(connecte)/(avec-menu)/(default)/tableau-de-bord/blocs/BlocMediateurs.tsx
@@ -10,7 +10,10 @@ import { Scope } from '@/use-cases/queries/ResoudreContexte'
 
 export default async function BlocMediateurs({ scope }: Props): Promise<ReactElement> {
   const loader = new PrismaStatistiquesMediateursLoader()
-  const readModel = await loader.get(scope.type === 'france' ? 'France' : scope.code)
+  const readModel = await loader.get(
+    scope.type === 'france' ? 'France' : scope.code,
+    scope.type === 'region' ? 'region' : 'departement'
+  )
 
   if (isErrorReadModel(readModel)) {
     return <MediateursAidants viewModel={viewModelVide} />

--- a/src/app/vitrine/donnees-territoriales/(with-layout)/mediateurs-numeriques/[niveau]/[[...code]]/page.tsx
+++ b/src/app/vitrine/donnees-territoriales/(with-layout)/mediateurs-numeriques/[niveau]/[[...code]]/page.tsx
@@ -70,7 +70,10 @@ export default async function MediateursNumeriques({ params, searchParams }: Pro
 
   // Récupérer les statistiques synchrones des médiateurs
   const statistiquesMediateursLoader = new PrismaStatistiquesMediateursLoader()
-  const statistiquesMediateursReadModel = await statistiquesMediateursLoader.get(territoire)
+  const statistiquesMediateursReadModel = await statistiquesMediateursLoader.get(
+    territoire,
+    niveau === 'national' ? 'national' : 'departement'
+  )
   const statistiquesMediateursViewModel = handleReadModelOrError(
     statistiquesMediateursReadModel,
     statistiquesMediateursPresenter

--- a/src/gateways/PrismaStatistiquesMediateursLoader.ts
+++ b/src/gateways/PrismaStatistiquesMediateursLoader.ts
@@ -13,14 +13,15 @@ export interface StatistiquesMediateursReadModel {
 }
 
 export class PrismaStatistiquesMediateursLoader implements StatistiquesMediateursLoader {
-  async get(territoire: string): Promise<ErrorReadModel | StatistiquesMediateursReadModel> {
+  async get(
+    territoire: string,
+    niveau: NiveauTerritoire = 'departement'
+  ): Promise<ErrorReadModel | StatistiquesMediateursReadModel> {
     try {
-      const departementFilter = this.buildDepartementFilter(territoire)
-
       const result =
-        territoire === 'France'
+        territoire === 'France' || niveau === 'national'
           ? await this.getStatistiquesNationales()
-          : await this.getStatistiquesDepartement(departementFilter)
+          : await this.getStatistiquesDepartement(this.buildDepartementFilter(territoire, niveau))
 
       return {
         nombreAidantsConnect: Number(result.aidants_connect),
@@ -40,18 +41,15 @@ export class PrismaStatistiquesMediateursLoader implements StatistiquesMediateur
     }
   }
 
-  private buildDepartementFilter(territoire: string): Array<string> {
-    if (territoire === 'France') {
-      return []
+  // Le code de territoire est ambigu : un code département (ex. '01' = Ain) coïncide avec un
+  // code région d'outre-mer (ex. '01' = Guadeloupe). On s'appuie sur le niveau explicite plutôt
+  // que de deviner, sinon la vitrine d'un département (01 à 06) affiche les chiffres de la région
+  // d'outre-mer homonyme.
+  private buildDepartementFilter(territoire: string, niveau: NiveauTerritoire): Array<string> {
+    if (niveau === 'region') {
+      return departements.filter((dept) => dept.regionCode === territoire).map((dept) => dept.code)
     }
 
-    // Vérifier si c'est un code région
-    const departementsRegion = departements.filter((dept) => dept.regionCode === territoire)
-    if (departementsRegion.length > 0) {
-      return departementsRegion.map((dept) => dept.code)
-    }
-
-    // Sinon c'est un code département
     return [territoire]
   }
 
@@ -89,8 +87,10 @@ export class PrismaStatistiquesMediateursLoader implements StatistiquesMediateur
 }
 
 interface StatistiquesMediateursLoader {
-  get(territoire: string): Promise<ErrorReadModel | StatistiquesMediateursReadModel>
+  get(territoire: string, niveau?: NiveauTerritoire): Promise<ErrorReadModel | StatistiquesMediateursReadModel>
 }
+
+type NiveauTerritoire = 'departement' | 'national' | 'region'
 
 interface StatistiquesQueryResult {
   aidants_connect: bigint


### PR DESCRIPTION
## Contexte

Remontée de la préfecture de l'Ain (#1561) : les chiffres des cartes « Médiateurs numériques » du site vitrine sont incohérents avec ceux du backoffice MIN, pour les mêmes données.

## Problème

`PrismaStatistiquesMediateursLoader.buildDepartementFilter()` désambiguïsait le code de territoire en **testant le code région en premier**. Or plusieurs codes départements coïncident avec des codes régions d'outre-mer :

| Département | Région homonyme |
|---|---|
| 01 Ain | 01 Guadeloupe (971) |
| 02 Aisne | 02 Martinique |
| 03 Allier | 03 Guyane |
| 04 Alpes-de-Haute-Provence | 04 La Réunion |
| 06 Alpes-Maritimes | 06 Mayotte |

Résultat : la page vitrine `/departement/01` affichait les médiateurs de **la Guadeloupe (47)** au lieu de l'Ain (**33** — chiffre cohérent avec MIN `/gouvernance/01/aidants-mediateurs`). Les loaders MIN du même concept n'avaient pas ce bug car ils traitent le code directement comme un département — c'est la duplication / correction non reportée pointée dans le ticket.

## Correction

Le niveau (`departement` / `region` / `national`) est désormais **passé explicitement** par les appelants au lieu d'être deviné :
- `PrismaStatistiquesMediateursLoader.get(territoire, niveau)` — l'expansion région → départements n'a lieu que si `niveau === 'region'`.
- Page vitrine médiateurs : passe le `niveau` de la route.
- `BlocMediateurs` : passe `region`/`departement` selon `scope.type`.

## Vérification

- `/departement/01` → 33 médiateurs = MIN ✅
- Niveaux national et région inchangés ✅
- `typecheck` + `lint` OK, pre-push `yarn check` passé.

Closes #1561

🤖 Generated with [Claude Code](https://claude.com/claude-code)