### PR TITLE
feat(membres-a-consolider): consolidation des membres mal raccrochés + transfert + import CSV

### DIFF
--- a/docs/constat-membres-gouvernance-mal-raccroches.md
+++ b/docs/constat-membres-gouvernance-mal-raccroches.md
@@ -1,0 +1,383 @@
+# Constat — membres de gouvernance raccrochés à la mauvaise structure
+
+> Document de travail. Base de référence : `dataspace_dev` (localhost:5532).
+> Tables : `min.membre`, `main.structure_administrative` (+ `main.adresse`).
+
+## Contexte
+
+Suite à la refonte structure (`main.structure` → `main.structure_administrative` /
+`lieu_inclusion`, migrations Flyway V085/V086), on vérifie que les membres de gouvernance
+pointent bien vers **leur** structure et non vers un doublon ou la structure d'un autre
+territoire.
+
+Rappel des colonnes utiles de `min.membre` :
+
+| Colonne                        | Rôle                                                         |
+| ------------------------------ | ------------------------------------------------------------ |
+| `id`                           | identifiant métier, ex. `departement-41-41`                  |
+| `nom`                          | **libellé historique fiable** du membre (ex. `Loir-et-Cher`) |
+| `gouvernance_departement_code` | département de la gouvernance où le membre siège             |
+| `is_coporteur`                 | membre co-porteur de la gouvernance                          |
+| `siret_ridet`                  | SIRET/RIDET porté par le membre (souvent NULL)               |
+| `old_structure_id`             | ancre vers l'ancien `main.structure` (souvent NULL)          |
+| `structure_id`                 | FK actuelle vers `main.structure_administrative`             |
+
+## Problème 1 — Conseils départementaux rattachés au CD d'un autre département
+
+### Lecture de l'id
+
+Pour les membres « conseil départemental », l'id suit le format
+`departement-<collectivité>-<gouvernance>` :
+
+- **1er nombre** = le département de la collectivité elle-même (= son `nom`) ;
+- **2e nombre** = la gouvernance à laquelle elle participe (= `gouvernance_departement_code`).
+
+La `structure_id` **doit** donc pointer vers le conseil départemental du **1er** nombre.
+La SA cible correcte est identifiable de façon déterministe via le membre
+`departement-<dep>-<dep>`.
+
+### Cas de référence : Loir-et-Cher (41) — cohérent ✅
+
+| id                  | `nom`        | `structure_id` | SIRET            | INSEE | dénomination                              |
+| ------------------- | ------------ | -------------- | ---------------- | ----- | ----------------------------------------- |
+| `departement-41-41` | Loir-et-Cher | **4622**       | `22410001600019` | 41018 | Conseil Départemental cité administrative |
+
+Le membre (co-porteur) pointe vers la bonne SA. À noter : le doublon historique existe
+toujours dans `structure_administrative` — **3 SA non fusionnées** partagent le SIRET
+`22410001600019` : `4622` (old `main.structure` 60149), `4623` (old 170189),
+`4624` (old 27984) — mais le membre est bien rattaché à 4622.
+
+### Les 6 membres mal raccrochés
+
+Dans chaque cas, le `nom` historique concorde avec le **1er** nombre (le département du
+membre) mais la structure rattachée est celle du **2e** nombre (le département de la
+gouvernance hôte).
+
+| id                  | `nom` (historique) | Rattaché à (SA actuelle)         | INSEE actuel | Devrait être (SA attendue)       |
+| ------------------- | ------------------ | -------------------------------- | ------------ | -------------------------------- |
+| `departement-05-26` | Hautes-Alpes       | 4543 — Dpt de la Drôme (Valence) | 26362        | **4442** — Dpt des Hautes-Alpes  |
+| `departement-18-36` | Cher               | 4604 — _(Indre)_                 | 36044        | **4491** — Dpt du Cher           |
+| `departement-22-29` | Côtes-d'Armor      | 4565 — Dpt du Finistère          | 29232        | **4508** — _(Côtes-d'Armor)_     |
+| `departement-35-22` | Ille-et-Vilaine    | 4508 — _(Côtes-d'Armor)_         | 22278        | **4602** — Dpt d'Ille-et-Vilaine |
+| `departement-77-95` | Seine-et-Marne     | 4858 — Dpt du Val-d'Oise (Cergy) | 95127        | **4783** — _(Seine-et-Marne)_    |
+| `departement-84-26` | Vaucluse           | 4543 — Dpt de la Drôme (Valence) | 26362        | **4803** — _(Vaucluse)_          |
+
+> **Doublon croisé 22 ↔ 35** : le membre Côtes-d'Armor pointe vers le Finistère, et le
+> membre Ille-et-Vilaine pointe vers les Côtes-d'Armor (4508) — chaîne décalée d'un cran.
+
+### Cas écartés (faux positifs)
+
+- `departement-48-30`, `departement-91-94` : rattachés à leur propre CD, simple
+  participation à une gouvernance voisine — **OK**.
+- `departement-67-68` : Collectivité Européenne d'Alsace, entité unique couvrant 67 et 68.
+- DOM 97x / 98x : faux positifs du tronquage à 2 chiffres du code INSEE.
+
+### Origine probable
+
+Les 6 membres fautifs ont tous `is_coporteur = false`, **`old_structure_id = NULL` et
+`siret_ridet = NULL`**. La migration V085 n'avait donc ni ancre `old_main_structure_id`
+ni SIRET pour les remapper : leur mauvais rattachement **préexistait à la refonte** —
+vraisemblablement attachés au porteur de la gouvernance hôte par la logique gouvernance
+d'origine, et non à leur propre CD. À l'inverse, `41-41` (co-porteur) disposait d'une
+ancre et reste correct.
+
+### Correction envisagée
+
+6 `UPDATE min.membre SET structure_id = <SA attendue>` ciblés, avec garde-fou
+`nom` / SIRET (`22<dep>…`). _(à dérouler dans un second temps)_
+
+---
+
+## Problème 2 — Élargissement à tous les membres
+
+On élargit le contrôle aux **2188 membres** (tous ont une `structure_id` non nulle).
+Les ids structurés encodent l'identifiant attendu, ce qui permet une détection
+**déterministe** par famille :
+
+| Famille d'id          | Format                        | Identifiant comparé         | Volume |
+| --------------------- | ----------------------------- | --------------------------- | ------ |
+| `structure`           | `structure-<SIRET14>-<gouv>`  | SIRET exact vs `sa.siret`   | 1246   |
+| `epci`                | `epci-<SIREN9>-<gouv>`        | SIREN vs `left(sa.siret,9)` | 304    |
+| `commune`             | `commune-<INSEE>-<gouv>`      | INSEE / SIREN `21+insee`    | 267    |
+| `departement`         | `departement-<dep>-<gouv>`    | `substr(siret,3,2)` = dep   | 97     |
+| `prefecture` / `sgar` | `prefecture-<dep>` / `sgar-…` | — (pas d'ancre SIRET)       | 135    |
+| `uuid` / autre        | UUID                          | — (pas d'ancre)             | 139    |
+
+> ⚠️ **Couverture** : 274 membres (préfectures, SGAR, ids UUID) n'ont **pas** d'identifiant
+> exploitable dans l'id ; non vérifiables par cette méthode (nécessiteraient un rapprochement
+> nom/SIRET). À traiter séparément.
+
+### Signaux à NE PAS confondre avec un bug
+
+- **Même SIREN, établissement (NIC) différent** : 99 membres `structure`. La refonte a
+  consolidé une SA par entité (SIREN) ; l'id portait un SIRET d'établissement précis.
+  Entité correcte → **bénin** (ex. Orange, La Poste).
+- **SIRET de l'id légèrement erroné (transposition) mais même entité** : 3 membres
+  `structure` — `Voix des Femmes`, `HALAYE`, `La Fabrique des possibles`. La SA est la
+  bonne (nom identique), c'est l'id qui porte une coquille → **bénin**.
+
+### 2.a — EPCI rattachés à une autre entité (3)
+
+| id                  | `nom`                                 | Rattaché à (SA)                       | Problème                 |
+| ------------------- | ------------------------------------- | ------------------------------------- | ------------------------ |
+| `epci-247200132-72` | CU Le Mans Métropole                  | 3629 — **Commune du Mans**            | EPCI → commune membre    |
+| `epci-243900479-39` | CC Haut-Jura Arcade                   | 1029 — **Commune de Hauts de Bienne** | EPCI → commune membre    |
+| `epci-200068914-16` | CC La Rochefoucauld porte du Périgord | 1309 — SA SIREN `200068014`           | SIREN voisin, à vérifier |
+
+### 2.b — Communes rattachées à une autre entité (6)
+
+| id                 | `nom`          | Rattaché à (SA)                               | Problème                             |
+| ------------------ | -------------- | --------------------------------------------- | ------------------------------------ |
+| `commune-49007-49` | **Angers**     | 2331 — **Mairie de Bonifacio (2A)** ‼️        | commune → commune corse sans rapport |
+| `commune-51454-51` | **Reims**      | 6227 — CCAS (SIRET dép. 81, Tarn)             | commune → CCAS d'un autre dép.       |
+| `commune-59512-59` | **Roubaix**    | 6381 — CCAS de l'Isle-Adam (95)               | commune → CCAS d'un autre dép.       |
+| `commune-76217-76` | Dieppe         | 5358 — Cté d'agglo de la région dieppoise     | commune → son EPCI                   |
+| `commune-09167-09` | Lézat-sur-Lèze | 1119 — CC Arize Lèze                          | commune → son EPCI                   |
+| `commune-19151-19` | Noailles       | 8919 — « NOAILLES DISTRIBUTION » (entreprise) | commune → entreprise homonyme        |
+
+### 2.c — Structures rattachées à une SA SANS SIRET (5)
+
+Entité correcte (le `nom` de la SA est identique au membre) mais la SA cible n'a **pas** de
+SIRET — vraisemblablement un _shell_ créé côté MIN, non raccordé à la SIRENE (ids SA élevés,
+récents). Problème de **qualité de donnée** (SA à enrichir / fusionner), pas de mauvais
+rattachement d'entité.
+
+| id                             | `nom`                                                 | SA cible (sans siret) |
+| ------------------------------ | ----------------------------------------------------- | --------------------- |
+| `structure-09132573900017-35`  | Ensemble Partageons le Numérique                      | 11177                 |
+| `structure-32532939300059-07`  | CIDFF07                                               | 11147                 |
+| `structure-33986977900029-79`  | Fédération des Centres Socioculturels des Deux-Sèvres | 11184                 |
+| `structure-77768873204287-59`  | APF France handicap (Association)                     | 11113                 |
+| `structure-82251316700035-972` | UP AND SPACE MARTINIQUE                               | 11260                 |
+
+### Synthèse Problème 2
+
+| Catégorie                       | Nb  | Nature                     |
+| ------------------------------- | --- | -------------------------- |
+| CD → autre département (Pb 1)   | 6   | mauvais rattachement       |
+| EPCI → autre entité (2.a)       | 3   | mauvais rattachement       |
+| Commune → autre entité (2.b)    | 6   | mauvais rattachement       |
+| Structure → SA sans SIRET (2.c) | 5   | qualité de donnée          |
+| Même SIREN, établissement ≠     | 99  | bénin (consolidation)      |
+| SIRET id erroné, même entité    | 3   | bénin (coquille id)        |
+| Préfecture / SGAR / UUID        | 274 | non couverts (pas d'ancre) |
+
+**15 vrais mauvais rattachements** (6 CD + 3 EPCI + 6 communes) + 5 SA à enrichir.
+
+---
+
+## Problème 3 — Nom affiché faux (ticket support : Paris Est Marne & Bois)
+
+### Symptôme
+
+Dans MIN, le co-porteur de la gouvernance du 94 s'affiche **« ville de Villiers sur Marne »**
+au lieu de **« Paris Est Marne et Bois »** (EPT). La collectivité **est** bien co-porteuse —
+seul le **nom d'affichage** est faux.
+
+### D'où vient le nom affiché
+
+`min/src/gateways/shared/MembresGouvernance.ts` → `determinerNomMembre()` :
+
+```ts
+return (
+  membre.relationStructureAdministrative.denomination_antenne ??
+  membre.relationStructureAdministrative.denomination_sirene ??
+  ''
+)
+```
+
+Le nom affiché = **`denomination_antenne` de la SA rattachée** si non nul, sinon
+`denomination_sirene`. **`min.membre.nom` n'est PAS utilisé** par l'affichage (il vaut pourtant
+« Paris Est Marne et Bois », correct). Le membre `epci-200057941-94` pointe vers la SA **978**
+dont `denomination_antenne = "ville de Villiers sur Marne"` → c'est ça qui s'affiche.
+
+### Décision de cadrage (utilisateur)
+
+> **On ne corrige PAS les SA** (pas de modif de `denomination_antenne`) en première étape.
+> On cherche un **pattern de re-rattachement** du membre vers la bonne SA.
+
+## Le « stock » de SA canoniques
+
+L'objectif de consolidation est d'avoir des **SA canoniques** : `denomination_antenne IS NULL`,
+correspondant à l'API SIREN. `structure_administrative` **n'a pas d'unicité sur le SIRET**.
+
+| Mesure                         | Valeur    |
+| ------------------------------ | --------- |
+| SA totales                     | 11 334    |
+| Canoniques (`antenne IS NULL`) | 5 787     |
+| Antennes (`antenne NOT NULL`)  | 5 547     |
+| Sans SIRET                     | 156       |
+| **SIRET avec 1 canonique**     | **5 787** |
+| SIRET avec >1 canonique        | **0**     |
+| SIRET sans canonique           | 2 025     |
+
+> ✅ **Propriété clé** : la canonique est **unique par SIRET** quand elle existe →
+> `WHERE siret = ? AND denomination_antenne IS NULL` renvoie 0 ou 1 ligne (déterministe).
+
+## Pattern de re-rattachement (sans toucher aux SA, on ne modifie que `structure_id`)
+
+On dérive une **clé** depuis le membre, par priorité, puis on cherche la cible :
+
+| Étage | Clé (source)                                                                                 | Cible                                                                          | Fiabilité                             |
+| ----- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------- |
+| **1** | SIRET exact (`siret_ridet`, ou `structure-<SIRET14>`)                                        | canonique unique du SIRET                                                      | déterministe                          |
+| **2** | SIREN (`epci-<SIREN>`, `departement→22+dep`, `commune→21+insee`, ou SIREN de la SA actuelle) | canonique du SIREN                                                             | bonne (vérifier multi-établissements) |
+| **3** | `membre.nom` (libellé historique fiable)                                                     | parmi les SA du **même SIREN**, meilleure **similarité trigramme** (`pg_trgm`) | heuristique, seuil à valider          |
+
+### Couverture mesurée
+
+- **Étage 1** (structure + uuid) : déjà ~100 % sur la bonne canonique → **2** à re-rattacher
+  seulement (`APEJ` 7002→7000, `FACE Territoire Bourbonnais` 10389→10387). RAS.
+- **Étage 2** : ~453 collectivités ont une canonique atteignable par SIREN
+  (143 EPCI + 174 communes + 97 préf + 39 CD).
+- **Sans canonique** (~321, dont PEMB) : l'étage 3 (similarité nom) prend le relais.
+
+### Démo étage 3 — Paris Est Marne & Bois (aucune canonique)
+
+`membre.nom = "Paris Est Marne et Bois"` vs les 8 SA du SIREN `200057941` :
+
+| SA               | nom                         | similarité  |
+| ---------------- | --------------------------- | ----------- |
+| **971**          | EPT Paris Est Marne & Bois  | **0.800** ⬅ |
+| 975 / 976        | #parisestmarne&bois         | 0.577       |
+| 978 _(actuelle)_ | ville de Villiers sur Marne | 0.150       |
+
+→ `UPDATE min.membre SET structure_id = 971 WHERE id = 'epci-200057941-94'` : zéro modif de SA,
+affichage devient « EPT Paris Est Marne & Bois ».
+
+## ⚠️ Migrer `structure_id` ≠ déplacer une seule FK — surface complète
+
+**7 FK** référencent `main.structure_administrative` :
+
+| Table                                          | Colonne                       | Classe          |
+| ---------------------------------------------- | ----------------------------- | --------------- |
+| `min.membre`                                   | `structure_id`                | **gouvernance** |
+| `min.utilisateur`                              | `structure_id`                | **gouvernance** |
+| `main.contact_structure_administrative`        | `structure_administrative_id` | **gouvernance** |
+| `main.poste`                                   | `structure_id`                | terrain         |
+| `main.contrat`                                 | `structure_id`                | terrain         |
+| `main.personne_affectations_emploi`            | `structure_administrative_id` | terrain         |
+| `main.lieu_inclusion_structure_administrative` | `structure_administrative_id` | terrain         |
+
+- **Cluster gouvernance** (membre + utilisateur + contact) : doit **voyager ensemble**. Re-rattacher
+  le seul membre laisse utilisateurs et contacts orphelins sur l'ancienne SA.
+- **Données terrain** (poste/contrat/affectation/lieu) : liées à l'établissement réel ; les déplacer
+  relève d'une **fusion de SA** complète (mécanisme `audit.structure_merge_log` :
+  `winner_id`/`loser_id`/`moved_identifiers`, transactionnel + gestion des collisions d'unicité).
+
+### Empreinte PEMB (les 8 SA du SIREN, fragmentées)
+
+| SA      | antenne                                                               | membre | utilisateur | contact | poste | contrat | affect. | lieu |
+| ------- | --------------------------------------------------------------------- | -----: | ----------: | ------: | ----: | ------: | ------: | ---: |
+| **978** | ville de Villiers sur Marne                                           |  **1** |       **2** |   **3** |     0 |       0 |       0 |    0 |
+| **977** | #Parisestmarne&Bois Champigny (14 r. Louis Talamoni = **siège réel**) |      0 |           0 |       1 |    19 |      16 |      25 |    1 |
+| 971     | EPT Paris Est Marne & Bois (Joinville)                                |      0 |           0 |       0 |     0 |       0 |       1 |    2 |
+| 972-976 | L'Escale / Mairies / #PEMB                                            |      0 |           0 |       0 |     0 |       0 |    1-11 |  0-1 |
+
+> ⚠️ 971, 977, 978 ont **le même SIRET** `20005794100011` / `denomination_sirene #PARISESTMARNE&BOIS` :
+> ce sont des **doublons de la même entité**, pas des collectivités voisines. Le nom de commune dans
+> `denomination_antenne` n'est qu'une **étiquette polluée**. La SA **977 n'est pas membre** (0 dans
+> `min.membre`) ; elle porte le **terrain** au **siège réel** (Champigny).
+
+## Motif systémique — gouvernance sur SA-antenne ≠ SA-terrain (même SIREN)
+
+PEMB est un cas général : ~**179 membres** ont leur gouvernance sur une SA **sans terrain**, alors
+que l'opérationnel (`postes + contrats + affectations + lieux`) vit sur une **autre SA du même
+SIREN**.
+
+| Famille     | Membres | SIREN multi-SA | **Terrain ailleurs** | Terrain déjà sur la SA membre |
+| ----------- | ------: | -------------: | -------------------: | ----------------------------: |
+| structure   |    1304 |            566 |              **106** |                           593 |
+| EPCI        |     304 |            169 |               **27** |                           205 |
+| préfecture  |     105 |             25 |               **15** |                            20 |
+| commune     |     257 |             93 |               **13** |                           146 |
+| département |      97 |             71 |               **12** |                            69 |
+| uuid        |      64 |             28 |                **6** |                            33 |
+
+Exemples : `departement-02-02` Aisne (gov 4422 « Conseil départemental » op=0 / terrain 4424
+« DEPARTEMENT DE L AISNE » op=115) ; `commune-91345-91` Longjumeau (gov « Centre social » /
+terrain « Mairie de Longjumeau ») ; `prefecture-48` Lozère (gov « PREFECTURE » / terrain
+« France Services Mende »). La gouvernance est souvent raccrochée à un **point de service /
+antenne** plutôt qu'à l'établissement réel.
+
+### Règle de « winner » déterministe pour la consolidation
+
+> **winner = la SA du SIREN avec la plus grosse empreinte opérationnelle**
+> (`postes + contrats + affectations + lieux`) — pas la SA pointée par la gouvernance, ni celle
+> au plus joli libellé.
+
+Pour PEMB → **977** (siège Champigny, op=61). Reste ensuite à nettoyer son `denomination_antenne`
+(étape SA différée) pour un affichage propre.
+
+## Feuille de migration (dry-run) — `migration-membres-gouvernance-candidats.csv`
+
+Un CSV par membre (2188 lignes) compare le **nom d'origine** (`membre.nom`), le **nom actuel
+affiché** (`denomination_antenne` de la SA rattachée) et **3 candidats** : canonique (même SIRET,
+`antenne IS NULL`), terrain (winner = max empreinte op. du SIREN), similarité (meilleur trigramme
+vs `membre.nom`). Colonnes d'action : `action`, `cible_proposee`, `confiance`.
+
+### Taxonomie `action`
+
+| action                   |    n | sens                                                                 | cible_proposée      |
+| ------------------------ | ---: | -------------------------------------------------------------------- | ------------------- |
+| `ok_canonique`           | 1389 | déjà sur une SA canonique                                            | inchangé            |
+| `ok`                     |  560 | déjà bon (terrain sur la SA, ou SA unique)                           | inchangé            |
+| `corriger_entite`        |  140 | l'id encode une entité ≠ SIREN/SIRET/INSEE de la SA actuelle         | _(vide — manuel)_   |
+| `fusionner_vers_terrain` |   98 | gouvernance sur antenne sans terrain ; terrain ailleurs (même SIREN) | SA-terrain (winner) |
+| `rattacher_canonique`    |    1 | une canonique existe pour le SIRET                                   | SA canonique        |
+
+- `confiance = a_revoir` quand : `corriger_entite`, ou `fusionner_vers_terrain` où **terrain ≠
+  similarité** (arbitrage libellé vs terrain, ex. PEMB : terrain=977 / simil=971 ; préf. Lozère :
+  terrain=France Services / actuelle=PREFECTURE). Sinon `haute`.
+
+### ⚠️ `corriger_entite` mélange deux niveaux
+
+- **dur** (vrais bugs) : entité d'un autre territoire — Angers→Bonifacio, Noailles→entreprise,
+  Reims→CCAS du Tarn. ⇒ Problèmes 1 & 2.
+- **doux** (~120, surtout commune) : commune rattachée à son **propre CCAS/EPCI** (forme juridique
+  ≠ 21, même territoire) — 61 sur CCAS, 27 sur EPCI/asso, 5 sur un CD… Souvent _intentionnel_
+  métier, mais l'affichage montre « CCAS de X » au lieu de « X ». À trancher avec le métier.
+
+## Plan d'action
+
+### 1. Deux parcours, selon l'action
+
+Le correctif dépend de la nature du problème — **ne pas confondre fusion de SA et re-rattachement**.
+
+| Parcours                 | Actions concernées                              | Volume | Mécanisme                                                                                                                                                                                                    | Touche aux SA ?                 |
+| ------------------------ | ----------------------------------------------- | -----: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------- |
+| **A — Fusion de SA**     | `fusionner_vers_terrain`                        |     98 | outil de fusion existant (`/structures-doublons/comparer`) : déplace les 7 FK (dont membre + utilisateur + contact) vers le _winner_, arbitre `denomination_antenne`, journalise `audit.structure_merge_log` | oui (soft-delete de l'absorbée) |
+| **B — Re-rattachement**  | `corriger_entite` (dur) + `rattacher_canonique` |    ~20 | simple `UPDATE min.membre.structure_id` (+ utilisateur/contact) vers la SA de la **bonne entité**                                                                                                            | non                             |
+| **C — Arbitrage métier** | `corriger_entite` (doux)                        |   ~120 | commune sur son propre CCAS/EPCI : décider si intentionnel                                                                                                                                                   | —                               |
+| **—**                    | `ok` / `ok_canonique`                           |   1949 | rien                                                                                                                                                                                                         | —                               |
+
+> Pourquoi pas tout en fusion : pour le parcours B, l'entité actuelle (ex. CCAS de Créteil) est
+> **juridiquement distincte** de la bonne (commune de Créteil). Les fusionner serait faux — on
+> re-pointe le membre, on ne fusionne pas.
+
+### 2. État de l'outillage
+
+- ✅ **Dry-run** : `migration-membres-gouvernance-candidats.csv` (2188 lignes, colonnes
+  `action` / `cible_proposee` / `confiance`).
+- ✅ **Prototype parcours A** : écran admin **`/membres-a-consolider`** qui détecte les 98 cas
+  (signal _gouvernance sur antenne sans terrain_, angle mort de la détection doublons existante)
+  et renvoie vers l'outil de fusion `/structures-doublons/comparer`. Aucun nouveau moteur de fusion.
+  - Worktree `min-wt-membres-consolider`, branche `prototype-membres-a-consolider`
+    (basée sur `structures-doublons-fusion-sa`). Typecheck + lint OK.
+  - 5 fichiers : query `RechercherMembresAConsolider`, loader `PrismaMembresAConsoliderLoader`,
+    presenter, composant `MembresAConsolider`, page.
+- ⏳ **Reste à faire** sur le prototype : tests (loader/presenter/composant), `pnpm db:sync-dataspace`
+  pour le faire tourner en local (la base min locale n'a pas `main.structure_administrative`),
+  puis PR.
+- ⏳ **Parcours B** : 2e écran « membres mal rattachés » (re-rattachement) — non prototypé.
+
+### 3. Ordre de traitement suggéré
+
+1. **Lot sûr d'abord** : les 43 `fusionner_vers_terrain` en `confiance = haute` (terrain = similarité)
+   via l'écran de fusion.
+2. **Arbitrages** : les 55 `fusionner_vers_terrain` en `a_revoir` (terrain ≠ similarité — ex. PEMB,
+   préf. Lozère), un par un.
+3. **Parcours B dur** : les ~20 `corriger_entite` d'un autre territoire (Angers→Bonifacio…).
+4. **Arbitrage métier** : trancher les ~120 communes→CCAS/EPCI (intentionnel ou non ?).
+5. **Nettoyage d'affichage** : à chaque fusion, mettre `denomination_antenne = NULL` sur le winner
+   (→ affichage = `denomination_sirene`), via l'arbitrage `ChampsRetenus` de l'outil.

--- a/prisma/migrations/20260616090000_creer_membre_transfert_log/migration.sql
+++ b/prisma/migrations/20260616090000_creer_membre_transfert_log/migration.sql
@@ -1,0 +1,17 @@
+-- Journal des transferts de membre (qui / quand / quoi) déclenchés depuis l'outil
+-- membres-a-consolider. Le transfert re-pointe un membre + ses utilisateurs + ses contacts
+-- d'une structure source vers une structure cible, sans suppression de la source.
+
+CREATE TABLE "min"."membre_transfert_log" (
+    "id" SERIAL NOT NULL,
+    "membre_id" TEXT NOT NULL,
+    "structure_source_id" INTEGER NOT NULL,
+    "structure_cible_id" INTEGER NOT NULL,
+    "utilisateurs_deplaces" INTEGER NOT NULL,
+    "contacts_deplaces" INTEGER NOT NULL,
+    "contacts_supprimes" INTEGER NOT NULL,
+    "par_utilisateur" TEXT NOT NULL,
+    "transfere_le" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "membre_transfert_log_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -217,6 +217,22 @@ model MembreRecord {
   @@schema("min")
 }
 
+model MembreTransfertLogRecord {
+  id Int @id @default(autoincrement())
+
+  membreId             String   @map("membre_id")
+  structureSourceId    Int      @map("structure_source_id")
+  structureCibleId     Int      @map("structure_cible_id")
+  utilisateursDeplaces Int      @map("utilisateurs_deplaces")
+  contactsDeplaces     Int      @map("contacts_deplaces")
+  contactsSupprimes    Int      @map("contacts_supprimes")
+  parUtilisateur       String   @map("par_utilisateur")
+  transfereLe          DateTime @default(now()) @map("transfere_le")
+
+  @@map("membre_transfert_log")
+  @@schema("min")
+}
+
 model ActionRecord {
   id           Int      @id @default(autoincrement())
   besoins      String[]

--- a/src/app/(connecte)/(sans-menu)/membres-a-consolider/page.tsx
+++ b/src/app/(connecte)/(sans-menu)/membres-a-consolider/page.tsx
@@ -27,7 +27,7 @@ export default async function MembresAConsoliderController({ searchParams }: Pro
   }
 
   const utilisateur = await new PrismaUtilisateurRepository(prisma.utilisateurRecord).get(await getSessionSub())
-  if (!(utilisateur instanceof Administrateur)) {
+  if (!(utilisateur instanceof Administrateur) || !utilisateur.isBetaTesteur) {
     redirect('/tableau-de-bord')
   }
 

--- a/src/app/(connecte)/(sans-menu)/membres-a-consolider/page.tsx
+++ b/src/app/(connecte)/(sans-menu)/membres-a-consolider/page.tsx
@@ -1,0 +1,55 @@
+import { Metadata } from 'next'
+import { redirect } from 'next/navigation'
+import { ReactElement } from 'react'
+
+import prisma from '../../../../../prisma/prismaClient'
+import MembresAConsolider from '@/components/MembresAConsolider/MembresAConsolider'
+import FilAriane from '@/components/vitrine/FilAriane/FilAriane'
+import { Administrateur } from '@/domain/Administrateur'
+import { getSession, getSessionSub } from '@/gateways/NextAuthAuthentificationGateway'
+import { PrismaMembresAConsoliderLoader } from '@/gateways/PrismaMembresAConsoliderLoader'
+import { PrismaUtilisateurRepository } from '@/gateways/PrismaUtilisateurRepository'
+import { membresAConsoliderPresenter, reglesPresenter } from '@/presenters/membresAConsoliderPresenter'
+import {
+  RechercherMembresAConsolider,
+  RegleConsolidation,
+  REGLES_CONSOLIDATION,
+} from '@/use-cases/queries/RechercherMembresAConsolider'
+
+export const metadata: Metadata = {
+  title: 'Membres à consolider',
+}
+
+export default async function MembresAConsoliderController({ searchParams }: Props): Promise<ReactElement> {
+  const session = await getSession()
+  if (!session) {
+    redirect('/connexion')
+  }
+
+  const utilisateur = await new PrismaUtilisateurRepository(prisma.utilisateurRecord).get(await getSessionSub())
+  if (!(utilisateur instanceof Administrateur)) {
+    redirect('/tableau-de-bord')
+  }
+
+  const { regle: regleParam } = await searchParams
+  const regle = estRegleValide(regleParam) ? regleParam : 'structure-fantome'
+
+  const readModel = await new RechercherMembresAConsolider(new PrismaMembresAConsoliderLoader()).handle({ regle })
+  const viewModel = membresAConsoliderPresenter(readModel)
+  const regles = reglesPresenter(regle)
+
+  return (
+    <>
+      <FilAriane items={[{ href: '/tableau-de-bord', label: 'Tableau de bord' }, { label: 'Membres à consolider' }]} />
+      <MembresAConsolider regles={regles} viewModel={viewModel} />
+    </>
+  )
+}
+
+function estRegleValide(valeur: string | undefined): valeur is RegleConsolidation {
+  return valeur !== undefined && (REGLES_CONSOLIDATION as ReadonlyArray<string>).includes(valeur)
+}
+
+type Props = Readonly<{
+  searchParams: Promise<Readonly<{ regle?: string }>>
+}>

--- a/src/app/api/actions/fusionnerStructuresAction.ts
+++ b/src/app/api/actions/fusionnerStructuresAction.ts
@@ -29,18 +29,28 @@ export async function fusionnerStructuresAction(actionParams: ActionParams): Pro
     return ['Action réservée aux administrateurs']
   }
 
-  const result = await new FusionnerStructures(new PrismaStructureFusionRepository()).handle({
-    champsRetenus: {
-      denominationAntenne: actionParams.denominationAntenne,
-      denominationSirene: actionParams.denominationSirene,
-    },
-    idAbsorbee: actionParams.idAbsorbee,
-    idSurvivante: actionParams.idSurvivante,
-    uidUtilisateur: sub,
-  })
+  // Fusion séquentielle : chaque absorbée est fusionnée dans la (même) survivante, une transaction
+  // par paire. Non atomique entre paires — en cas d'échec partiel, les fusions déjà faites sont
+  // conservées (réversibles via le journal d'audit) et les échecs sont remontés.
+  const fusionnerStructures = new FusionnerStructures(new PrismaStructureFusionRepository())
+  const echecs: Array<string> = []
+  for (const idAbsorbee of actionParams.idsAbsorbees) {
+    const result = await fusionnerStructures.handle({
+      champsRetenus: {
+        denominationAntenne: actionParams.denominationAntenne,
+        denominationSirene: actionParams.denominationSirene,
+      },
+      idAbsorbee,
+      idSurvivante: actionParams.idSurvivante,
+      uidUtilisateur: sub,
+    })
+    if (result !== 'OK') {
+      echecs.push(`Structure ${idAbsorbee} : ${MESSAGES_ECHEC[result]}`)
+    }
+  }
 
-  if (result !== 'OK') {
-    return [MESSAGES_ECHEC[result]]
+  if (echecs.length > 0) {
+    return echecs
   }
 
   revalidatePath(actionParams.path)
@@ -51,7 +61,7 @@ export async function fusionnerStructuresAction(actionParams: ActionParams): Pro
 type ActionParams = Readonly<{
   denominationAntenne?: null | string
   denominationSirene?: null | string
-  idAbsorbee: number
+  idsAbsorbees: ReadonlyArray<number>
   idSurvivante: number
   path: string
 }>
@@ -59,10 +69,9 @@ type ActionParams = Readonly<{
 const validator = z.object({
   denominationAntenne: z.string().nullish(),
   denominationSirene: z.string().nullish(),
-  idAbsorbee: z
-    .number()
-    .int()
-    .positive({ message: "L'identifiant de la structure absorbée doit être un entier positif" }),
+  idsAbsorbees: z
+    .array(z.number().int().positive())
+    .min(1, { message: 'Sélectionnez au moins une structure à fusionner' }),
   idSurvivante: z
     .number()
     .int()

--- a/src/app/api/actions/transfererMembreAction.test.ts
+++ b/src/app/api/actions/transfererMembreAction.test.ts
@@ -1,0 +1,90 @@
+import * as nextCache from 'next/cache'
+import { describe, expect, it } from 'vitest'
+
+import { transfererMembreAction } from './transfererMembreAction'
+import { utilisateurFactory } from '@/domain/testHelper'
+import * as ssoGateway from '@/gateways/NextAuthAuthentificationGateway'
+import { PrismaUtilisateurRepository } from '@/gateways/PrismaUtilisateurRepository'
+import { TransfererMembre } from '@/use-cases/commands/TransfererMembre'
+
+describe('transférer un membre action', () => {
+  it('transfère le membre et purge le cache quand un administrateur autorisé confirme', async () => {
+    // GIVEN
+    vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce('userFooId')
+    vi.spyOn(PrismaUtilisateurRepository.prototype, 'get').mockResolvedValueOnce(
+      utilisateurFactory({ isBetaTesteur: true, role: 'Administrateur dispositif' })
+    )
+    vi.spyOn(TransfererMembre.prototype, 'handle').mockResolvedValueOnce('OK')
+    vi.spyOn(nextCache, 'revalidatePath').mockImplementationOnce(() => undefined)
+
+    // WHEN
+    const messages = await transfererMembreAction({
+      idCible: 9867,
+      idMembre: 'structure-77944552700046-26',
+      idSource: 9869,
+      path: '/membres-a-consolider',
+    })
+
+    // THEN
+    expect(TransfererMembre.prototype.handle).toHaveBeenCalledWith({
+      idCible: 9867,
+      idMembre: 'structure-77944552700046-26',
+      idSource: 9869,
+      uidUtilisateur: 'userFooId',
+    })
+    expect(nextCache.revalidatePath).toHaveBeenCalledWith('/membres-a-consolider')
+    expect(messages).toStrictEqual(['OK'])
+  })
+
+  it('renvoie une erreur de validation quand le membre n’est pas renseigné', async () => {
+    // WHEN
+    const messages = await transfererMembreAction({
+      idCible: 9867,
+      idMembre: '',
+      idSource: 9869,
+      path: '/membres-a-consolider',
+    })
+
+    // THEN
+    expect(messages).toStrictEqual(['Le membre doit être renseigné'])
+  })
+
+  it('refuse l’action à un utilisateur non administrateur autorisé', async () => {
+    // GIVEN
+    vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce('userFooId')
+    vi.spyOn(PrismaUtilisateurRepository.prototype, 'get').mockResolvedValueOnce(
+      utilisateurFactory({ isBetaTesteur: false, role: 'Gestionnaire structure' })
+    )
+
+    // WHEN
+    const messages = await transfererMembreAction({
+      idCible: 9867,
+      idMembre: 'structure-77944552700046-26',
+      idSource: 9869,
+      path: '/membres-a-consolider',
+    })
+
+    // THEN
+    expect(messages).toStrictEqual(['Action réservée aux administrateurs autorisés'])
+  })
+
+  it('remonte le message d’échec métier renvoyé par la commande', async () => {
+    // GIVEN
+    vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce('userFooId')
+    vi.spyOn(PrismaUtilisateurRepository.prototype, 'get').mockResolvedValueOnce(
+      utilisateurFactory({ isBetaTesteur: true, role: 'Administrateur dispositif' })
+    )
+    vi.spyOn(TransfererMembre.prototype, 'handle').mockResolvedValueOnce('transfertCreeraitDoublonMembre')
+
+    // WHEN
+    const messages = await transfererMembreAction({
+      idCible: 9867,
+      idMembre: 'structure-77944552700046-26',
+      idSource: 9869,
+      path: '/membres-a-consolider',
+    })
+
+    // THEN
+    expect(messages).toStrictEqual(['La structure cible est déjà membre de cette gouvernance'])
+  })
+})

--- a/src/app/api/actions/transfererMembreAction.ts
+++ b/src/app/api/actions/transfererMembreAction.ts
@@ -1,0 +1,62 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { z } from 'zod'
+
+import prisma from '../../../../prisma/prismaClient'
+import { Administrateur } from '@/domain/Administrateur'
+import { getSessionSub } from '@/gateways/NextAuthAuthentificationGateway'
+import { PrismaMembreTransfertRepository } from '@/gateways/PrismaMembreTransfertRepository'
+import { PrismaUtilisateurRepository } from '@/gateways/PrismaUtilisateurRepository'
+import { TransfererMembre, TransfertFailure } from '@/use-cases/commands/TransfererMembre'
+
+const MESSAGES_ECHEC: Readonly<Record<TransfertFailure, string>> = {
+  membreIntrouvable: 'Membre introuvable sur la structure d’origine',
+  structureIntrouvable: 'Structure introuvable ou déjà supprimée',
+  transfertCreeraitDoublonMembre: 'La structure cible est déjà membre de cette gouvernance',
+  transfertEchoue: 'Le transfert a échoué, aucune modification effectuée',
+  transfertImpossibleMemeStructure: 'La structure d’origine et la structure cible sont identiques',
+}
+
+export async function transfererMembreAction(actionParams: ActionParams): Promise<ReadonlyArray<string>> {
+  const validationResult = validator.safeParse(actionParams)
+  if (validationResult.error) {
+    return validationResult.error.issues.map(({ message }) => message)
+  }
+
+  // Garde : seul un administrateur_dispositif porteur du flag beta testeur peut transférer.
+  const sub = await getSessionSub()
+  const utilisateur = await new PrismaUtilisateurRepository(prisma.utilisateurRecord).get(sub)
+  if (!(utilisateur instanceof Administrateur) || !utilisateur.isBetaTesteur) {
+    return ['Action réservée aux administrateurs autorisés']
+  }
+
+  const result = await new TransfererMembre(new PrismaMembreTransfertRepository()).handle({
+    idCible: actionParams.idCible,
+    idMembre: actionParams.idMembre,
+    idSource: actionParams.idSource,
+    uidUtilisateur: sub,
+  })
+
+  if (result !== 'OK') {
+    return [MESSAGES_ECHEC[result]]
+  }
+
+  revalidatePath(actionParams.path)
+
+  return ['OK']
+}
+
+type ActionParams = Readonly<{
+  idCible: number
+  idMembre: string
+  idSource: number
+  path: string
+}>
+
+const validator = z.object({
+  idCible: z.number().int().positive({ message: 'La structure cible doit être un entier positif' }),
+  idMembre: z.string().min(1, { message: 'Le membre doit être renseigné' }),
+  idSource: z.number().int().positive({ message: 'La structure d’origine doit être un entier positif' }),
+  path: z.string().min(1, { message: 'Le chemin doit être renseigné' }),
+})

--- a/src/components/MembresAConsolider/MembresAConsolider.test.tsx
+++ b/src/components/MembresAConsolider/MembresAConsolider.test.tsx
@@ -106,7 +106,54 @@ describe('membres à consolider', () => {
     const notification = await screen.findByRole('alert')
     expect(notification.textContent).toBe('Erreur : La structure cible est déjà membre de cette gouvernance')
   })
+
+  it('importe une liste depuis un CSV collé et transfère une ligne', async () => {
+    // GIVEN
+    const transfererMembreAction = stubbedServerAction(['OK'])
+    renderComponent(<MembresAConsolider regles={reglesPresenter('structure-fantome')} viewModel={listeVide()} />, {
+      pathname: '/membres-a-consolider',
+      transfererMembreAction,
+    })
+
+    // WHEN
+    fireEvent.click(screen.getByText('Importer une liste depuis un CSV'))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Contenu du CSV' }), {
+      target: { value: 'membre_id,cur_id,alt_id\nstructure-77944552700046-26,9869,9867' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Charger la liste' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Transférer' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Transférer le membre' }))
+
+    // THEN
+    await screen.findByRole('status')
+    expect(transfererMembreAction).toHaveBeenCalledWith({
+      idCible: 9867,
+      idMembre: 'structure-77944552700046-26',
+      idSource: 9869,
+      path: '/membres-a-consolider',
+    })
+  })
+
+  it('signale les lignes invalides du CSV importé', () => {
+    // GIVEN
+    renderComponent(<MembresAConsolider regles={reglesPresenter('structure-fantome')} viewModel={listeVide()} />)
+
+    // WHEN
+    fireEvent.click(screen.getByText('Importer une liste depuis un CSV'))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Contenu du CSV' }), {
+      target: { value: 'membre_id,cur_id,alt_id\n,10,20' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Charger la liste' }))
+
+    // THEN
+    expect(screen.getByText('Aucune ligne exploitable.')).toBeInTheDocument()
+    expect(screen.getByText('Ligne 2 ignorée : membre_id / cur_id / alt_id invalides.')).toBeInTheDocument()
+  })
 })
+
+function listeVide(): MembresAConsoliderViewModel {
+  return { membres: [], total: 0 }
+}
 
 function unMembre(): MembresAConsoliderViewModel {
   return {

--- a/src/components/MembresAConsolider/MembresAConsolider.test.tsx
+++ b/src/components/MembresAConsolider/MembresAConsolider.test.tsx
@@ -116,7 +116,7 @@ describe('membres à consolider', () => {
     })
 
     // WHEN
-    fireEvent.click(screen.getByText('Importer une liste depuis un CSV'))
+    fireEvent.click(screen.getByRole('button', { name: 'Importer un CSV' }))
     fireEvent.change(screen.getByRole('textbox', { name: 'Contenu du CSV' }), {
       target: { value: 'membre_id,cur_id,alt_id\nstructure-77944552700046-26,9869,9867' },
     })
@@ -139,7 +139,7 @@ describe('membres à consolider', () => {
     renderComponent(<MembresAConsolider regles={reglesPresenter('structure-fantome')} viewModel={listeVide()} />)
 
     // WHEN
-    fireEvent.click(screen.getByText('Importer une liste depuis un CSV'))
+    fireEvent.click(screen.getByRole('button', { name: 'Importer un CSV' }))
     fireEvent.change(screen.getByRole('textbox', { name: 'Contenu du CSV' }), {
       target: { value: 'membre_id,cur_id,alt_id\n,10,20' },
     })

--- a/src/components/MembresAConsolider/MembresAConsolider.test.tsx
+++ b/src/components/MembresAConsolider/MembresAConsolider.test.tsx
@@ -1,0 +1,130 @@
+import { fireEvent, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import MembresAConsolider from './MembresAConsolider'
+import { renderComponent, stubbedServerAction } from '@/components/testHelper'
+import { MembresAConsoliderViewModel, reglesPresenter } from '@/presenters/membresAConsoliderPresenter'
+
+describe('membres à consolider', () => {
+  it('affiche le membre à consolider et son action de transfert', () => {
+    // WHEN
+    renderComponent(<MembresAConsolider regles={reglesPresenter('structure-fantome')} viewModel={unMembre()} />)
+
+    // THEN
+    expect(screen.getByRole('heading', { level: 1, name: 'Membres à consolider' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Transférer' })).toBeInTheDocument()
+  })
+
+  it('transfère le membre vers la structure cible proposée, notifie et rafraîchit', async () => {
+    // GIVEN
+    const transfererMembreAction = stubbedServerAction(['OK'])
+    const refresh = vi.fn<() => void>()
+    renderComponent(<MembresAConsolider regles={reglesPresenter('structure-fantome')} viewModel={unMembre()} />, {
+      pathname: '/membres-a-consolider',
+      router: {
+        back: vi.fn<() => void>(),
+        forward: vi.fn<() => void>(),
+        prefetch: vi.fn<() => void>(),
+        push: vi.fn<() => void>(),
+        refresh,
+        replace: vi.fn<() => void>(),
+      },
+      transfererMembreAction,
+    })
+
+    // WHEN
+    fireEvent.click(screen.getByRole('button', { name: 'Transférer' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Transférer le membre' }))
+
+    // THEN
+    const notification = await screen.findByRole('status')
+    expect(notification.textContent).toBe('Membre transféré')
+    expect(transfererMembreAction).toHaveBeenCalledWith({
+      idCible: 9867,
+      idMembre: 'structure-77944552700046-26',
+      idSource: 9869,
+      path: '/membres-a-consolider',
+    })
+    expect(refresh).toHaveBeenCalledWith()
+  })
+
+  it('permet de modifier l’identifiant de la structure cible avant de transférer', async () => {
+    // GIVEN
+    const transfererMembreAction = stubbedServerAction(['OK'])
+    renderComponent(<MembresAConsolider regles={reglesPresenter('structure-fantome')} viewModel={unMembre()} />, {
+      pathname: '/membres-a-consolider',
+      transfererMembreAction,
+    })
+
+    // WHEN
+    fireEvent.click(screen.getByRole('button', { name: 'Transférer' }))
+    fireEvent.change(screen.getByRole('spinbutton', { name: 'Identifiant de la structure cible' }), {
+      target: { value: '1234' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Transférer le membre' }))
+
+    // THEN
+    await screen.findByRole('status')
+    expect(transfererMembreAction).toHaveBeenCalledWith({
+      idCible: 1234,
+      idMembre: 'structure-77944552700046-26',
+      idSource: 9869,
+      path: '/membres-a-consolider',
+    })
+  })
+
+  it('affiche une erreur si la cible saisie est invalide, sans appeler l’action', () => {
+    // GIVEN
+    const transfererMembreAction = stubbedServerAction(['OK'])
+    renderComponent(<MembresAConsolider regles={reglesPresenter('structure-fantome')} viewModel={unMembre()} />, {
+      transfererMembreAction,
+    })
+
+    // WHEN
+    fireEvent.click(screen.getByRole('button', { name: 'Transférer' }))
+    fireEvent.change(screen.getByRole('spinbutton', { name: 'Identifiant de la structure cible' }), {
+      target: { value: '' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Transférer le membre' }))
+
+    // THEN
+    expect(transfererMembreAction).not.toHaveBeenCalled()
+  })
+
+  it('affiche une notification d’erreur si le transfert échoue', async () => {
+    // GIVEN
+    const transfererMembreAction = stubbedServerAction(['La structure cible est déjà membre de cette gouvernance'])
+    renderComponent(<MembresAConsolider regles={reglesPresenter('structure-fantome')} viewModel={unMembre()} />, {
+      transfererMembreAction,
+    })
+
+    // WHEN
+    fireEvent.click(screen.getByRole('button', { name: 'Transférer' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Transférer le membre' }))
+
+    // THEN
+    const notification = await screen.findByRole('alert')
+    expect(notification.textContent).toBe('Erreur : La structure cible est déjà membre de cette gouvernance')
+  })
+})
+
+function unMembre(): MembresAConsoliderViewModel {
+  return {
+    membres: [
+      {
+        departement: '26',
+        estCoporteur: false,
+        idCible: 9867,
+        idSource: 9869,
+        idsParam: '9869,9867',
+        membreId: 'structure-77944552700046-26',
+        nbSaDuSiren: 2,
+        nomActuelAffiche: 'PRÊT MATERIEL INFORMATIQUE RECONDITIONNE',
+        nomOrigine: 'Maison citoyenne Noël Guichard',
+        saTerrainNom: 'Maison Citoyenne Noel Guichard',
+        saTerrainOp: 5,
+      },
+    ],
+    total: 1,
+  }
+}

--- a/src/components/MembresAConsolider/MembresAConsolider.tsx
+++ b/src/components/MembresAConsolider/MembresAConsolider.tsx
@@ -19,28 +19,45 @@ import {
 
 export default function MembresAConsolider({ regles, viewModel }: Props): ReactElement {
   const regleActive = regles.find((regle) => regle.actif)
+  const [afficherCsv, setAfficherCsv] = useState(false)
 
   return (
     <section>
       <h1>Membres à consolider</h1>
       <p>
         Chaque règle ci-dessous liste les membres dont le rattachement à une structure mérite d’être corrigé.
-        Sélectionnez-en une.
+        Sélectionnez-en une, ou importez une liste depuis un CSV.
       </p>
-      <SelecteurRegles regles={regles} />
-      {regleActive === undefined ? null : (
-        <>
-          <p>{regleActive.sousTitre}</p>
-          <ConditionsRegle conditions={regleActive.conditions} />
-          {regleActive.disponible ? <ListeMembres viewModel={viewModel} /> : <AVenir />}
-        </>
-      )}
-      <ImportCsv />
+      <SelecteurRegles
+        afficherCsv={afficherCsv}
+        regles={regles}
+        surImportCsv={() => {
+          setAfficherCsv(true)
+        }}
+      />
+      {afficherCsv ? <ImportCsv /> : <ContenuRegle regleActive={regleActive} viewModel={viewModel} />}
     </section>
   )
 }
 
-function SelecteurRegles({ regles }: Readonly<{ regles: ReadonlyArray<RegleViewModel> }>): ReactElement {
+function ContenuRegle({
+  regleActive,
+  viewModel,
+}: Readonly<{ regleActive: RegleViewModel | undefined; viewModel: MembresAConsoliderViewModel }>): null | ReactElement {
+  if (regleActive === undefined) {
+    return null
+  }
+
+  return (
+    <>
+      <p>{regleActive.sousTitre}</p>
+      <ConditionsRegle conditions={regleActive.conditions} />
+      {regleActive.disponible ? <ListeMembres viewModel={viewModel} /> : <AVenir />}
+    </>
+  )
+}
+
+function SelecteurRegles({ afficherCsv, regles, surImportCsv }: SelecteurReglesProps): ReactElement {
   return (
     <nav
       aria-label="Règle de détection"
@@ -49,14 +66,22 @@ function SelecteurRegles({ regles }: Readonly<{ regles: ReadonlyArray<RegleViewM
     >
       {regles.map((regle) => (
         <Link
-          aria-current={regle.actif ? 'page' : undefined}
-          className={regle.actif ? 'fr-btn fr-btn--sm' : 'fr-btn fr-btn--sm fr-btn--secondary'}
+          aria-current={!afficherCsv && regle.actif ? 'page' : undefined}
+          className={!afficherCsv && regle.actif ? 'fr-btn fr-btn--sm' : 'fr-btn fr-btn--sm fr-btn--secondary'}
           href={regle.href}
           key={regle.id}
         >
           {regle.titre}
         </Link>
       ))}
+      <button
+        aria-current={afficherCsv ? 'page' : undefined}
+        className={afficherCsv ? 'fr-btn fr-btn--sm' : 'fr-btn fr-btn--sm fr-btn--secondary'}
+        onClick={surImportCsv}
+        type="button"
+      >
+        Importer un CSV
+      </button>
     </nav>
   )
 }
@@ -256,9 +281,8 @@ function ImportCsv(): ReactElement {
   const texteId = useId()
 
   return (
-    <details className="fr-mt-4w">
-      <summary className="fr-text--bold">Importer une liste depuis un CSV</summary>
-      <p className="fr-text--sm fr-text-mention--grey fr-mt-1w">
+    <div>
+      <p className="fr-text--sm fr-text-mention--grey">
         Collez un CSV de triage avec les en-têtes <code>membre_id</code>, <code>cur_id</code> (structure source) et{' '}
         <code>alt_id</code> (structure cible). Séparateur tabulation, point-virgule ou virgule.
       </p>
@@ -286,7 +310,7 @@ function ImportCsv(): ReactElement {
         Charger la liste
       </button>
       {resultat === undefined ? null : <ResultatCsv resultat={resultat} />}
-    </details>
+    </div>
   )
 }
 
@@ -345,4 +369,10 @@ type BoutonTransfererProps = Readonly<{
 type Props = Readonly<{
   regles: ReadonlyArray<RegleViewModel>
   viewModel: MembresAConsoliderViewModel
+}>
+
+type SelecteurReglesProps = Readonly<{
+  afficherCsv: boolean
+  regles: ReadonlyArray<RegleViewModel>
+  surImportCsv(): void
 }>

--- a/src/components/MembresAConsolider/MembresAConsolider.tsx
+++ b/src/components/MembresAConsolider/MembresAConsolider.tsx
@@ -9,8 +9,11 @@ import { Notification } from '../shared/Notification/Notification'
 import Table from '../shared/Table/Table'
 import { clientContext } from '@/components/shared/ClientContext'
 import {
+  ImportCsvResultViewModel,
+  MembreCsvLigneViewModel,
   MembreLigneViewModel,
   MembresAConsoliderViewModel,
+  parserCsvMembresAConsolider,
   RegleViewModel,
 } from '@/presenters/membresAConsoliderPresenter'
 
@@ -32,6 +35,7 @@ export default function MembresAConsolider({ regles, viewModel }: Props): ReactE
           {regleActive.disponible ? <ListeMembres viewModel={viewModel} /> : <AVenir />}
         </>
       )}
+      <ImportCsv />
     </section>
   )
 }
@@ -124,36 +128,6 @@ function ListeMembres({ viewModel }: Readonly<{ viewModel: MembresAConsoliderVie
 }
 
 function LigneMembre({ membre }: Readonly<{ membre: MembreLigneViewModel }>): ReactElement {
-  const { pathname, router, transfererMembreAction } = useContext(clientContext)
-  const [estModaleOuverte, setEstModaleOuverte] = useState(false)
-  const [idCible, setIdCible] = useState(String(membre.idCible))
-  const [enCours, setEnCours] = useState(false)
-  const idCibleChampId = useId()
-
-  async function confirmerTransfert(): Promise<void> {
-    const cible = Number(idCible)
-    if (!Number.isInteger(cible) || cible <= 0) {
-      Notification('error', { description: 'Identifiant de structure cible invalide', title: 'Erreur : ' })
-      return
-    }
-    setEnCours(true)
-    const messages = await transfererMembreAction({
-      idCible: cible,
-      idMembre: membre.membreId,
-      idSource: membre.idSource,
-      path: pathname,
-    })
-    setEnCours(false)
-    setEstModaleOuverte(false)
-
-    if (messages.includes('OK')) {
-      Notification('success', { description: 'transféré', title: 'Membre ' })
-      router.refresh()
-    } else {
-      Notification('error', { description: messages.join(', '), title: 'Erreur : ' })
-    }
-  }
-
   return (
     <tr>
       <td>
@@ -177,15 +151,13 @@ function LigneMembre({ membre }: Readonly<{ membre: MembreLigneViewModel }>): Re
       </td>
       <td>
         <div className="fr-btns-group fr-btns-group--sm fr-btns-group--inline">
-          <button
-            className="fr-btn fr-btn--sm"
-            onClick={() => {
-              setEstModaleOuverte(true)
-            }}
-            type="button"
-          >
-            Transférer
-          </button>
+          <BoutonTransfererMembre
+            idCibleProposee={membre.idCible}
+            idMembre={membre.membreId}
+            idSource={membre.idSource}
+            nomActuel={membre.nomActuelAffiche}
+            nomOrigine={membre.nomOrigine}
+          />
           <Link
             className="fr-btn fr-btn--secondary fr-btn--sm"
             href={`/structures-doublons/comparer?ids=${membre.idsParam}`}
@@ -193,41 +165,182 @@ function LigneMembre({ membre }: Readonly<{ membre: MembreLigneViewModel }>): Re
             Comparer
           </Link>
         </div>
-        <ConfirmationModal
-          confirmLabel={enCours ? 'Transfert…' : 'Transférer le membre'}
-          id={`transferer-membre-${membre.membreId}`}
-          isOpen={estModaleOuverte}
-          onCancel={() => {
-            setEstModaleOuverte(false)
-          }}
-          onConfirm={confirmerTransfert}
-          title="Transférer le membre vers une autre structure"
-        >
-          <p className="fr-text--sm">
-            Le membre <span className="fr-text--bold">{membre.nomOrigine}</span>, ses utilisateurs et ses contacts
-            seront re-rattachés de la structure #{membre.idSource} ({membre.nomActuelAffiche}) vers la structure cible
-            ci-dessous. La structure d’origine n’est pas supprimée.
-          </p>
-          <div className="fr-input-group">
-            <label className="fr-label" htmlFor={idCibleChampId}>
-              Identifiant de la structure cible
-            </label>
-            <input
-              className="fr-input"
-              id={idCibleChampId}
-              min={1}
-              onChange={(event) => {
-                setIdCible(event.target.value)
-              }}
-              type="number"
-              value={idCible}
-            />
-          </div>
-        </ConfirmationModal>
       </td>
     </tr>
   )
 }
+
+// Bouton + modale de transfert d'un membre, réutilisé par la liste détectée et par l'import CSV.
+function BoutonTransfererMembre({
+  idCibleProposee,
+  idMembre,
+  idSource,
+  nomActuel,
+  nomOrigine,
+}: BoutonTransfererProps): ReactElement {
+  const { pathname, router, transfererMembreAction } = useContext(clientContext)
+  const [estModaleOuverte, setEstModaleOuverte] = useState(false)
+  const [idCible, setIdCible] = useState(String(idCibleProposee))
+  const [enCours, setEnCours] = useState(false)
+  const modaleId = useId()
+  const idCibleChampId = useId()
+
+  async function confirmerTransfert(): Promise<void> {
+    const cible = Number(idCible)
+    if (!Number.isInteger(cible) || cible <= 0) {
+      Notification('error', { description: 'Identifiant de structure cible invalide', title: 'Erreur : ' })
+      return
+    }
+    setEnCours(true)
+    const messages = await transfererMembreAction({ idCible: cible, idMembre, idSource, path: pathname })
+    setEnCours(false)
+    setEstModaleOuverte(false)
+
+    if (messages.includes('OK')) {
+      Notification('success', { description: 'transféré', title: 'Membre ' })
+      router.refresh()
+    } else {
+      Notification('error', { description: messages.join(', '), title: 'Erreur : ' })
+    }
+  }
+
+  return (
+    <>
+      <button
+        className="fr-btn fr-btn--sm"
+        onClick={() => {
+          setEstModaleOuverte(true)
+        }}
+        type="button"
+      >
+        Transférer
+      </button>
+      <ConfirmationModal
+        confirmLabel={enCours ? 'Transfert…' : 'Transférer le membre'}
+        id={modaleId}
+        isOpen={estModaleOuverte}
+        onCancel={() => {
+          setEstModaleOuverte(false)
+        }}
+        onConfirm={confirmerTransfert}
+        title="Transférer le membre vers une autre structure"
+      >
+        <p className="fr-text--sm">
+          Le membre <span className="fr-text--bold">{nomOrigine}</span>, ses utilisateurs et ses contacts seront
+          re-rattachés de la structure #{idSource} ({nomActuel}) vers la structure cible ci-dessous. La structure
+          d’origine n’est pas supprimée.
+        </p>
+        <div className="fr-input-group">
+          <label className="fr-label" htmlFor={idCibleChampId}>
+            Identifiant de la structure cible
+          </label>
+          <input
+            className="fr-input"
+            id={idCibleChampId}
+            min={1}
+            onChange={(event) => {
+              setIdCible(event.target.value)
+            }}
+            type="number"
+            value={idCible}
+          />
+        </div>
+      </ConfirmationModal>
+    </>
+  )
+}
+
+function ImportCsv(): ReactElement {
+  const [texte, setTexte] = useState('')
+  const [resultat, setResultat] = useState<ImportCsvResultViewModel | undefined>(undefined)
+  const texteId = useId()
+
+  return (
+    <details className="fr-mt-4w">
+      <summary className="fr-text--bold">Importer une liste depuis un CSV</summary>
+      <p className="fr-text--sm fr-text-mention--grey fr-mt-1w">
+        Collez un CSV de triage avec les en-têtes <code>membre_id</code>, <code>cur_id</code> (structure source) et{' '}
+        <code>alt_id</code> (structure cible). Séparateur tabulation, point-virgule ou virgule.
+      </p>
+      <div className="fr-input-group">
+        <label className="fr-label" htmlFor={texteId}>
+          Contenu du CSV
+        </label>
+        <textarea
+          className="fr-input"
+          id={texteId}
+          onChange={(event) => {
+            setTexte(event.target.value)
+          }}
+          rows={6}
+          value={texte}
+        />
+      </div>
+      <button
+        className="fr-btn fr-btn--sm fr-mb-2w"
+        onClick={() => {
+          setResultat(parserCsvMembresAConsolider(texte))
+        }}
+        type="button"
+      >
+        Charger la liste
+      </button>
+      {resultat === undefined ? null : <ResultatCsv resultat={resultat} />}
+    </details>
+  )
+}
+
+function ResultatCsv({ resultat }: Readonly<{ resultat: ImportCsvResultViewModel }>): ReactElement {
+  return (
+    <>
+      {resultat.erreurs.length > 0 ? (
+        <ul className="fr-text--sm fr-mb-2w" style={{ color: 'var(--text-default-error)' }}>
+          {resultat.erreurs.map((erreur) => (
+            <li key={erreur}>{erreur}</li>
+          ))}
+        </ul>
+      ) : null}
+      {resultat.lignes.length > 0 ? (
+        <Table enTetes={['Membre', 'Structure source', 'Structure cible', '']} titre="Membres importés du CSV">
+          {resultat.lignes.map((ligne) => (
+            <LigneCsv key={`${ligne.idMembre}-${ligne.idSource}-${ligne.idCible}`} ligne={ligne} />
+          ))}
+        </Table>
+      ) : (
+        <p className="fr-text--sm fr-text-mention--grey">Aucune ligne exploitable.</p>
+      )}
+    </>
+  )
+}
+
+function LigneCsv({ ligne }: Readonly<{ ligne: MembreCsvLigneViewModel }>): ReactElement {
+  return (
+    <tr>
+      <td>
+        <span className="fr-text--bold">{ligne.nomOrigine}</span>
+      </td>
+      <td>#{ligne.idSource}</td>
+      <td>#{ligne.idCible}</td>
+      <td>
+        <BoutonTransfererMembre
+          idCibleProposee={ligne.idCible}
+          idMembre={ligne.idMembre}
+          idSource={ligne.idSource}
+          nomActuel={ligne.nomActuel}
+          nomOrigine={ligne.nomOrigine}
+        />
+      </td>
+    </tr>
+  )
+}
+
+type BoutonTransfererProps = Readonly<{
+  idCibleProposee: number
+  idMembre: string
+  idSource: number
+  nomActuel: string
+  nomOrigine: string
+}>
 
 type Props = Readonly<{
   regles: ReadonlyArray<RegleViewModel>

--- a/src/components/MembresAConsolider/MembresAConsolider.tsx
+++ b/src/components/MembresAConsolider/MembresAConsolider.tsx
@@ -1,0 +1,160 @@
+'use client'
+
+import Link from 'next/link'
+import { ReactElement } from 'react'
+
+import Information from '../shared/Information/Information'
+import Table from '../shared/Table/Table'
+import {
+  MembreLigneViewModel,
+  MembresAConsoliderViewModel,
+  RegleViewModel,
+} from '@/presenters/membresAConsoliderPresenter'
+
+export default function MembresAConsolider({ regles, viewModel }: Props): ReactElement {
+  const regleActive = regles.find((regle) => regle.actif)
+
+  return (
+    <section>
+      <h1>Membres à consolider</h1>
+      <p>
+        Chaque règle ci-dessous liste les membres dont le rattachement à une structure mérite d’être corrigé.
+        Sélectionnez-en une.
+      </p>
+      <SelecteurRegles regles={regles} />
+      {regleActive === undefined ? null : (
+        <>
+          <p>{regleActive.sousTitre}</p>
+          <ConditionsRegle conditions={regleActive.conditions} />
+          {regleActive.disponible ? <ListeMembres viewModel={viewModel} /> : <AVenir />}
+        </>
+      )}
+    </section>
+  )
+}
+
+function SelecteurRegles({ regles }: Readonly<{ regles: ReadonlyArray<RegleViewModel> }>): ReactElement {
+  return (
+    <nav
+      aria-label="Règle de détection"
+      className="fr-mb-3w"
+      style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}
+    >
+      {regles.map((regle) => (
+        <Link
+          aria-current={regle.actif ? 'page' : undefined}
+          className={regle.actif ? 'fr-btn fr-btn--sm' : 'fr-btn fr-btn--sm fr-btn--secondary'}
+          href={regle.href}
+          key={regle.id}
+        >
+          {regle.titre}
+        </Link>
+      ))}
+    </nav>
+  )
+}
+
+function ConditionsRegle({ conditions }: Readonly<{ conditions: ReadonlyArray<string> }>): ReactElement {
+  return (
+    <>
+      <p className="fr-text--sm fr-text--bold fr-mb-1v">Règles de sélection (toutes réunies) :</p>
+      <ul className="fr-text--sm fr-mb-2w">
+        {conditions.map((condition) => (
+          <li className="fr-mb-1v" key={condition}>
+            {condition}
+          </li>
+        ))}
+      </ul>
+    </>
+  )
+}
+
+function AVenir(): ReactElement {
+  return (
+    <div className="fr-p-4w fr-mt-2w" style={{ border: '1px dashed var(--border-default-grey)', textAlign: 'center' }}>
+      <p className="fr-badge fr-badge--info fr-badge--no-icon fr-mb-1w">À venir</p>
+      <p className="fr-text--sm fr-text-mention--grey fr-mb-0">
+        La détection de cette règle n’est pas encore implémentée. La liste des membres concernés s’affichera ici.
+      </p>
+    </div>
+  )
+}
+
+function ListeMembres({ viewModel }: Readonly<{ viewModel: MembresAConsoliderViewModel }>): ReactElement {
+  const pluriel = viewModel.total > 1 ? 's' : ''
+  const resume =
+    viewModel.total === 0
+      ? 'Aucun membre à consolider détecté pour cette règle.'
+      : `${viewModel.total} membre${pluriel} de gouvernance rattaché${pluriel} à une antenne sans activité, alors que l’établissement réel existe ailleurs.`
+
+  return (
+    <>
+      <p className="fr-text--sm fr-text--bold fr-mb-1v">Lecture des colonnes :</p>
+      <ul className="fr-raw-list fr-text--sm fr-text-mention--grey fr-mb-2w">
+        <li className="fr-mb-1v">
+          <span className="fr-text--bold">Membre (nom d’origine)</span> : nom du membre à l’origine dans FNE.
+        </li>
+        <li className="fr-mb-1v">
+          <span className="fr-text--bold">Nom affiché aujourd’hui</span> : nom de la structure (antenne) à laquelle le
+          membre est aujourd’hui rattaché.
+        </li>
+        <li className="fr-mb-1v">
+          <span className="fr-text--bold">Établissement réel proposé</span> : candidat que le système détecte comme
+          étant proche.
+          <Information>Structure dont le SIRET est identique</Information>
+        </li>
+      </ul>
+      <p className="fr-text--sm fr-text-mention--grey">{resume}</p>
+
+      {viewModel.total > 0 ? (
+        <Table
+          enTetes={['Membre (nom d’origine)', 'Nom affiché aujourd’hui', 'Établissement réel proposé', '']}
+          titre="Membres à consolider"
+        >
+          {viewModel.membres.map((membre) => (
+            <LigneMembre key={membre.membreId} membre={membre} />
+          ))}
+        </Table>
+      ) : null}
+    </>
+  )
+}
+
+function LigneMembre({ membre }: Readonly<{ membre: MembreLigneViewModel }>): ReactElement {
+  return (
+    <tr>
+      <td>
+        <span className="fr-text--bold">{membre.nomOrigine}</span>{' '}
+        <span className="fr-text--xs fr-text-mention--grey">(dép. {membre.departement})</span>
+        {membre.estCoporteur ? (
+          <>
+            <br />
+            <span className="fr-badge fr-badge--no-icon fr-badge--sm fr-badge--green-emeraude">Co-porteur</span>
+          </>
+        ) : null}
+      </td>
+      <td>
+        <span className="fr-badge fr-badge--no-icon fr-badge--sm fr-badge--warning">{membre.nomActuelAffiche}</span>
+      </td>
+      <td>
+        <span className="fr-text--bold">{membre.saTerrainNom}</span>{' '}
+        <span className="fr-text--xs fr-text-mention--grey">
+          ({membre.saTerrainOp} rattachement{membre.saTerrainOp > 1 ? 's' : ''} · {membre.nbSaDuSiren} SA pour ce SIREN)
+        </span>
+      </td>
+      <td>
+        <Link
+          className="fr-btn fr-btn--secondary fr-btn--sm"
+          href={`/structures-doublons/comparer?ids=${membre.idsParam}`}
+        >
+          Comparer / fusionner
+        </Link>
+      </td>
+    </tr>
+  )
+}
+
+type Props = Readonly<{
+  regles: ReadonlyArray<RegleViewModel>
+  viewModel: MembresAConsoliderViewModel
+}>

--- a/src/components/MembresAConsolider/MembresAConsolider.tsx
+++ b/src/components/MembresAConsolider/MembresAConsolider.tsx
@@ -1,10 +1,13 @@
 'use client'
 
 import Link from 'next/link'
-import { ReactElement } from 'react'
+import { ReactElement, useContext, useId, useState } from 'react'
 
 import Information from '../shared/Information/Information'
+import ConfirmationModal from '../shared/Modal/ConfirmationModal'
+import { Notification } from '../shared/Notification/Notification'
 import Table from '../shared/Table/Table'
+import { clientContext } from '@/components/shared/ClientContext'
 import {
   MembreLigneViewModel,
   MembresAConsoliderViewModel,
@@ -121,6 +124,36 @@ function ListeMembres({ viewModel }: Readonly<{ viewModel: MembresAConsoliderVie
 }
 
 function LigneMembre({ membre }: Readonly<{ membre: MembreLigneViewModel }>): ReactElement {
+  const { pathname, router, transfererMembreAction } = useContext(clientContext)
+  const [estModaleOuverte, setEstModaleOuverte] = useState(false)
+  const [idCible, setIdCible] = useState(String(membre.idCible))
+  const [enCours, setEnCours] = useState(false)
+  const idCibleChampId = useId()
+
+  async function confirmerTransfert(): Promise<void> {
+    const cible = Number(idCible)
+    if (!Number.isInteger(cible) || cible <= 0) {
+      Notification('error', { description: 'Identifiant de structure cible invalide', title: 'Erreur : ' })
+      return
+    }
+    setEnCours(true)
+    const messages = await transfererMembreAction({
+      idCible: cible,
+      idMembre: membre.membreId,
+      idSource: membre.idSource,
+      path: pathname,
+    })
+    setEnCours(false)
+    setEstModaleOuverte(false)
+
+    if (messages.includes('OK')) {
+      Notification('success', { description: 'transféré', title: 'Membre ' })
+      router.refresh()
+    } else {
+      Notification('error', { description: messages.join(', '), title: 'Erreur : ' })
+    }
+  }
+
   return (
     <tr>
       <td>
@@ -143,12 +176,54 @@ function LigneMembre({ membre }: Readonly<{ membre: MembreLigneViewModel }>): Re
         </span>
       </td>
       <td>
-        <Link
-          className="fr-btn fr-btn--secondary fr-btn--sm"
-          href={`/structures-doublons/comparer?ids=${membre.idsParam}`}
+        <div className="fr-btns-group fr-btns-group--sm fr-btns-group--inline">
+          <button
+            className="fr-btn fr-btn--sm"
+            onClick={() => {
+              setEstModaleOuverte(true)
+            }}
+            type="button"
+          >
+            Transférer
+          </button>
+          <Link
+            className="fr-btn fr-btn--secondary fr-btn--sm"
+            href={`/structures-doublons/comparer?ids=${membre.idsParam}`}
+          >
+            Comparer
+          </Link>
+        </div>
+        <ConfirmationModal
+          confirmLabel={enCours ? 'Transfert…' : 'Transférer le membre'}
+          id={`transferer-membre-${membre.membreId}`}
+          isOpen={estModaleOuverte}
+          onCancel={() => {
+            setEstModaleOuverte(false)
+          }}
+          onConfirm={confirmerTransfert}
+          title="Transférer le membre vers une autre structure"
         >
-          Comparer / fusionner
-        </Link>
+          <p className="fr-text--sm">
+            Le membre <span className="fr-text--bold">{membre.nomOrigine}</span>, ses utilisateurs et ses contacts
+            seront re-rattachés de la structure #{membre.idSource} ({membre.nomActuelAffiche}) vers la structure cible
+            ci-dessous. La structure d’origine n’est pas supprimée.
+          </p>
+          <div className="fr-input-group">
+            <label className="fr-label" htmlFor={idCibleChampId}>
+              Identifiant de la structure cible
+            </label>
+            <input
+              className="fr-input"
+              id={idCibleChampId}
+              min={1}
+              onChange={(event) => {
+                setIdCible(event.target.value)
+              }}
+              type="number"
+              value={idCible}
+            />
+          </div>
+        </ConfirmationModal>
       </td>
     </tr>
   )

--- a/src/components/StructuresDoublons/ComparerStructures.test.tsx
+++ b/src/components/StructuresDoublons/ComparerStructures.test.tsx
@@ -42,11 +42,33 @@ describe('examiner et fusionner un doublon', () => {
     const notification = await screen.findByRole('status')
     expect(notification.textContent).toBe('Structures fusionnées')
     expect(fusionnerStructuresAction).toHaveBeenCalledWith({
-      idAbsorbee: 7,
+      idsAbsorbees: [7],
       idSurvivante: 3,
       path: '/structures-doublons/comparer',
     })
     expect(push).toHaveBeenCalledWith('/structures-doublons')
+  })
+
+  it('fusionne plusieurs structures dans la survivante', async () => {
+    // GIVEN
+    const fusionnerStructuresAction = stubbedServerAction(['OK'])
+    renderComponent(<ComparerStructures viewModel={troisStructures()} />, {
+      fusionnerStructuresAction,
+      pathname: '/structures-doublons/comparer',
+    })
+
+    // WHEN : la 2e carte est absorbée par défaut, on ajoute la 3e
+    fireEvent.click(screen.getAllByRole('radio', { name: 'Fusionner dans la survivante' })[2])
+    fireEvent.click(screen.getByRole('button', { name: 'Fusionner' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Confirmer la fusion' }))
+
+    // THEN
+    await screen.findByRole('status')
+    expect(fusionnerStructuresAction).toHaveBeenCalledWith({
+      idsAbsorbees: [7, 11],
+      idSurvivante: 3,
+      path: '/structures-doublons/comparer',
+    })
   })
 
   it('affiche une notification d’erreur si la fusion échoue', async () => {
@@ -62,10 +84,76 @@ describe('examiner et fusionner un doublon', () => {
     const notification = await screen.findByRole('alert')
     expect(notification.textContent).toBe('Erreur : Structure introuvable ou déjà supprimée')
   })
+
+  it('marque la structure canonique d’un tag et l’autre comme antenne', () => {
+    // WHEN
+    renderComponent(<ComparerStructures viewModel={deuxStructures()} />)
+
+    // THEN
+    expect(screen.getByText('Canonique')).toBeInTheDocument()
+    expect(screen.getByText('Antenne')).toBeInTheDocument()
+  })
+
+  it('marque d’un tag Membre la structure qui porte un membre de gouvernance', () => {
+    // WHEN
+    renderComponent(<ComparerStructures viewModel={deuxStructures()} />)
+
+    // THEN
+    expect(screen.getByText('Membre')).toBeInTheDocument()
+  })
+
+  it('marque d’un tag Lieu d’inclusion la structure associée à un lieu d’inclusion', () => {
+    // WHEN
+    renderComponent(<ComparerStructures viewModel={deuxStructures()} />)
+
+    // THEN
+    expect(screen.getByText('Lieu d’inclusion rattaché')).toBeInTheDocument()
+  })
+
+  it('affiche le détail des rattachements de chaque structure', () => {
+    // WHEN
+    renderComponent(<ComparerStructures viewModel={deuxStructures()} />)
+
+    // THEN
+    expect(screen.getAllByText('Détail des rattachements')).toHaveLength(2)
+    expect(screen.getAllByText('Postes :', { exact: false }).length).toBeGreaterThan(0)
+  })
+
+  it('bascule sur la vue Distances et affiche la matrice de distances entre structures', () => {
+    // GIVEN
+    renderComponent(<ComparerStructures viewModel={deuxStructures()} />)
+
+    // WHEN
+    fireEvent.click(screen.getByRole('button', { name: 'Distances' }))
+
+    // THEN
+    expect(screen.getByRole('columnheader', { name: 'Conseil Départemental' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Antenne Sud' })).toBeInTheDocument()
+    expect(screen.queryByRole('radio', { name: 'Conserver (survivante)' })).not.toBeInTheDocument()
+  })
+
+  it('« Ne pas toucher » retire la carte de la fusion et désactive le bouton', () => {
+    // GIVEN
+    renderComponent(<ComparerStructures viewModel={deuxStructures()} />)
+
+    // WHEN : on retire la survivante par défaut (1re carte)
+    fireEvent.click(screen.getAllByRole('radio', { name: 'Ne pas toucher' })[0])
+
+    // THEN
+    expect(screen.getByRole('button', { name: 'Fusionner' })).toBeDisabled()
+  })
 })
 
 function deuxStructures(): ComparaisonViewModel {
   return [structureComparaison(3, 'Conseil Départemental'), structureComparaison(7, 'Antenne Sud')]
+}
+
+function troisStructures(): ComparaisonViewModel {
+  return [
+    structureComparaison(3, 'Conseil Départemental'),
+    structureComparaison(7, 'Antenne Sud'),
+    structureComparaison(11, 'Antenne Est'),
+  ]
 }
 
 function structureComparaison(id: number, denomination: string): StructureComparaisonViewModel {
@@ -74,7 +162,12 @@ function structureComparaison(id: number, denomination: string): StructureCompar
     champs: [{ label: 'SIRET', valeur: '22280001300013' }],
     denomination,
     denominationSirene: denomination,
+    estAssocieLieuInclusion: id === 7,
+    estCanonique: id === 3,
+    estMembre: id === 7,
     id,
+    latitude: id === 3 ? 48.45 : 48.5,
+    longitude: id === 3 ? 1.49 : 1.6,
     rattachements: [{ label: 'Postes', nombre: 15 }],
     rattachementsTotal: 15,
   }

--- a/src/components/StructuresDoublons/ComparerStructures.tsx
+++ b/src/components/StructuresDoublons/ComparerStructures.tsx
@@ -1,23 +1,72 @@
 'use client'
 
-import { ReactElement, useContext, useState } from 'react'
+import { CSSProperties, ReactElement, useContext, useState } from 'react'
 
+import Information from '../shared/Information/Information'
 import ConfirmationModal from '../shared/Modal/ConfirmationModal'
 import { Notification } from '../shared/Notification/Notification'
 import { clientContext } from '@/components/shared/ClientContext'
-import { ComparaisonViewModel, StructureComparaisonViewModel } from '@/presenters/comparaisonDoublonsPresenter'
+import {
+  ComparaisonViewModel,
+  matriceDistances,
+  MatriceDistancesViewModel,
+  NiveauDistance,
+  StructureComparaisonViewModel,
+} from '@/presenters/comparaisonDoublonsPresenter'
+
+type Choix = 'conserver' | 'fusionner' | 'ignorer'
+
+type Vue = 'comparer' | 'distances'
+
+const CHOIX_OPTIONS: ReadonlyArray<Readonly<{ label: string; valeur: Choix }>> = [
+  { label: 'Conserver (survivante)', valeur: 'conserver' },
+  { label: 'Fusionner dans la survivante', valeur: 'fusionner' },
+  { label: 'Ne pas toucher', valeur: 'ignorer' },
+]
 
 export default function ComparerStructures({ viewModel }: Props): ReactElement {
   const { fusionnerStructuresAction, pathname, router } = useContext(clientContext)
 
   const [idSurvivante, setIdSurvivante] = useState(viewModel[0]?.id ?? 0)
-  const [idAbsorbee, setIdAbsorbee] = useState(viewModel[1]?.id ?? 0)
+  const [idsAbsorbees, setIdsAbsorbees] = useState<ReadonlyArray<number>>(
+    viewModel.slice(1, 2).map((structure) => structure.id)
+  )
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [vue, setVue] = useState<Vue>('comparer')
 
   const survivante = viewModel.find((structure) => structure.id === idSurvivante)
-  const absorbee = viewModel.find((structure) => structure.id === idAbsorbee)
-  const fusionPossible = survivante !== undefined && absorbee !== undefined && idSurvivante !== idAbsorbee
+  const absorbees = viewModel.filter((structure) => idsAbsorbees.includes(structure.id))
+  const fusionPossible = survivante !== undefined && absorbees.length > 0
+
+  function choixDe(id: number): Choix {
+    if (id === idSurvivante) {
+      return 'conserver'
+    }
+    if (idsAbsorbees.includes(id)) {
+      return 'fusionner'
+    }
+    return 'ignorer'
+  }
+
+  // La survivante est unique ; on peut en revanche fusionner PLUSIEURS structures dans celle-ci.
+  // Choisir un rôle sur une carte la retire des autres rôles. « Ne pas toucher » = neutre.
+  function definirChoix(id: number, choix: Choix): void {
+    if (choix === 'conserver') {
+      setIdSurvivante(id)
+      setIdsAbsorbees((ids) => ids.filter((autre) => autre !== id))
+    } else if (choix === 'fusionner') {
+      setIdsAbsorbees((ids) => (ids.includes(id) ? ids : [...ids, id]))
+      if (id === idSurvivante) {
+        setIdSurvivante(0)
+      }
+    } else {
+      setIdsAbsorbees((ids) => ids.filter((autre) => autre !== id))
+      if (id === idSurvivante) {
+        setIdSurvivante(0)
+      }
+    }
+  }
 
   async function confirmerFusion(): Promise<void> {
     if (!fusionPossible) {
@@ -25,7 +74,7 @@ export default function ComparerStructures({ viewModel }: Props): ReactElement {
     }
     setIsSubmitting(true)
     const messages = await fusionnerStructuresAction({
-      idAbsorbee,
+      idsAbsorbees,
       idSurvivante,
       path: pathname,
     })
@@ -48,23 +97,44 @@ export default function ComparerStructures({ viewModel }: Props): ReactElement {
         absorbée seront déplacés vers la survivante, qui conserve ses propres identifiants (SIRET, RNA…).
       </p>
 
-      <div className="fr-grid-row fr-grid-row--gutters">
-        {viewModel.map((structure) => (
-          <div className="fr-col-12 fr-col-md-6" key={structure.id}>
-            <CarteStructure
-              estAbsorbee={structure.id === idAbsorbee}
-              estSurvivante={structure.id === idSurvivante}
-              onAbsorbee={() => {
-                setIdAbsorbee(structure.id)
-              }}
-              onSurvivante={() => {
-                setIdSurvivante(structure.id)
-              }}
-              structure={structure}
-            />
-          </div>
-        ))}
+      <div className="fr-btns-group fr-btns-group--inline fr-btns-group--sm fr-mb-2w">
+        <button
+          className={vue === 'comparer' ? 'fr-btn' : 'fr-btn fr-btn--secondary'}
+          onClick={() => {
+            setVue('comparer')
+          }}
+          type="button"
+        >
+          Comparer
+        </button>
+        <button
+          className={vue === 'distances' ? 'fr-btn' : 'fr-btn fr-btn--secondary'}
+          onClick={() => {
+            setVue('distances')
+          }}
+          type="button"
+        >
+          Distances
+        </button>
       </div>
+
+      {vue === 'comparer' ? (
+        <div className="fr-grid-row fr-grid-row--gutters">
+          {viewModel.map((structure) => (
+            <div className="fr-col-12 fr-col-md-6" key={structure.id}>
+              <CarteStructure
+                choix={choixDe(structure.id)}
+                onChoix={(choix) => {
+                  definirChoix(structure.id, choix)
+                }}
+                structure={structure}
+              />
+            </div>
+          ))}
+        </div>
+      ) : (
+        <MatriceDistances matrice={matriceDistances(viewModel)} />
+      )}
 
       <div className="fr-mt-4w">
         <button
@@ -77,9 +147,11 @@ export default function ComparerStructures({ viewModel }: Props): ReactElement {
         >
           Fusionner
         </button>
-        {idSurvivante === idAbsorbee ? (
-          <p className="fr-error-text">La survivante et la structure à fusionner doivent être différentes.</p>
-        ) : null}
+        {fusionPossible ? null : (
+          <p className="fr-text--sm fr-text-mention--grey fr-mt-1w">
+            Sélectionnez une structure à conserver et au moins une à fusionner.
+          </p>
+        )}
       </div>
 
       <ConfirmationModal
@@ -95,27 +167,92 @@ export default function ComparerStructures({ viewModel }: Props): ReactElement {
         }}
         title="Confirmer la fusion des structures"
       >
-        {fusionPossible ? <AvertissementFusion absorbee={absorbee} survivante={survivante} /> : null}
+        {fusionPossible ? <AvertissementFusion absorbees={absorbees} survivante={survivante} /> : null}
       </ConfirmationModal>
     </section>
   )
 }
 
+function MatriceDistances({ matrice }: Readonly<{ matrice: MatriceDistancesViewModel }>): ReactElement {
+  return (
+    <>
+      <p className="fr-text--sm fr-text-mention--grey fr-mb-1v">
+        Distances à vol d’oiseau (km) entre les adresses des structures candidates.
+        {matrice.coordsIncompletes ? ' Certaines structures n’ont pas de coordonnées (n/a).' : ''}
+      </p>
+      <p className="fr-text--xs fr-text-mention--grey">
+        <span style={{ fontWeight: 700 }}>0.0</span> = même adresse · <span style={{ opacity: 0.4 }}>&lt; 100 m</span> ·{' '}
+        <span style={{ color: 'var(--text-default-warning)', fontWeight: 700 }}>&gt; 1 km</span>
+      </p>
+      <div className="fr-table fr-table--md">
+        <div className="fr-table__wrapper">
+          <div className="fr-table__container">
+            <div className="fr-table__content">
+              <table>
+                <caption className="fr-sr-only">Distances entre structures candidates</caption>
+                <thead>
+                  <tr>
+                    <th scope="col">Structure</th>
+                    {matrice.colonnes.map((colonne) => (
+                      <th key={colonne.id} scope="col">
+                        {colonne.nom}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {matrice.lignes.map((ligne) => (
+                    <tr key={ligne.id}>
+                      <th scope="row">
+                        <span className="fr-text--bold">{ligne.nom}</span>
+                        <br />
+                        <span className="fr-text--xs fr-text-mention--grey">{ligne.adresse}</span>
+                      </th>
+                      {ligne.cellules.map((cellule) => (
+                        <td key={cellule.colonneId} style={styleCellule(cellule.niveau)}>
+                          {cellule.valeur}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}
+
 function CarteStructure({
-  estAbsorbee,
-  estSurvivante,
-  onAbsorbee,
-  onSurvivante,
+  choix,
+  onChoix,
   structure,
 }: Readonly<{
-  estAbsorbee: boolean
-  estSurvivante: boolean
-  onAbsorbee(): void
-  onSurvivante(): void
+  choix: Choix
+  onChoix(choix: Choix): void
   structure: StructureComparaisonViewModel
 }>): ReactElement {
+  const rattachementsDetail = structure.rattachements.filter((rattachement) => rattachement.nombre > 0)
+
   return (
-    <div className="fr-p-3w" style={{ border: '1px solid var(--border-default-grey)' }}>
+    <div className="fr-p-3w" style={{ borderStyle: 'solid', borderWidth: 1, ...styleCarte(choix) }}>
+      <p className="fr-mb-1w">
+        {structure.estCanonique ? (
+          <span className="fr-badge fr-badge--no-icon fr-badge--sm fr-badge--success">Canonique</span>
+        ) : (
+          <span className="fr-badge fr-badge--no-icon fr-badge--sm fr-badge--purple-glycine">Antenne</span>
+        )}
+        {structure.estMembre ? (
+          <span className="fr-badge fr-badge--no-icon fr-badge--sm fr-badge--green-emeraude fr-ml-1w">Membre</span>
+        ) : null}
+        {structure.estAssocieLieuInclusion ? (
+          <span className="fr-badge fr-badge--no-icon fr-badge--sm fr-badge--blue-ecume fr-ml-1w">
+            Lieu d’inclusion rattaché
+          </span>
+        ) : null}
+      </p>
       <h2 className="fr-h5">{structure.denomination}</h2>
       <p className="fr-text--xs fr-text-mention--grey">
         {structure.adresse} · {structure.rattachementsTotal} rattachement{structure.rattachementsTotal > 1 ? 's' : ''}
@@ -130,32 +267,38 @@ function CarteStructure({
         ))}
       </dl>
 
+      <p className="fr-text--sm fr-text--bold fr-mb-1v">Détail des rattachements</p>
+      {rattachementsDetail.length === 0 ? (
+        <p className="fr-text--sm fr-text-mention--grey">Aucun rattachement.</p>
+      ) : (
+        <ul className="fr-text--sm">
+          {rattachementsDetail.map((rattachement) => (
+            <li key={rattachement.label}>
+              {rattachement.label} : <span className="fr-text--bold">{rattachement.nombre}</span>
+              {rattachement.info === undefined ? null : <Information>{rattachement.info}</Information>}
+            </li>
+          ))}
+        </ul>
+      )}
+
       <fieldset className="fr-fieldset fr-mt-2w">
         <div className="fr-fieldset__content">
-          <div className="fr-radio-group">
-            <input
-              checked={estSurvivante}
-              id={`survivante-${structure.id}`}
-              name="survivante"
-              onChange={onSurvivante}
-              type="radio"
-            />
-            <label className="fr-label" htmlFor={`survivante-${structure.id}`}>
-              Conserver (survivante)
-            </label>
-          </div>
-          <div className="fr-radio-group">
-            <input
-              checked={estAbsorbee}
-              id={`absorbee-${structure.id}`}
-              name="absorbee"
-              onChange={onAbsorbee}
-              type="radio"
-            />
-            <label className="fr-label" htmlFor={`absorbee-${structure.id}`}>
-              Fusionner dans la survivante
-            </label>
-          </div>
+          {CHOIX_OPTIONS.map((option) => (
+            <div className="fr-radio-group" key={option.valeur}>
+              <input
+                checked={choix === option.valeur}
+                id={`choix-${option.valeur}-${structure.id}`}
+                name={`choix-${structure.id}`}
+                onChange={() => {
+                  onChoix(option.valeur)
+                }}
+                type="radio"
+              />
+              <label className="fr-label" htmlFor={`choix-${option.valeur}-${structure.id}`}>
+                {option.label}
+              </label>
+            </div>
+          ))}
         </div>
       </fieldset>
     </div>
@@ -163,22 +306,28 @@ function CarteStructure({
 }
 
 function AvertissementFusion({
-  absorbee,
+  absorbees,
   survivante,
 }: Readonly<{
-  absorbee: StructureComparaisonViewModel
+  absorbees: ReadonlyArray<StructureComparaisonViewModel>
   survivante: StructureComparaisonViewModel
 }>): ReactElement {
-  const rattachementsDeplaces = absorbee.rattachements.filter((rattachement) => rattachement.nombre > 0)
+  const rattachementsDeplaces = agregerRattachements(absorbees)
 
   return (
     <>
       <div className="fr-alert fr-alert--warning fr-mb-2w">
         <p>
-          <span className="fr-text--bold">{absorbee.denomination}</span> sera marquée comme supprimée (réversible via le
-          journal d&apos;audit) et ses rattachements déplacés vers{' '}
-          <span className="fr-text--bold">{survivante.denomination}</span>.
+          Chaque structure ci-dessous sera marquée comme supprimée (réversible via le journal d&apos;audit) et ses
+          rattachements déplacés vers <span className="fr-text--bold">{survivante.denomination}</span> :
         </p>
+        <ul>
+          {absorbees.map((absorbee) => (
+            <li key={absorbee.id}>
+              <span className="fr-text--bold">{absorbee.denomination}</span>
+            </li>
+          ))}
+        </ul>
       </div>
 
       <p className="fr-text--bold">Ce que la fusion implique :</p>
@@ -195,11 +344,55 @@ function AvertissementFusion({
       )}
 
       <p className="fr-text--sm fr-text-mention--grey">
-        Les identifiants uniques de la structure absorbée (SIRET, RNA, identifiants Coop/AC…) seront conservés dans le
+        Les identifiants uniques des structures absorbées (SIRET, RNA, identifiants Coop/AC…) seront conservés dans le
         journal d&apos;audit puis perdus. Cette action est tracée.
       </p>
     </>
   )
+}
+
+// Cumule les rattachements (par libellé) de toutes les absorbées, ne garde que les non nuls.
+function agregerRattachements(
+  absorbees: ReadonlyArray<StructureComparaisonViewModel>
+): ReadonlyArray<Readonly<{ label: string; nombre: number }>> {
+  const totaux = new Map<string, number>()
+  for (const absorbee of absorbees) {
+    for (const rattachement of absorbee.rattachements) {
+      totaux.set(rattachement.label, (totaux.get(rattachement.label) ?? 0) + rattachement.nombre)
+    }
+  }
+
+  return Array.from(totaux, ([label, nombre]) => ({ label, nombre })).filter((rattachement) => rattachement.nombre > 0)
+}
+
+// Couleur de carte selon le rôle : conservée (vert), fusionnée (bleu), non touchée (gris).
+function styleCarte(choix: Choix): CSSProperties {
+  if (choix === 'conserver') {
+    return { backgroundColor: 'var(--background-contrast-success)', borderColor: 'var(--border-plain-success)' }
+  }
+  if (choix === 'fusionner') {
+    return { backgroundColor: 'var(--background-contrast-info)', borderColor: 'var(--border-plain-info)' }
+  }
+
+  return { borderColor: 'var(--border-default-grey)' }
+}
+
+// Mise en forme d'une distance : 0 (même adresse) en gras, < 100 m grisé, > 1 km en orange.
+function styleCellule(niveau: NiveauDistance): CSSProperties {
+  if (niveau === 'identique') {
+    return { fontWeight: 700 }
+  }
+  if (niveau === 'proche') {
+    return { opacity: 0.4 }
+  }
+  if (niveau === 'eloigne') {
+    return { color: 'var(--text-default-warning)', fontWeight: 700 }
+  }
+  if (niveau === 'diagonale' || niveau === 'inconnu') {
+    return { color: 'var(--text-mention-grey)' }
+  }
+
+  return {}
 }
 
 type Props = Readonly<{

--- a/src/components/shared/ClientContext.tsx
+++ b/src/components/shared/ClientContext.tsx
@@ -44,6 +44,7 @@ import { supprimerUneNoteDeContextualisationAction } from '@/app/api/actions/sup
 import { supprimerUneNotePriveeAction } from '@/app/api/actions/supprimerUneNotePriveeAction'
 import { supprimerUnMembreOuCandidatAction } from '@/app/api/actions/supprimerUnMembreOuCandidatAction'
 import { supprimerUnUtilisateurAction } from '@/app/api/actions/supprimerUnUtilisateurAction'
+import { transfererMembreAction } from '@/app/api/actions/transfererMembreAction'
 import { SessionUtilisateurViewModel } from '@/presenters/sessionUtilisateurPresenter'
 
 export default function ClientContext({
@@ -102,6 +103,7 @@ export default function ClientContext({
       supprimerUneNotePriveeAction,
       supprimerUnMembreOuCandidatAction,
       supprimerUnUtilisateurAction,
+      transfererMembreAction,
       utilisateursParPage,
     }),
     [pathname, roles, router, searchParams, sessionUtilisateurViewModel, utilisateursParPage]
@@ -157,6 +159,7 @@ export type ClientContextProviderValue = Readonly<{
   supprimerUneNotePriveeAction: typeof supprimerUneNotePriveeAction
   supprimerUnMembreOuCandidatAction: typeof supprimerUnMembreOuCandidatAction
   supprimerUnUtilisateurAction: typeof supprimerUnUtilisateurAction
+  transfererMembreAction: typeof transfererMembreAction
   utilisateursParPage: number
 }>
 type Props = PropsWithChildren<

--- a/src/components/testHelper.tsx
+++ b/src/components/testHelper.tsx
@@ -74,6 +74,7 @@ export function renderComponent(
     supprimerUneNotePriveeAction: vi.fn(),
     supprimerUnMembreOuCandidatAction: vi.fn(),
     supprimerUnUtilisateurAction: vi.fn(),
+    transfererMembreAction: vi.fn(),
     utilisateursParPage: 10,
   }
 

--- a/src/gateways/PrismaMembreTransfertRepository.test.ts
+++ b/src/gateways/PrismaMembreTransfertRepository.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { PrismaMembreTransfertRepository } from './PrismaMembreTransfertRepository'
+import {
+  creerUnContact,
+  creerUnDepartement,
+  creerUneGouvernance,
+  creerUneRegion,
+  creerUneStructure,
+  creerUnMembre,
+  creerUnUtilisateur,
+} from './testHelper'
+import prisma from '../../prisma/prismaClient'
+
+// Données namespacées (codes/ids dédiés) pour ne pas entrer en collision avec les autres
+// fichiers de test : le repository ouvre sa PROPRE transaction (qui commit), on ne peut donc
+// pas s'appuyer sur le wrapper START TRANSACTION/ROLLBACK ; on nettoie explicitement.
+const SOURCE = 990001
+const CIBLE = 990002
+const REGION = 'TT'
+const DEPT = '991'
+const MEMBRE_SOURCE = 'transfert-test-source'
+
+describe('transfert de membre (repository Prisma)', () => {
+  afterEach(nettoyer)
+
+  it('déplace le membre, ses utilisateurs et ses contacts vers la cible, sans supprimer la source, et journalise', async () => {
+    // GIVEN
+    await seedBaseEtStructures()
+    await creerUnMembre({ gouvernanceDepartementCode: DEPT, id: MEMBRE_SOURCE, structureId: SOURCE })
+    await creerUnUtilisateur({ ssoEmail: 'tt.user1@example.com', ssoId: 'tt-user-1', structureId: SOURCE })
+    await creerUnUtilisateur({ ssoEmail: 'tt.user2@example.com', ssoId: 'tt-user-2', structureId: SOURCE })
+    const contactA = await creerUnContact({ email: 'tt.a@example.com', nom: 'TransfertTestContact' })
+    const contactB = await creerUnContact({ email: 'tt.b@example.com', nom: 'TransfertTestContact' })
+    await lier(contactA, SOURCE)
+    await lier(contactB, SOURCE)
+
+    // WHEN
+    const result = await transferer()
+
+    // THEN
+    expect(result).toBe('OK')
+    await expect(structureIdDuMembre(MEMBRE_SOURCE)).resolves.toBe(CIBLE)
+    await expect(structuresDesUtilisateurs(['tt-user-1', 'tt-user-2'])).resolves.toStrictEqual([CIBLE, CIBLE])
+    await expect(contactsDe(SOURCE)).resolves.toStrictEqual([])
+    await expect(contactsDe(CIBLE)).resolves.toStrictEqual([contactA, contactB].sort((un, autre) => un - autre))
+    await expect(sourceEstSupprimee()).resolves.toBe(false)
+    await expect(dernierAudit()).resolves.toMatchObject({
+      contactsDeplaces: 2,
+      contactsSupprimes: 0,
+      membreId: MEMBRE_SOURCE,
+      structureCibleId: CIBLE,
+      structureSourceId: SOURCE,
+      utilisateursDeplaces: 2,
+    })
+  })
+
+  it('en cas de collision de contact, supprime le doublon côté source et déplace les autres', async () => {
+    // GIVEN
+    await seedBaseEtStructures()
+    await creerUnMembre({ gouvernanceDepartementCode: DEPT, id: MEMBRE_SOURCE, structureId: SOURCE })
+    await creerUnUtilisateur({ ssoEmail: 'tt.user1@example.com', ssoId: 'tt-user-1', structureId: SOURCE })
+    const contactPartage = await creerUnContact({ email: 'tt.partage@example.com', nom: 'TransfertTestContact' })
+    const contactPropre = await creerUnContact({ email: 'tt.propre@example.com', nom: 'TransfertTestContact' })
+    await lier(contactPartage, SOURCE)
+    await lier(contactPropre, SOURCE)
+    await lier(contactPartage, CIBLE) // déjà côté cible → collision
+
+    // WHEN
+    const result = await transferer()
+
+    // THEN
+    expect(result).toBe('OK')
+    await expect(contactsDe(SOURCE)).resolves.toStrictEqual([])
+    await expect(contactsDe(CIBLE)).resolves.toStrictEqual(
+      [contactPartage, contactPropre].sort((un, autre) => un - autre)
+    )
+    await expect(dernierAudit()).resolves.toMatchObject({
+      contactsDeplaces: 1,
+      contactsSupprimes: 1,
+      utilisateursDeplaces: 1,
+    })
+  })
+
+  it('refuse le transfert si la cible est déjà membre de la même gouvernance, sans rien modifier', async () => {
+    // GIVEN
+    await seedBaseEtStructures()
+    await creerUnMembre({ gouvernanceDepartementCode: DEPT, id: MEMBRE_SOURCE, structureId: SOURCE })
+    await creerUnMembre({ gouvernanceDepartementCode: DEPT, id: 'transfert-test-cible', structureId: CIBLE })
+
+    // WHEN
+    const result = await transferer()
+
+    // THEN
+    expect(result).toBe('transfertCreeraitDoublonMembre')
+    await expect(structureIdDuMembre(MEMBRE_SOURCE)).resolves.toBe(SOURCE) // inchangé
+    await expect(dernierAudit()).resolves.toBeUndefined()
+  })
+
+  it('retourne structureIntrouvable quand la cible n’existe pas', async () => {
+    // GIVEN
+    await seedBaseEtStructures()
+    await creerUnMembre({ gouvernanceDepartementCode: DEPT, id: MEMBRE_SOURCE, structureId: SOURCE })
+
+    // WHEN
+    const result = await new PrismaMembreTransfertRepository().transferer({
+      idCible: 999999,
+      idMembre: MEMBRE_SOURCE,
+      idSource: SOURCE,
+      parUtilisateur: 'admin-test',
+    })
+
+    // THEN
+    expect(result).toBe('structureIntrouvable')
+    await expect(structureIdDuMembre(MEMBRE_SOURCE)).resolves.toBe(SOURCE)
+  })
+})
+
+async function transferer(): Promise<string> {
+  return new PrismaMembreTransfertRepository().transferer({
+    idCible: CIBLE,
+    idMembre: MEMBRE_SOURCE,
+    idSource: SOURCE,
+    parUtilisateur: 'admin-test',
+  })
+}
+
+async function seedBaseEtStructures(): Promise<void> {
+  await creerUneRegion({ code: REGION, nom: 'Région de test transfert' })
+  await creerUnDepartement({ code: DEPT, nom: 'Département de test transfert', regionCode: REGION })
+  await creerUneGouvernance({ departementCode: DEPT })
+  await creerUneStructure({ id: SOURCE, siret: '99000100000001' })
+  await creerUneStructure({ id: CIBLE, siret: '99000100000002' })
+}
+
+async function lier(contactId: number, structureId: number): Promise<void> {
+  await prisma.contact_structure_administrative.create({
+    data: { contact_id: contactId, structure_administrative_id: structureId },
+  })
+}
+
+async function structureIdDuMembre(id: string): Promise<number | undefined> {
+  const membre = await prisma.membreRecord.findUnique({ where: { id } })
+  return membre?.structureId
+}
+
+async function structuresDesUtilisateurs(ssoIds: ReadonlyArray<string>): Promise<ReadonlyArray<null | number>> {
+  const utilisateurs = await prisma.utilisateurRecord.findMany({
+    orderBy: { ssoId: 'asc' },
+    where: { ssoId: { in: [...ssoIds] } },
+  })
+  return utilisateurs.map((utilisateur) => utilisateur.structureId)
+}
+
+async function contactsDe(structureId: number): Promise<ReadonlyArray<number>> {
+  const liens = await prisma.contact_structure_administrative.findMany({
+    where: { structure_administrative_id: structureId },
+  })
+  return liens.map((lien) => lien.contact_id).sort((un, autre) => un - autre)
+}
+
+async function sourceEstSupprimee(): Promise<boolean> {
+  const structure = await prisma.main_structure_administrative.findUnique({ where: { id: SOURCE } })
+  return structure?.deleted_at !== null
+}
+
+async function dernierAudit(): Promise<Record<string, unknown> | undefined> {
+  const lignes = await prisma.membreTransfertLogRecord.findMany({
+    orderBy: { id: 'desc' },
+    where: { structureSourceId: SOURCE },
+  })
+  return lignes.at(0) as Record<string, unknown> | undefined
+}
+
+async function nettoyer(): Promise<void> {
+  await prisma.membreTransfertLogRecord.deleteMany({ where: { structureSourceId: { in: [SOURCE, CIBLE] } } })
+  await prisma.membreRecord.deleteMany({ where: { structureId: { in: [SOURCE, CIBLE] } } })
+  await prisma.utilisateurRecord.deleteMany({ where: { structureId: { in: [SOURCE, CIBLE] } } })
+  await prisma.contact_structure_administrative.deleteMany({
+    where: { structure_administrative_id: { in: [SOURCE, CIBLE] } },
+  })
+  await prisma.main_contact.deleteMany({ where: { nom: 'TransfertTestContact' } })
+  await prisma.main_structure_administrative.deleteMany({ where: { id: { in: [SOURCE, CIBLE] } } })
+  await prisma.gouvernanceRecord.deleteMany({ where: { departementCode: DEPT } })
+  await prisma.departementRecord.deleteMany({ where: { code: DEPT } })
+  await prisma.regionRecord.deleteMany({ where: { code: REGION } })
+}

--- a/src/gateways/PrismaMembreTransfertRepository.ts
+++ b/src/gateways/PrismaMembreTransfertRepository.ts
@@ -1,0 +1,84 @@
+import { Prisma } from '@prisma/client'
+
+import prisma from '../../prisma/prismaClient'
+import { ResultAsync } from '@/use-cases/CommandHandler'
+import { MembreTransfertRepository, Transfert, TransfertFailure } from '@/use-cases/commands/TransfererMembre'
+
+export class PrismaMembreTransfertRepository implements MembreTransfertRepository {
+  async transferer(transfert: Transfert): ResultAsync<TransfertFailure> {
+    try {
+      return await prisma.$transaction(async (tx) => this.#transfererDansTransaction(tx, transfert))
+    } catch {
+      return 'transfertEchoue'
+    }
+  }
+
+  async #transfererDansTransaction(tx: Prisma.TransactionClient, transfert: Transfert): ResultAsync<TransfertFailure> {
+    const { idCible, idMembre, idSource, parUtilisateur } = transfert
+
+    // Les deux structures doivent exister et ne pas être supprimées.
+    const structures = await tx.$queryRaw<Array<{ id: number }>>`
+      SELECT id FROM main.structure_administrative
+      WHERE id IN (${idSource}, ${idCible}) AND deleted_at IS NULL
+    `
+    if (structures.length < 2) {
+      return 'structureIntrouvable'
+    }
+
+    // Le membre doit exister sur la structure source.
+    const membres = await tx.$queryRaw<Array<{ gouvernance_departement_code: string }>>`
+      SELECT gouvernance_departement_code FROM min.membre
+      WHERE id = ${idMembre} AND structure_id = ${idSource}
+    `
+    const membre = membres.at(0)
+    if (membre === undefined) {
+      return 'membreIntrouvable'
+    }
+
+    // Règle métier : interdire le double rattachement — la cible ne doit pas déjà être
+    // membre de la même gouvernance.
+    const doublons = await tx.$queryRaw<Array<{ id: string }>>`
+      SELECT id FROM min.membre
+      WHERE structure_id = ${idCible}
+        AND gouvernance_departement_code = ${membre.gouvernance_departement_code}
+    `
+    if (doublons.length > 0) {
+      return 'transfertCreeraitDoublonMembre'
+    }
+
+    // Re-pointage du membre et de tous les utilisateurs de la source vers la cible.
+    await tx.$executeRaw`
+      UPDATE min.membre SET structure_id = ${idCible}
+      WHERE id = ${idMembre} AND structure_id = ${idSource}
+    `
+    const utilisateursDeplaces = await tx.$executeRaw`
+      UPDATE min.utilisateur SET structure_id = ${idCible} WHERE structure_id = ${idSource}
+    `
+
+    // Contacts : un contact déjà présent côté cible (index unique (struct, contact)) se
+    // supprime côté source ; les autres se déplacent.
+    const contactsSupprimes = await tx.$executeRaw`
+      DELETE FROM main.contact_structure_administrative
+      WHERE structure_administrative_id = ${idSource}
+        AND contact_id IN (
+          SELECT contact_id FROM main.contact_structure_administrative
+          WHERE structure_administrative_id = ${idCible}
+        )
+    `
+    const contactsDeplaces = await tx.$executeRaw`
+      UPDATE main.contact_structure_administrative SET structure_administrative_id = ${idCible}
+      WHERE structure_administrative_id = ${idSource}
+    `
+
+    // Journal d'audit : qui, quand, quoi. La structure source N'EST PAS supprimée.
+    await tx.$executeRaw`
+      INSERT INTO min.membre_transfert_log
+        (membre_id, structure_source_id, structure_cible_id,
+         utilisateurs_deplaces, contacts_deplaces, contacts_supprimes, par_utilisateur)
+      VALUES (${idMembre}, ${idSource}, ${idCible},
+              ${utilisateursDeplaces}, ${contactsDeplaces}, ${contactsSupprimes}, ${parUtilisateur})
+    `
+
+    return 'OK'
+  }
+}

--- a/src/gateways/PrismaMembresAConsoliderLoader.ts
+++ b/src/gateways/PrismaMembresAConsoliderLoader.ts
@@ -1,0 +1,128 @@
+import prisma from '../../prisma/prismaClient'
+import {
+  MembreAConsoliderReadModel,
+  MembresAConsoliderLoader,
+  MembresAConsoliderReadModel,
+} from '@/use-cases/queries/RechercherMembresAConsolider'
+
+export class PrismaMembresAConsoliderLoader implements MembresAConsoliderLoader {
+  async membres(): Promise<MembresAConsoliderReadModel> {
+    const lignes = await this.#detecter()
+
+    return lignes.map(versReadModel)
+  }
+
+  // Empreinte opérationnelle (op) = postes + contrats + affectations + lieux portés par la SA.
+  // - `sa`     : SA actives avec un SIRET, op calculée.
+  // - `terrain`: par SIREN, la SA d'op maximale (l'établissement réel) — le winner proposé.
+  // On retient le membre dont la SA actuelle est une antenne sans terrain (op = 0) alors que le
+  // terrain existe ailleurs dans le même SIREN, hors mauvaise entité (garde ci-dessous).
+  async #detecter(): Promise<ReadonlyArray<LigneMembre>> {
+    return prisma.$queryRaw<Array<LigneMembre>>`
+      WITH sa AS (
+        SELECT
+          s.id,
+          LEFT(s.siret, 9) AS siren,
+          s.siret,
+          s.denomination_sirene,
+          s.denomination_antenne,
+          (
+              (SELECT COUNT(*) FROM main.poste p WHERE p.structure_id = s.id)
+            + (SELECT COUNT(*) FROM main.contrat c WHERE c.structure_id = s.id)
+            + (SELECT COUNT(*) FROM main.personne_affectations_emploi a
+               WHERE a.structure_administrative_id = s.id)
+            + (SELECT COUNT(*) FROM main.lieu_inclusion_structure_administrative l
+               WHERE l.structure_administrative_id = s.id)
+          )::int AS op
+        FROM main.structure_administrative s
+        WHERE s.deleted_at IS NULL AND s.siret ~ '^[0-9]{9}'
+      ),
+      siren_sa AS (
+        SELECT siren, COUNT(*)::int AS nb_sa, STRING_AGG(id::text, ',' ORDER BY id) AS sa_ids
+        FROM sa
+        GROUP BY siren
+      ),
+      terrain AS (
+        SELECT DISTINCT ON (siren)
+          siren,
+          id AS terrain_id,
+          denomination_sirene AS terrain_denomination,
+          denomination_antenne AS terrain_antenne,
+          op AS terrain_op
+        FROM sa
+        WHERE op > 0
+        ORDER BY siren, op DESC, id
+      )
+      SELECT
+        m.id AS membre_id,
+        m.nom AS membre_nom,
+        m.gouvernance_departement_code AS departement_gouvernance,
+        m.is_coporteur AS est_coporteur,
+        cur.id AS sa_actuelle_id,
+        cur.denomination_sirene AS sa_actuelle_denomination,
+        cur.denomination_antenne AS sa_actuelle_antenne,
+        t.terrain_id AS sa_terrain_id,
+        t.terrain_denomination AS sa_terrain_denomination,
+        t.terrain_antenne AS sa_terrain_antenne,
+        t.terrain_op AS sa_terrain_op,
+        cur.siren,
+        ss.nb_sa,
+        ss.sa_ids
+      FROM min.membre m
+      JOIN sa cur ON cur.id = m.structure_id
+      JOIN siren_sa ss ON ss.siren = cur.siren
+      JOIN terrain t ON t.siren = cur.siren
+      WHERE cur.op = 0
+        AND cur.denomination_antenne IS NOT NULL
+        AND t.terrain_id <> cur.id
+        AND NOT (
+             (m.id ~ '^structure-[0-9]{14}-'
+               AND LEFT((regexp_match(m.id, '^structure-([0-9]{14})-'))[1], 9) <> cur.siren)
+          OR (m.id ~ '^epci-[0-9]{9}-'
+               AND (regexp_match(m.id, '^epci-([0-9]{9})-'))[1] <> cur.siren)
+          OR (m.id ~ '^departement-[0-9]'
+               AND LEFT(cur.siret, 2) = '22'
+               AND SUBSTR(cur.siret, 3, 2) <> LPAD((regexp_match(m.id, '^departement-([0-9]{2,3})-'))[1], 2, '0'))
+          OR (m.id ~ '^commune-' AND cur.siret NOT LIKE '21%')
+        )
+      ORDER BY t.terrain_op DESC, m.id
+    `
+  }
+}
+
+// Ligne brute renvoyée par le SQL de détection (snake_case).
+interface LigneMembre {
+  departement_gouvernance: null | string
+  est_coporteur: boolean
+  membre_id: string
+  membre_nom: null | string
+  nb_sa: number
+  sa_actuelle_antenne: null | string
+  sa_actuelle_denomination: null | string
+  sa_actuelle_id: number
+  sa_ids: string
+  sa_terrain_antenne: null | string
+  sa_terrain_denomination: null | string
+  sa_terrain_id: number
+  sa_terrain_op: number
+  siren: null | string
+}
+
+function versReadModel(ligne: LigneMembre): MembreAConsoliderReadModel {
+  return {
+    departementGouvernance: ligne.departement_gouvernance,
+    estCoporteur: ligne.est_coporteur,
+    membreId: ligne.membre_id,
+    membreNom: ligne.membre_nom,
+    nbSaDuSiren: ligne.nb_sa,
+    saActuelleAntenne: ligne.sa_actuelle_antenne,
+    saActuelleDenomination: ligne.sa_actuelle_denomination,
+    saActuelleId: ligne.sa_actuelle_id,
+    saIdsDuSiren: ligne.sa_ids,
+    saTerrainAntenne: ligne.sa_terrain_antenne,
+    saTerrainDenomination: ligne.sa_terrain_denomination,
+    saTerrainId: ligne.sa_terrain_id,
+    saTerrainOp: ligne.sa_terrain_op,
+    siren: ligne.siren,
+  }
+}

--- a/src/gateways/PrismaStructuresComparaisonLoader.ts
+++ b/src/gateways/PrismaStructuresComparaisonLoader.ts
@@ -28,6 +28,8 @@ export class PrismaStructuresComparaisonLoader implements ComparaisonDoublonsLoa
         ) AS deja_fusionnee,
         a.nom_commune,
         NULLIF(TRIM(CONCAT_WS(' ', a.numero_voie, a.nom_voie, a.code_postal, a.nom_commune)), '') AS adresse,
+        ST_Y(a.geom) AS latitude,
+        ST_X(a.geom) AS longitude,
         (SELECT COUNT(*) FROM min.utilisateur u WHERE u.structure_id = sa.id)::int AS nb_utilisateurs_min,
         (SELECT COUNT(*) FROM min.membre m WHERE m.structure_id = sa.id)::int AS nb_membres_min,
         (SELECT COUNT(*) FROM main.poste p WHERE p.structure_id = sa.id)::int AS nb_postes,
@@ -68,6 +70,8 @@ interface LigneDetail {
   est_beneficiaire: boolean
   etat_administratif: null | string
   id: number
+  latitude: null | number
+  longitude: null | number
   nb_affectations_emploi: number
   nb_associations_lieux: number
   nb_contacts: number
@@ -105,6 +109,8 @@ function versDetail(ligne: LigneDetail): StructureDetailReadModel {
     estBeneficiaire: ligne.est_beneficiaire,
     etatAdministratif: ligne.etat_administratif,
     id: ligne.id,
+    latitude: ligne.latitude,
+    longitude: ligne.longitude,
     rattachements: {
       affectationsEmploi: ligne.nb_affectations_emploi,
       associationsLieux: ligne.nb_associations_lieux,

--- a/src/presenters/comparaisonDoublonsPresenter.test.ts
+++ b/src/presenters/comparaisonDoublonsPresenter.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { comparaisonDoublonsPresenter } from './comparaisonDoublonsPresenter'
+import {
+  comparaisonDoublonsPresenter,
+  matriceDistances,
+  StructureComparaisonViewModel,
+} from './comparaisonDoublonsPresenter'
 import { StructureDetailReadModel } from '@/use-cases/queries/ComparerStructuresAFusionner'
 
 describe('comparaison doublons presenter', () => {
@@ -17,6 +21,8 @@ describe('comparaison doublons presenter', () => {
         estBeneficiaire: true,
         etatAdministratif: 'A',
         id: 4555,
+        latitude: 48.45,
+        longitude: 1.49,
         rattachements: {
           affectationsEmploi: 37,
           associationsLieux: 0,
@@ -57,7 +63,7 @@ describe('comparaison doublons presenter', () => {
       { label: 'Bénéficiaire de subvention', valeur: 'Oui' },
       { label: 'Issue d’une fusion précédente', valeur: 'Non' },
     ])
-    expect(structure.rattachements).toStrictEqual([
+    expect(structure.rattachements.map(({ label, nombre }) => ({ label, nombre }))).toStrictEqual([
       { label: 'Utilisateurs MIN', nombre: 2 },
       { label: 'Membres MIN', nombre: 1 },
       { label: 'Gouvernances', nombre: 1 },
@@ -84,6 +90,8 @@ describe('comparaison doublons presenter', () => {
         estBeneficiaire: false,
         etatAdministratif: null,
         id: 99,
+        latitude: null,
+        longitude: null,
         rattachements: {
           affectationsEmploi: 0,
           associationsLieux: 0,
@@ -112,4 +120,50 @@ describe('comparaison doublons presenter', () => {
     expect(structure.adresse).toBe('—')
     expect(structure.denominationSirene).toBe('')
   })
+
+  it('matriceDistances classe chaque distance par niveau (identique / proche / normal / éloigné / inconnu)', () => {
+    // GIVEN
+    const structures = [
+      structureAvecCoords(1, 48.8, 2.3),
+      structureAvecCoords(2, 48.8, 2.3), // 0 m → identique
+      structureAvecCoords(3, 48.8008, 2.3), // ~89 m → proche
+      structureAvecCoords(4, 48.805, 2.3), // ~560 m → normal
+      structureAvecCoords(5, 48.85, 2.3), // ~5,6 km → éloigné
+      structureAvecCoords(6, null, null), // coords manquantes → inconnu
+    ]
+
+    // WHEN
+    const matrice = matriceDistances(structures)
+
+    // THEN
+    expect(matrice.lignes[0]?.cellules.map((cellule) => cellule.niveau)).toStrictEqual([
+      'diagonale',
+      'identique',
+      'proche',
+      'normal',
+      'eloigne',
+      'inconnu',
+    ])
+  })
 })
+
+function structureAvecCoords(
+  id: number,
+  latitude: null | number,
+  longitude: null | number
+): StructureComparaisonViewModel {
+  return {
+    adresse: `Adresse ${id}`,
+    champs: [],
+    denomination: `Structure ${id}`,
+    denominationSirene: `Structure ${id}`,
+    estAssocieLieuInclusion: false,
+    estCanonique: false,
+    estMembre: false,
+    id,
+    latitude,
+    longitude,
+    rattachements: [],
+    rattachementsTotal: 0,
+  }
+}

--- a/src/presenters/comparaisonDoublonsPresenter.ts
+++ b/src/presenters/comparaisonDoublonsPresenter.ts
@@ -5,7 +5,9 @@ import {
   StructureDetailReadModel,
 } from '@/use-cases/queries/ComparerStructuresAFusionner'
 
-const LIBELLES_RATTACHEMENTS: ReadonlyArray<Readonly<{ cle: keyof RattachementsReadModel; label: string }>> = [
+const LIBELLES_RATTACHEMENTS: ReadonlyArray<
+  Readonly<{ cle: keyof RattachementsReadModel; info?: string; label: string }>
+> = [
   { cle: 'utilisateursMin', label: 'Utilisateurs MIN' },
   { cle: 'membresMin', label: 'Membres MIN' },
   { cle: 'gouvernances', label: 'Gouvernances' },
@@ -15,7 +17,14 @@ const LIBELLES_RATTACHEMENTS: ReadonlyArray<Readonly<{ cle: keyof RattachementsR
   { cle: 'contrats', label: 'Contrats' },
   { cle: 'affectationsEmploi', label: 'Affectations emploi' },
   { cle: 'contacts', label: 'Contacts référents' },
-  { cle: 'associationsLieux', label: "Associations à des lieux d'inclusion" },
+  {
+    cle: 'associationsLieux',
+    info:
+      'Les lieux d’inclusion sont rattachés à cette structure par leur SIRET. Fusionner une structure qui a des ' +
+      'lieux d’inclusion rattachés ne « déplace » pas les lieux d’inclusion sur la carte, ces derniers ayant une ' +
+      'adresse indépendante.',
+    label: "Associations à des lieux d'inclusion",
+  },
 ]
 
 export function comparaisonDoublonsPresenter(readModel: ComparaisonDoublonsReadModel): ComparaisonViewModel {
@@ -29,7 +38,17 @@ export type StructureComparaisonViewModel = Readonly<{
   champs: ReadonlyArray<ChampViewModel>
   denomination: string
   denominationSirene: string
+  // true si la structure est associée à au moins un lieu d'inclusion
+  // (table main.lieu_inclusion_structure_administrative).
+  estAssocieLieuInclusion: boolean
+  // true si la structure est la forme canonique (aucune denomination_antenne) = celle qui devrait
+  // porter le rattachement et l'affichage. Sinon c'est une antenne.
+  estCanonique: boolean
+  // true si la structure porte au moins un membre de gouvernance (critère de décision important).
+  estMembre: boolean
   id: number
+  latitude: null | number
+  longitude: null | number
   rattachements: ReadonlyArray<RattachementViewModel>
   rattachementsTotal: number
 }>
@@ -40,9 +59,87 @@ export type ChampViewModel = Readonly<{
 }>
 
 export type RattachementViewModel = Readonly<{
+  info?: string
   label: string
   nombre: number
 }>
+
+export type MatriceDistancesViewModel = Readonly<{
+  // En-têtes de colonnes : nom seul (pour ne pas surcharger l'axe horizontal).
+  colonnes: ReadonlyArray<ColonneDistanceViewModel>
+  // true si au moins une structure n'a pas de coordonnées (cellules « n/a »).
+  coordsIncompletes: boolean
+  // En-têtes de lignes : nom + adresse (axe vertical, plus de place).
+  lignes: ReadonlyArray<LigneDistanceViewModel>
+}>
+
+export type ColonneDistanceViewModel = Readonly<{
+  id: number
+  nom: string
+}>
+
+export type LigneDistanceViewModel = Readonly<{
+  adresse: string
+  cellules: ReadonlyArray<CelluleDistanceViewModel>
+  id: number
+  nom: string
+}>
+
+export type CelluleDistanceViewModel = Readonly<{
+  colonneId: number
+  niveau: NiveauDistance
+  valeur: string
+}>
+
+// Niveau de proximité d'une cellule, pour la mise en forme : identique (0 = même adresse),
+// proche (< 100 m), eloigne (> 1 km), normal (entre les deux), inconnu (coords manquantes),
+// diagonale (structure vs elle-même).
+export type NiveauDistance = 'diagonale' | 'eloigne' | 'identique' | 'inconnu' | 'normal' | 'proche'
+
+// Matrice N×N des distances (km) à vol d'oiseau entre structures candidates. Diagonale = « — »,
+// cellule « n/a » si une coordonnée manque. Sert à juger si des antennes d'un même SIRET sont
+// géographiquement proches ou éparpillées.
+export function matriceDistances(structures: ReadonlyArray<StructureComparaisonViewModel>): MatriceDistancesViewModel {
+  return {
+    colonnes: structures.map((structure) => ({ id: structure.id, nom: structure.denomination })),
+    coordsIncompletes: structures.some((structure) => structure.latitude === null || structure.longitude === null),
+    lignes: structures.map((ligne) => ({
+      adresse: ligne.adresse,
+      cellules: structures.map((colonne) => celluleDistance(ligne, colonne)),
+      id: ligne.id,
+      nom: ligne.denomination,
+    })),
+  }
+}
+
+function celluleDistance(
+  ligne: StructureComparaisonViewModel,
+  colonne: StructureComparaisonViewModel
+): CelluleDistanceViewModel {
+  if (ligne.id === colonne.id) {
+    return { colonneId: colonne.id, niveau: 'diagonale', valeur: '—' }
+  }
+  const km = distanceKm(ligne, colonne)
+  if (km === null) {
+    return { colonneId: colonne.id, niveau: 'inconnu', valeur: 'n/a' }
+  }
+
+  return { colonneId: colonne.id, niveau: niveauDistance(km), valeur: km.toFixed(1) }
+}
+
+function niveauDistance(km: number): NiveauDistance {
+  if (km === 0) {
+    return 'identique'
+  }
+  if (km < 0.1) {
+    return 'proche'
+  }
+  if (km > 1) {
+    return 'eloigne'
+  }
+
+  return 'normal'
+}
 
 function versStructureComparaison(structure: StructureDetailReadModel): StructureComparaisonViewModel {
   return {
@@ -65,11 +162,42 @@ function versStructureComparaison(structure: StructureDetailReadModel): Structur
     ],
     denomination: structure.denominationAntenne ?? structure.denominationSirene ?? `Structure #${structure.id}`,
     denominationSirene: structure.denominationSirene ?? '',
+    estAssocieLieuInclusion: structure.rattachements.associationsLieux > 0,
+    estCanonique: structure.denominationAntenne === null,
+    estMembre: structure.rattachements.membresMin > 0,
     id: structure.id,
-    rattachements: LIBELLES_RATTACHEMENTS.map(({ cle, label }) => ({
+    latitude: structure.latitude,
+    longitude: structure.longitude,
+    rattachements: LIBELLES_RATTACHEMENTS.map(({ cle, info, label }) => ({
+      info,
       label,
       nombre: structure.rattachements[cle],
     })),
     rattachementsTotal: structure.rattachements.total,
   }
+}
+
+// Distance à vol d'oiseau (Haversine) en km entre deux structures, ou null si une coordonnée manque.
+function distanceKm(depart: StructureComparaisonViewModel, arrivee: StructureComparaisonViewModel): null | number {
+  if (
+    depart.latitude === null ||
+    depart.longitude === null ||
+    arrivee.latitude === null ||
+    arrivee.longitude === null
+  ) {
+    return null
+  }
+
+  const rayonTerreKm = 6371
+  const dLat = versRadians(arrivee.latitude - depart.latitude)
+  const dLon = versRadians(arrivee.longitude - depart.longitude)
+  const hav =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(versRadians(depart.latitude)) * Math.cos(versRadians(arrivee.latitude)) * Math.sin(dLon / 2) ** 2
+
+  return 2 * rayonTerreKm * Math.asin(Math.sqrt(hav))
+}
+
+function versRadians(degres: number): number {
+  return (degres * Math.PI) / 180
 }

--- a/src/presenters/comparaisonDoublonsPresenter.ts
+++ b/src/presenters/comparaisonDoublonsPresenter.ts
@@ -85,12 +85,6 @@ export type LigneDistanceViewModel = Readonly<{
   nom: string
 }>
 
-export type CelluleDistanceViewModel = Readonly<{
-  colonneId: number
-  niveau: NiveauDistance
-  valeur: string
-}>
-
 // Niveau de proximité d'une cellule, pour la mise en forme : identique (0 = même adresse),
 // proche (< 100 m), eloigne (> 1 km), normal (entre les deux), inconnu (coords manquantes),
 // diagonale (structure vs elle-même).
@@ -111,6 +105,12 @@ export function matriceDistances(structures: ReadonlyArray<StructureComparaisonV
     })),
   }
 }
+
+type CelluleDistanceViewModel = Readonly<{
+  colonneId: number
+  niveau: NiveauDistance
+  valeur: string
+}>
 
 function celluleDistance(
   ligne: StructureComparaisonViewModel,

--- a/src/presenters/membresAConsoliderPresenter.test.ts
+++ b/src/presenters/membresAConsoliderPresenter.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+
+import { parserCsvMembresAConsolider } from './membresAConsoliderPresenter'
+
+describe('parser CSV des membres à consolider', () => {
+  it('parse les lignes valides (séparateur tabulation, en-têtes #1573)', () => {
+    // GIVEN
+    const csv = [
+      'membre_id\tmembre_nom\tcur_id\talt_id',
+      'structure-26800067600331-80\tCCAS Amiens\t6220\t6221',
+      'epci-200070126-10\tCC Seine et Aube\t1506\t1505',
+    ].join('\n')
+
+    // WHEN
+    const resultat = parserCsvMembresAConsolider(csv)
+
+    // THEN
+    expect(resultat.erreurs).toStrictEqual([])
+    expect(resultat.lignes).toStrictEqual([
+      {
+        idCible: 6221,
+        idMembre: 'structure-26800067600331-80',
+        idSource: 6220,
+        nomActuel: 'Structure #6220',
+        nomOrigine: 'CCAS Amiens',
+      },
+      {
+        idCible: 1505,
+        idMembre: 'epci-200070126-10',
+        idSource: 1506,
+        nomActuel: 'Structure #1506',
+        nomOrigine: 'CC Seine et Aube',
+      },
+    ])
+  })
+
+  it('supporte le point-virgule et se rabat sur membre_id quand membre_nom est absent', () => {
+    // WHEN
+    const resultat = parserCsvMembresAConsolider('membre_id;cur_id;alt_id\nstructure-1-26;10;20')
+
+    // THEN
+    expect(resultat.lignes).toStrictEqual([
+      {
+        idCible: 20,
+        idMembre: 'structure-1-26',
+        idSource: 10,
+        nomActuel: 'Structure #10',
+        nomOrigine: 'structure-1-26',
+      },
+    ])
+  })
+
+  it('signale et ignore les lignes aux identifiants invalides', () => {
+    // GIVEN
+    const csv = 'membre_id,cur_id,alt_id\nstructure-1-26,10,20\n,30,40\nstructure-2-26,abc,50'
+
+    // WHEN
+    const resultat = parserCsvMembresAConsolider(csv)
+
+    // THEN
+    expect(resultat.lignes).toHaveLength(1)
+    expect(resultat.lignes[0].idMembre).toBe('structure-1-26')
+    expect(resultat.erreurs).toStrictEqual([
+      'Ligne 3 ignorée : membre_id / cur_id / alt_id invalides.',
+      'Ligne 4 ignorée : membre_id / cur_id / alt_id invalides.',
+    ])
+  })
+
+  it('renvoie une erreur quand les en-têtes requis manquent', () => {
+    // WHEN
+    const resultat = parserCsvMembresAConsolider('membre_id,source,cible\nstructure-1-26,10,20')
+
+    // THEN
+    expect(resultat.lignes).toStrictEqual([])
+    expect(resultat.erreurs).toStrictEqual(['En-têtes requis manquants : membre_id, cur_id, alt_id.'])
+  })
+
+  it('renvoie une erreur quand il n’y a pas de ligne de données', () => {
+    // WHEN
+    const resultat = parserCsvMembresAConsolider('membre_id,cur_id,alt_id')
+
+    // THEN
+    expect(resultat.erreurs).toStrictEqual(['Collez au moins une ligne d’en-tête et une ligne de données.'])
+  })
+})

--- a/src/presenters/membresAConsoliderPresenter.ts
+++ b/src/presenters/membresAConsoliderPresenter.ts
@@ -120,6 +120,65 @@ export type MembreLigneViewModel = Readonly<{
   saTerrainOp: number
 }>
 
+// Parse un CSV de triage (format #1573) collé par l'admin pour transférer des membres en lot.
+// En-têtes requis : membre_id, cur_id (structure source), alt_id (structure cible). Séparateur
+// auto-détecté (tabulation, point-virgule ou virgule). Les lignes invalides sont signalées et ignorées.
+export function parserCsvMembresAConsolider(texte: string): ImportCsvResultViewModel {
+  const lignesTexte = texte
+    .split('\n')
+    .map((ligne) => ligne.trim())
+    .filter((ligne) => ligne !== '')
+  if (lignesTexte.length < 2) {
+    return { erreurs: ['Collez au moins une ligne d’en-tête et une ligne de données.'], lignes: [] }
+  }
+
+  const separateur = detecterSeparateur(lignesTexte[0])
+  const entetes = lignesTexte[0].split(separateur).map((entete) => entete.trim().toLowerCase())
+  const indexMembre = entetes.indexOf('membre_id')
+  const indexSource = entetes.indexOf('cur_id')
+  const indexCible = entetes.indexOf('alt_id')
+  const indexNom = entetes.indexOf('membre_nom')
+  if (indexMembre === -1 || indexSource === -1 || indexCible === -1) {
+    return { erreurs: ['En-têtes requis manquants : membre_id, cur_id, alt_id.'], lignes: [] }
+  }
+
+  const lignes: Array<MembreCsvLigneViewModel> = []
+  const erreurs: Array<string> = []
+  lignesTexte.slice(1).forEach((ligneTexte, index) => {
+    const colonnes = ligneTexte.split(separateur)
+    const idMembre = (colonnes[indexMembre] ?? '').trim()
+    const idSource = Number((colonnes[indexSource] ?? '').trim())
+    const idCible = Number((colonnes[indexCible] ?? '').trim())
+    const nom = (colonnes[indexNom] ?? '').trim()
+    if (idMembre === '' || !estIdStructureValide(idSource) || !estIdStructureValide(idCible)) {
+      erreurs.push(`Ligne ${index + 2} ignorée : membre_id / cur_id / alt_id invalides.`)
+      return
+    }
+    lignes.push({
+      idCible,
+      idMembre,
+      idSource,
+      nomActuel: `Structure #${idSource}`,
+      nomOrigine: nom === '' ? idMembre : nom,
+    })
+  })
+
+  return { erreurs, lignes }
+}
+
+export type ImportCsvResultViewModel = Readonly<{
+  erreurs: ReadonlyArray<string>
+  lignes: ReadonlyArray<MembreCsvLigneViewModel>
+}>
+
+export type MembreCsvLigneViewModel = Readonly<{
+  idCible: number
+  idMembre: string
+  idSource: number
+  nomActuel: string
+  nomOrigine: string
+}>
+
 function versLigneViewModel(membre: MembreAConsoliderReadModel): MembreLigneViewModel {
   return {
     departement: membre.departementGouvernance ?? '—',
@@ -134,4 +193,18 @@ function versLigneViewModel(membre: MembreAConsoliderReadModel): MembreLigneView
     saTerrainNom: membre.saTerrainAntenne ?? membre.saTerrainDenomination ?? `Structure #${membre.saTerrainId}`,
     saTerrainOp: membre.saTerrainOp,
   }
+}
+
+function detecterSeparateur(entete: string): string {
+  if (entete.includes('\t')) {
+    return '\t'
+  }
+  if (entete.includes(';')) {
+    return ';'
+  }
+  return ','
+}
+
+function estIdStructureValide(valeur: number): boolean {
+  return Number.isInteger(valeur) && valeur > 0
 }

--- a/src/presenters/membresAConsoliderPresenter.ts
+++ b/src/presenters/membresAConsoliderPresenter.ts
@@ -1,0 +1,131 @@
+import {
+  MembreAConsoliderReadModel,
+  MembresAConsoliderReadModel,
+  RegleConsolidation,
+} from '@/use-cases/queries/RechercherMembresAConsolider'
+
+export function membresAConsoliderPresenter(readModel: MembresAConsoliderReadModel): MembresAConsoliderViewModel {
+  return {
+    membres: readModel.map(versLigneViewModel),
+    total: readModel.length,
+  }
+}
+
+export type MembresAConsoliderViewModel = Readonly<{
+  membres: ReadonlyArray<MembreLigneViewModel>
+  total: number
+}>
+
+// Métadonnées d'affichage des règles de détection : titre, accroche, conditions métier détaillées,
+// et si la règle est branchée (sinon onglet « à venir »).
+const CATALOGUE_REGLES: ReadonlyArray<
+  Readonly<{
+    conditions: ReadonlyArray<string>
+    disponible: boolean
+    id: RegleConsolidation
+    sousTitre: string
+    titre: string
+  }>
+> = [
+  {
+    conditions: [
+      'Le membre est rattaché à une structure « antenne » (champ denomination_antenne renseigné) : le nom affiché provient de cette antenne, pas de la structure canonique.',
+      'Cette structure ne porte aucune activité : ni poste, ni contrat, ni affectation, ni lieu d’inclusion.',
+      'Une autre structure du même SIREN (même entité juridique) concentre cette activité — c’est l’établissement réel proposé.',
+      'L’identifiant du membre correspond bien à cette entité (les cas « autre SIRET » relèvent d’une autre règle).',
+    ],
+    disponible: true,
+    id: 'structure-fantome',
+    sousTitre:
+      'Membre rattaché à une antenne sans aucune activité, alors qu’un établissement actif du même SIREN existe.',
+    titre: 'Structure fantôme',
+  },
+  {
+    conditions: [
+      'Le membre est rattaché à une structure dont le SIRET / SIREN ne correspond pas à son identifiant métier.',
+      'La structure rattachée est une autre personne morale — parfois sur un autre territoire (ex. Angers rattaché à la mairie de Bonifacio).',
+      'Le bon rattachement existe (ou doit être créé) sur l’entité réelle du membre.',
+      'Geste attendu : re-rattacher le membre à la bonne structure — et non fusionner, car ce sont des entités juridiques distinctes.',
+    ],
+    disponible: false,
+    id: 'mauvaise-entite',
+    sousTitre: 'Membre rattaché à une autre entité juridique (SIRET différent), parfois un autre territoire.',
+    titre: 'Mauvaise entité',
+  },
+  {
+    conditions: [
+      'Le membre est une commune, mais il est rattaché à une structure d’une autre forme juridique : son CCAS, son EPCI, un syndicat…',
+      'Même territoire, mais entité « satellite » de la commune.',
+      'Souvent intentionnel côté métier (c’est le satellite qui agit) — à confirmer au cas par cas.',
+      'Geste attendu : arbitrage métier, puis re-rattachement à la commune si nécessaire.',
+    ],
+    disponible: false,
+    id: 'commune-ccas-epci',
+    sousTitre: 'Commune rattachée à son propre CCAS ou EPCI (même territoire, forme juridique différente).',
+    titre: 'Commune via son CCAS/EPCI',
+  },
+  {
+    conditions: [
+      'Le membre est rattaché à une antenne (champ denomination_antenne renseigné).',
+      'Une structure canonique (sans denomination_antenne) portant le même SIRET existe déjà en base.',
+      'Le nom affiché serait correct si le membre pointait sur la canonique.',
+      'Geste attendu : re-rattacher le membre à la structure canonique.',
+    ],
+    disponible: false,
+    id: 'canonique-disponible',
+    sousTitre: 'Membre sur une antenne alors que la structure canonique du même SIRET existe.',
+    titre: 'Canonique disponible',
+  },
+]
+
+export function reglesPresenter(regleActive: RegleConsolidation): ReadonlyArray<RegleViewModel> {
+  return CATALOGUE_REGLES.map((regle) => ({
+    actif: regle.id === regleActive,
+    conditions: regle.conditions,
+    disponible: regle.disponible,
+    href: `/membres-a-consolider?regle=${regle.id}`,
+    id: regle.id,
+    sousTitre: regle.sousTitre,
+    titre: regle.disponible ? regle.titre : `${regle.titre} (à venir)`,
+  }))
+}
+
+export type RegleViewModel = Readonly<{
+  actif: boolean
+  conditions: ReadonlyArray<string>
+  disponible: boolean
+  href: string
+  id: RegleConsolidation
+  sousTitre: string
+  titre: string
+}>
+
+export type MembreLigneViewModel = Readonly<{
+  departement: string
+  estCoporteur: boolean
+  // ids des SA du SIREN à comparer/fusionner via l'outil existant.
+  idsParam: string
+  membreId: string
+  nbSaDuSiren: number
+  // Nom actuellement AFFICHÉ dans MIN = denomination_antenne de la SA rattachée (souvent faux).
+  nomActuelAffiche: string
+  // Nom porté historiquement par le membre (membre.nom) — la vérité métier.
+  nomOrigine: string
+  // Établissement réel proposé comme survivant (SA-terrain).
+  saTerrainNom: string
+  saTerrainOp: number
+}>
+
+function versLigneViewModel(membre: MembreAConsoliderReadModel): MembreLigneViewModel {
+  return {
+    departement: membre.departementGouvernance ?? '—',
+    estCoporteur: membre.estCoporteur,
+    idsParam: membre.saIdsDuSiren,
+    membreId: membre.membreId,
+    nbSaDuSiren: membre.nbSaDuSiren,
+    nomActuelAffiche: membre.saActuelleAntenne ?? membre.saActuelleDenomination ?? `Structure #${membre.saActuelleId}`,
+    nomOrigine: membre.membreNom ?? membre.membreId,
+    saTerrainNom: membre.saTerrainAntenne ?? membre.saTerrainDenomination ?? `Structure #${membre.saTerrainId}`,
+    saTerrainOp: membre.saTerrainOp,
+  }
+}

--- a/src/presenters/membresAConsoliderPresenter.ts
+++ b/src/presenters/membresAConsoliderPresenter.ts
@@ -103,6 +103,10 @@ export type RegleViewModel = Readonly<{
 export type MembreLigneViewModel = Readonly<{
   departement: string
   estCoporteur: boolean
+  // Établissement réel proposé comme cible du transfert (SA-terrain), modifiable côté UI.
+  idCible: number
+  // Structure actuelle (antenne) à laquelle le membre est rattaché à tort.
+  idSource: number
   // ids des SA du SIREN à comparer/fusionner via l'outil existant.
   idsParam: string
   membreId: string
@@ -120,6 +124,8 @@ function versLigneViewModel(membre: MembreAConsoliderReadModel): MembreLigneView
   return {
     departement: membre.departementGouvernance ?? '—',
     estCoporteur: membre.estCoporteur,
+    idCible: membre.saTerrainId,
+    idSource: membre.saActuelleId,
     idsParam: membre.saIdsDuSiren,
     membreId: membre.membreId,
     nbSaDuSiren: membre.nbSaDuSiren,

--- a/src/use-cases/commands/TransfererMembre.test.ts
+++ b/src/use-cases/commands/TransfererMembre.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { MembreTransfertRepository, TransfererMembre, Transfert } from './TransfererMembre'
+import { ResultAsync } from '../CommandHandler'
+
+describe('transférer un membre', () => {
+  beforeEach(() => {
+    spiedTransfert = null
+  })
+
+  it('refuse le transfert vers la même structure, sans appeler le repository', async () => {
+    // GIVEN
+    const transferer = new TransfererMembre(new MembreTransfertRepositorySpy())
+
+    // WHEN
+    const result = await transferer.handle({
+      idCible: 42,
+      idMembre: 'structure-1-26',
+      idSource: 42,
+      uidUtilisateur: 'admin-1',
+    })
+
+    // THEN
+    expect(result).toBe('transfertImpossibleMemeStructure')
+    expect(spiedTransfert).toBeNull()
+  })
+
+  it('délègue au repository le transfert vers une structure distincte', async () => {
+    // GIVEN
+    const transferer = new TransfererMembre(new MembreTransfertRepositorySpy())
+
+    // WHEN
+    const result = await transferer.handle({
+      idCible: 3,
+      idMembre: 'structure-1-26',
+      idSource: 7,
+      uidUtilisateur: 'admin-1',
+    })
+
+    // THEN
+    expect(result).toBe('OK')
+    expect(spiedTransfert).toStrictEqual({
+      idCible: 3,
+      idMembre: 'structure-1-26',
+      idSource: 7,
+      parUtilisateur: 'admin-1',
+    })
+  })
+})
+
+let spiedTransfert: null | Transfert
+
+class MembreTransfertRepositorySpy implements MembreTransfertRepository {
+  transferer(transfert: Transfert): ResultAsync<never> {
+    spiedTransfert = transfert
+    return Promise.resolve('OK')
+  }
+}

--- a/src/use-cases/commands/TransfererMembre.ts
+++ b/src/use-cases/commands/TransfererMembre.ts
@@ -1,0 +1,49 @@
+import { CommandHandler, ResultAsync } from '../CommandHandler'
+
+export class TransfererMembre implements CommandHandler<Command, TransfertFailure> {
+  readonly #repository: MembreTransfertRepository
+
+  constructor(repository: MembreTransfertRepository) {
+    this.#repository = repository
+  }
+
+  async handle(command: Command): ResultAsync<TransfertFailure> {
+    if (command.idSource === command.idCible) {
+      return 'transfertImpossibleMemeStructure'
+    }
+
+    return this.#repository.transferer({
+      idCible: command.idCible,
+      idMembre: command.idMembre,
+      idSource: command.idSource,
+      parUtilisateur: command.uidUtilisateur,
+    })
+  }
+}
+
+export interface MembreTransfertRepository {
+  transferer(transfert: Transfert): ResultAsync<TransfertFailure>
+}
+
+// Transfert d'UN membre + ses utilisateurs + ses contacts de la structure source vers la cible.
+// La source n'est jamais supprimée (contrairement à la fusion) : elle reste une structure légitime.
+export type Transfert = Readonly<{
+  idCible: number
+  idMembre: string
+  idSource: number
+  parUtilisateur: string
+}>
+
+export type TransfertFailure =
+  | 'membreIntrouvable'
+  | 'structureIntrouvable'
+  | 'transfertCreeraitDoublonMembre'
+  | 'transfertEchoue'
+  | 'transfertImpossibleMemeStructure'
+
+type Command = Readonly<{
+  idCible: number
+  idMembre: string
+  idSource: number
+  uidUtilisateur: string
+}>

--- a/src/use-cases/queries/ComparerStructuresAFusionner.test.ts
+++ b/src/use-cases/queries/ComparerStructuresAFusionner.test.ts
@@ -74,6 +74,8 @@ function structureDetail(id: number, total: number): StructureDetailReadModel {
     estBeneficiaire: false,
     etatAdministratif: null,
     id,
+    latitude: null,
+    longitude: null,
     rattachements,
     ridet: null,
     rna: null,

--- a/src/use-cases/queries/ComparerStructuresAFusionner.ts
+++ b/src/use-cases/queries/ComparerStructuresAFusionner.ts
@@ -36,6 +36,10 @@ export type StructureDetailReadModel = Readonly<{
   estBeneficiaire: boolean
   etatAdministratif: null | string
   id: number
+  // Coordonnées (geom de l'adresse, SRID 4326). Permettent de calculer les distances entre
+  // structures candidates : des antennes d'un même SIRET peuvent avoir des adresses distinctes.
+  latitude: null | number
+  longitude: null | number
   rattachements: RattachementsReadModel
   ridet: null | string
   rna: null | string

--- a/src/use-cases/queries/RechercherMembresAConsolider.ts
+++ b/src/use-cases/queries/RechercherMembresAConsolider.ts
@@ -1,0 +1,74 @@
+import { QueryHandler } from '../QueryHandler'
+
+// Aide à la consolidation des membres de gouvernance.
+//
+// Signal `gouvernance_sans_terrain` : un membre de gouvernance est rattaché à une SA
+// « antenne » (denomination_antenne renseignée) qui ne porte AUCUNE donnée opérationnelle
+// (poste / contrat / affectation / lieu), alors qu'une autre SA du MÊME SIREN — l'établissement
+// réel — concentre cet opérationnel. C'est un angle mort de la détection des doublons de
+// structures (même SIRET, antennes toutes nommées → jamais signalé). Cf
+// dataspace/docs/constat-membres-gouvernance-mal-raccroches.md (Problème 3, motif systémique).
+//
+// GARDE ENTITÉ : on exclut les membres dont l'identifiant métier (structure-<siret> / epci-<siren>
+// / departement-<dep> / commune-<insee>) désigne une entité différente du SIREN de la SA actuelle
+// (ceux-là relèvent d'une CORRECTION de rattachement, pas d'une fusion de SA).
+//
+// La cible proposée = la SA-terrain (plus grosse empreinte opérationnelle du SIREN). La fusion
+// elle-même réutilise l'outil existant (`/structures-doublons/comparer`), qui déplace les 7 FK
+// (dont membre / utilisateur / contact) et permet d'arbitrer la denomination_antenne retenue.
+export class RechercherMembresAConsolider implements QueryHandler<Query, MembresAConsoliderReadModel> {
+  readonly #loader: MembresAConsoliderLoader
+
+  constructor(loader: MembresAConsoliderLoader) {
+    this.#loader = loader
+  }
+
+  async handle(query: Query): Promise<MembresAConsoliderReadModel> {
+    // Seule la règle « structure fantôme » est branchée pour l'instant. Les autres règles du
+    // catalogue (cf REGLES_CONSOLIDATION) sont « à venir » et renvoient une liste vide.
+    if (query.regle !== 'structure-fantome') {
+      return []
+    }
+
+    return this.#loader.membres()
+  }
+}
+
+export interface MembresAConsoliderLoader {
+  membres(): Promise<MembresAConsoliderReadModel>
+}
+
+// Catalogue des règles de détection. Une seule est implémentée à ce stade ; les autres servent
+// d'onglets « à venir » dans le sélecteur. Les libellés sont portés par le presenter.
+export const REGLES_CONSOLIDATION = [
+  'structure-fantome',
+  'mauvaise-entite',
+  'commune-ccas-epci',
+  'canonique-disponible',
+] as const
+
+export type RegleConsolidation = (typeof REGLES_CONSOLIDATION)[number]
+
+export type MembresAConsoliderReadModel = ReadonlyArray<MembreAConsoliderReadModel>
+
+export type MembreAConsoliderReadModel = Readonly<{
+  departementGouvernance: null | string
+  estCoporteur: boolean
+  membreId: string
+  membreNom: null | string
+  nbSaDuSiren: number
+  saActuelleAntenne: null | string
+  saActuelleDenomination: null | string
+  saActuelleId: number
+  // Liste des ids de SA du SIREN (séparés par des virgules) à passer à la page de comparaison.
+  saIdsDuSiren: string
+  saTerrainAntenne: null | string
+  saTerrainDenomination: null | string
+  saTerrainId: number
+  saTerrainOp: number
+  siren: null | string
+}>
+
+type Query = Readonly<{
+  regle: RegleConsolidation
+}>


### PR DESCRIPTION
> 🧱 **PR empilée sur #1593** (base = `structures-doublons`). GitHub la repointera automatiquement sur `main` quand #1593 sera mergée. Le diff ne montre que le delta « membres-a-consolider ».

Première brique de la généralisation décrite dans #1624 (étape ①).

## Contenu

- **Page `membres-a-consolider`** (gatée `is_beta_testeur`) : détection des membres rattachés à une structure « fantôme » (antenne sans activité) alors qu'un établissement réel du même SIREN existe.
- **Transfert de membre** : re-pointe un **membre + ses utilisateurs + ses contacts** d'une structure source vers une cible, **sans supprimer la source** (contrairement à la fusion). Gestion des collisions de contact (DELETE si déjà côté cible, sinon UPDATE).
- **Règle anti-doublon** : refus si la cible est déjà membre de la même gouvernance.
- **Import CSV** (onglet) : coller un CSV de triage (#1573, en-têtes `membre_id`/`cur_id`/`alt_id`) → liste de couples source→cible transférables.
- **Audit** : table `min.membre_transfert_log` (qui / quand / quoi) — migration Prisma + **migration Flyway dataspace (MR !874)**.

## Tests

- Commande `TransfererMembre`, server action, composant, **+ test d'intégration du gateway** (happy path, collision, anti-doublon, structureIntrouvable).
- `typecheck` ✓ · `lint` ✓ · `knip` ✓ · suite complète **914 tests** ✓.

## Validé en conditions réelles

Transfert testé sur la base dev (CA Alès Agglo, #1205→#1204) : membre + 2 utilisateurs + 2 contacts déplacés, source préservée, audit conforme.

Refs #1624