### PR TITLE
feat(structure): éditer l'adresse d'une structure (admin bêta)

### DIFF
--- a/src/app/api/actions/modifierAdresseStructureAction.test.ts
+++ b/src/app/api/actions/modifierAdresseStructureAction.test.ts
@@ -60,6 +60,27 @@ describe('modifier l’adresse d’une structure action', () => {
     expect(messages).toStrictEqual(['Adresse introuvable — vérifiez la saisie'])
   })
 
+  it('traduit le refus de modifier une structure canonique', async () => {
+    // GIVEN
+    vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce('userFooId')
+    vi.spyOn(PrismaUtilisateurRepository.prototype, 'get').mockResolvedValueOnce(
+      utilisateurFactory({ isBetaTesteur: true, role: 'Administrateur dispositif' })
+    )
+    vi.spyOn(ModifierAdresseStructure.prototype, 'handle').mockResolvedValueOnce('structureCanoniqueNonModifiable')
+
+    // WHEN
+    const messages = await modifierAdresseStructureAction({
+      adresse: '14 rue Louis Talamoni',
+      path: '/structure/978',
+      structureId: 978,
+    })
+
+    // THEN
+    expect(messages).toStrictEqual([
+      'Cette structure utilise le nom officiel (SIRENE) et ne peut pas être modifiée',
+    ])
+  })
+
   it('refuse l’action à un utilisateur non bêta-testeur', async () => {
     // GIVEN
     vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce('userFooId')

--- a/src/app/api/actions/modifierAdresseStructureAction.test.ts
+++ b/src/app/api/actions/modifierAdresseStructureAction.test.ts
@@ -76,9 +76,7 @@ describe('modifier l’adresse d’une structure action', () => {
     })
 
     // THEN
-    expect(messages).toStrictEqual([
-      'Cette structure utilise le nom officiel (SIRENE) et ne peut pas être modifiée',
-    ])
+    expect(messages).toStrictEqual(['Cette structure utilise le nom officiel (SIRENE) et ne peut pas être modifiée'])
   })
 
   it('refuse l’action à un utilisateur non bêta-testeur', async () => {

--- a/src/app/api/actions/modifierAdresseStructureAction.test.ts
+++ b/src/app/api/actions/modifierAdresseStructureAction.test.ts
@@ -1,0 +1,80 @@
+import * as nextCache from 'next/cache'
+import { describe, expect, it } from 'vitest'
+
+import { modifierAdresseStructureAction } from './modifierAdresseStructureAction'
+import { utilisateurFactory } from '@/domain/testHelper'
+import * as ssoGateway from '@/gateways/NextAuthAuthentificationGateway'
+import { PrismaUtilisateurRepository } from '@/gateways/PrismaUtilisateurRepository'
+import { ModifierAdresseStructure } from '@/use-cases/commands/ModifierAdresseStructure'
+
+describe('modifier l’adresse d’une structure action', () => {
+  it('modifie l’adresse et purge le cache quand un bêta-testeur confirme', async () => {
+    // GIVEN
+    vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce('userFooId')
+    vi.spyOn(PrismaUtilisateurRepository.prototype, 'get').mockResolvedValueOnce(
+      utilisateurFactory({ isBetaTesteur: true, role: 'Administrateur dispositif' })
+    )
+    vi.spyOn(ModifierAdresseStructure.prototype, 'handle').mockResolvedValueOnce('OK')
+    vi.spyOn(nextCache, 'revalidatePath').mockImplementationOnce(() => undefined)
+
+    // WHEN
+    const messages = await modifierAdresseStructureAction({
+      adresse: '14 rue Louis Talamoni, Champigny',
+      path: '/structure/978',
+      structureId: 978,
+    })
+
+    // THEN
+    expect(ModifierAdresseStructure.prototype.handle).toHaveBeenCalledWith({
+      adresse: '14 rue Louis Talamoni, Champigny',
+      structureId: 978,
+    })
+    expect(nextCache.revalidatePath).toHaveBeenCalledWith('/structure/978')
+    expect(messages).toStrictEqual(['OK'])
+  })
+
+  it('renvoie une erreur de validation quand l’adresse est vide', async () => {
+    // WHEN
+    const messages = await modifierAdresseStructureAction({ adresse: '', path: '/structure/978', structureId: 978 })
+
+    // THEN
+    expect(messages).toStrictEqual(['L’adresse doit être renseignée'])
+  })
+
+  it('traduit l’échec « adresse introuvable » renvoyé par la commande', async () => {
+    // GIVEN
+    vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce('userFooId')
+    vi.spyOn(PrismaUtilisateurRepository.prototype, 'get').mockResolvedValueOnce(
+      utilisateurFactory({ isBetaTesteur: true, role: 'Administrateur dispositif' })
+    )
+    vi.spyOn(ModifierAdresseStructure.prototype, 'handle').mockResolvedValueOnce('adresseIntrouvable')
+
+    // WHEN
+    const messages = await modifierAdresseStructureAction({
+      adresse: 'azertyuiop',
+      path: '/structure/978',
+      structureId: 978,
+    })
+
+    // THEN
+    expect(messages).toStrictEqual(['Adresse introuvable — vérifiez la saisie'])
+  })
+
+  it('refuse l’action à un utilisateur non bêta-testeur', async () => {
+    // GIVEN
+    vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce('userFooId')
+    vi.spyOn(PrismaUtilisateurRepository.prototype, 'get').mockResolvedValueOnce(
+      utilisateurFactory({ isBetaTesteur: false, role: 'Administrateur dispositif' })
+    )
+
+    // WHEN
+    const messages = await modifierAdresseStructureAction({
+      adresse: '14 rue Louis Talamoni',
+      path: '/structure/978',
+      structureId: 978,
+    })
+
+    // THEN
+    expect(messages).toStrictEqual(['Action réservée aux administrateurs autorisés'])
+  })
+})

--- a/src/app/api/actions/modifierAdresseStructureAction.ts
+++ b/src/app/api/actions/modifierAdresseStructureAction.ts
@@ -13,6 +13,8 @@ import { Failure, ModifierAdresseStructure } from '@/use-cases/commands/Modifier
 
 const MESSAGES_ECHEC: Readonly<Record<Failure, string>> = {
   adresseIntrouvable: 'Adresse introuvable — vérifiez la saisie',
+  structureCanoniqueNonModifiable: 'Cette structure utilise le nom officiel (SIRENE) et ne peut pas être modifiée',
+  structureIntrouvable: 'Structure introuvable',
 }
 
 export async function modifierAdresseStructureAction(actionParams: ActionParams): Promise<ReadonlyArray<string>> {

--- a/src/app/api/actions/modifierAdresseStructureAction.ts
+++ b/src/app/api/actions/modifierAdresseStructureAction.ts
@@ -1,0 +1,57 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { z } from 'zod'
+
+import prisma from '../../../../prisma/prismaClient'
+import { Administrateur } from '@/domain/Administrateur'
+import { ApiBanGeocodingGateway } from '@/gateways/apiBan/ApiBanGeocodingGateway'
+import { getSessionSub } from '@/gateways/NextAuthAuthentificationGateway'
+import { PrismaStructureRepository } from '@/gateways/PrismaStructureRepository'
+import { PrismaUtilisateurRepository } from '@/gateways/PrismaUtilisateurRepository'
+import { Failure, ModifierAdresseStructure } from '@/use-cases/commands/ModifierAdresseStructure'
+
+const MESSAGES_ECHEC: Readonly<Record<Failure, string>> = {
+  adresseIntrouvable: 'Adresse introuvable — vérifiez la saisie',
+}
+
+export async function modifierAdresseStructureAction(actionParams: ActionParams): Promise<ReadonlyArray<string>> {
+  const validationResult = validator.safeParse(actionParams)
+  if (validationResult.error) {
+    return validationResult.error.issues.map(({ message }) => message)
+  }
+
+  // Garde : édition réservée aux bêta-testeurs (administrateur dispositif + flag is_beta_testeur).
+  const utilisateur = await new PrismaUtilisateurRepository(prisma.utilisateurRecord).get(await getSessionSub())
+  if (!(utilisateur instanceof Administrateur) || !utilisateur.isBetaTesteur) {
+    return ['Action réservée aux administrateurs autorisés']
+  }
+
+  const result = await new ModifierAdresseStructure(
+    new ApiBanGeocodingGateway(),
+    new PrismaStructureRepository()
+  ).handle({
+    adresse: validationResult.data.adresse,
+    structureId: validationResult.data.structureId,
+  })
+
+  if (result !== 'OK') {
+    return [MESSAGES_ECHEC[result]]
+  }
+
+  revalidatePath(validationResult.data.path)
+
+  return ['OK']
+}
+
+type ActionParams = Readonly<{
+  adresse: string
+  path: string
+  structureId: number
+}>
+
+const validator = z.object({
+  adresse: z.string().min(1, { message: 'L’adresse doit être renseignée' }),
+  path: z.string().min(1, { message: 'Le chemin doit être renseigné' }),
+  structureId: z.number().int().positive({ message: "L'identifiant de la structure doit être un entier positif" }),
+})

--- a/src/app/api/actions/previsualiserAdresseAction.test.ts
+++ b/src/app/api/actions/previsualiserAdresseAction.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { previsualiserAdresseAction } from './previsualiserAdresseAction'
+import { ApiBanGeocodingGateway } from '@/gateways/apiBan/ApiBanGeocodingGateway'
+
+describe('prévisualiser une adresse action', () => {
+  it('géocode la saisie et renvoie l’adresse normalisée à valider', async () => {
+    // GIVEN
+    vi.spyOn(ApiBanGeocodingGateway.prototype, 'geocoder').mockResolvedValueOnce({
+      banClefInterop: '94017_aaaa',
+      banCodeBan: null,
+      banCodeInsee: '94017',
+      banCodePostal: '94500',
+      banLatitude: 48.81,
+      banLongitude: 2.51,
+      banNomCommune: 'Champigny-sur-Marne',
+      banNomVoie: 'Rue Louis Talamoni',
+      banNumeroVoie: 14,
+      banRepetition: null,
+      score: 0.96,
+      type: 'housenumber',
+    })
+
+    // WHEN
+    const apercu = await previsualiserAdresseAction('14 rue louis talamoni champigny')
+
+    // THEN
+    expect(apercu).toStrictEqual({ label: '14 Rue Louis Talamoni, 94500 Champigny-sur-Marne', score: 0.96 })
+  })
+
+  it('renvoie null quand la saisie est vide, sans appeler la BAN', async () => {
+    // GIVEN
+    const geocoder = vi.spyOn(ApiBanGeocodingGateway.prototype, 'geocoder')
+
+    // WHEN
+    const apercu = await previsualiserAdresseAction('   ')
+
+    // THEN
+    expect(apercu).toBeNull()
+    expect(geocoder).not.toHaveBeenCalled()
+  })
+
+  it('renvoie null quand la BAN ne trouve aucune adresse', async () => {
+    // GIVEN
+    vi.spyOn(ApiBanGeocodingGateway.prototype, 'geocoder').mockResolvedValueOnce(null)
+
+    // WHEN
+    const apercu = await previsualiserAdresseAction('azertyuiop')
+
+    // THEN
+    expect(apercu).toBeNull()
+  })
+})

--- a/src/app/api/actions/previsualiserAdresseAction.ts
+++ b/src/app/api/actions/previsualiserAdresseAction.ts
@@ -1,0 +1,28 @@
+'use server'
+
+import { ApiBanGeocodingGateway } from '@/gateways/apiBan/ApiBanGeocodingGateway'
+
+export async function previsualiserAdresseAction(adresse: string): Promise<AdresseApercu | null> {
+  if (adresse.trim() === '') {
+    return null
+  }
+
+  // Lecture seule : on géocode la saisie via la BAN pour la faire valider à l'utilisateur avant
+  // toute écriture. Le re-pointage (mutation) reste géré par modifierAdresseStructureAction.
+  const geocode = await new ApiBanGeocodingGateway().geocoder({ adresse })
+  if (geocode === null) {
+    return null
+  }
+
+  const numero = geocode.banNumeroVoie === null ? '' : `${geocode.banNumeroVoie} `
+
+  return {
+    label: `${numero}${geocode.banNomVoie}, ${geocode.banCodePostal} ${geocode.banNomCommune}`,
+    score: geocode.score,
+  }
+}
+
+export type AdresseApercu = Readonly<{
+  label: string
+  score: number
+}>

--- a/src/components/Structure/EditionNomStructure.test.tsx
+++ b/src/components/Structure/EditionNomStructure.test.tsx
@@ -61,15 +61,40 @@ describe('édition du nom de structure', () => {
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Enregistrer' })).not.toBeInTheDocument()
   })
+
+  it('modifie l’adresse depuis l’onglet Adresse en appelant l’action', async () => {
+    // GIVEN
+    const modifierAdresseStructureAction = stubbedServerAction(['OK'])
+    renderComponent(<EditionNomStructure {...props()} />, {
+      modifierAdresseStructureAction,
+      pathname: '/structure/978',
+    })
+
+    // WHEN
+    fireEvent.click(screen.getByRole('button', { name: 'Éditer' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Adresse' }))
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: '5 rue Neuve, 13001 Marseille' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Enregistrer' }))
+
+    // THEN
+    await screen.findByRole('status')
+    expect(modifierAdresseStructureAction).toHaveBeenCalledWith({
+      adresse: '5 rue Neuve, 13001 Marseille',
+      path: '/structure/978',
+      structureId: 978,
+    })
+  })
 })
 
 function props(denominationAntenne: null | string = 'Antenne actuelle'): Readonly<{
+  adresse: string
   denominationAntenne: null | string
   nom: string
   rattachements: ReadonlyArray<Readonly<{ label: string; nombre: number }>>
   structureId: number
 }> {
   return {
+    adresse: '3 rue de la Paix, 75002 Paris',
     denominationAntenne,
     nom: 'Conseil départemental',
     rattachements: [

--- a/src/components/Structure/EditionNomStructure.test.tsx
+++ b/src/components/Structure/EditionNomStructure.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 
 import EditionNomStructure from './EditionNomStructure'
+import { AdresseApercu } from '@/app/api/actions/previsualiserAdresseAction'
 import { renderComponent, stubbedServerAction } from '@/components/testHelper'
 
 describe('édition du nom de structure', () => {
@@ -76,24 +77,35 @@ describe('édition du nom de structure', () => {
     expect(screen.queryByRole('button', { name: 'Enregistrer' })).not.toBeInTheDocument()
   })
 
-  it('modifie l’adresse depuis l’onglet Adresse en appelant l’action', async () => {
+  it('recherche puis valide une adresse via la BAN (saisie en 2 temps)', async () => {
     // GIVEN
+    const previsualiserAdresseAction = vi
+      .fn<(adresse: string) => Promise<AdresseApercu | null>>()
+      .mockResolvedValue({ label: '14 Rue Louis Talamoni, 94500 Champigny-sur-Marne', score: 0.96 })
     const modifierAdresseStructureAction = stubbedServerAction(['OK'])
     renderComponent(<EditionNomStructure {...props()} />, {
       modifierAdresseStructureAction,
       pathname: '/structure/978',
+      previsualiserAdresseAction,
     })
 
-    // WHEN
+    // WHEN — étape 1 : recherche
     fireEvent.click(screen.getByRole('button', { name: 'Éditer' }))
     fireEvent.click(screen.getByRole('button', { name: 'Adresse' }))
-    fireEvent.change(screen.getByRole('textbox'), { target: { value: '5 rue Neuve, 13001 Marseille' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Enregistrer' }))
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: '14 rue louis talamoni champigny' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Rechercher' }))
+
+    // THEN — l'adresse trouvée s'affiche pour validation
+    await screen.findByText(/14 Rue Louis Talamoni/)
+    expect(previsualiserAdresseAction).toHaveBeenCalledWith('14 rue louis talamoni champigny')
+
+    // WHEN — étape 2 : validation
+    fireEvent.click(screen.getByRole('button', { name: 'Valider cette adresse' }))
 
     // THEN
     await screen.findByRole('status')
     expect(modifierAdresseStructureAction).toHaveBeenCalledWith({
-      adresse: '5 rue Neuve, 13001 Marseille',
+      adresse: '14 Rue Louis Talamoni, 94500 Champigny-sur-Marne',
       path: '/structure/978',
       structureId: 978,
     })

--- a/src/components/Structure/EditionNomStructure.test.tsx
+++ b/src/components/Structure/EditionNomStructure.test.tsx
@@ -62,6 +62,20 @@ describe('édition du nom de structure', () => {
     expect(screen.queryByRole('button', { name: 'Enregistrer' })).not.toBeInTheDocument()
   })
 
+  it('interdit la modification d’adresse d’une structure canonique', () => {
+    // GIVEN
+    renderComponent(<EditionNomStructure {...props(null)} />)
+
+    // WHEN
+    fireEvent.click(screen.getByRole('button', { name: 'Éditer' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Adresse' }))
+
+    // THEN
+    expect(screen.getByText(/La modification de l/)).toBeInTheDocument()
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Enregistrer' })).not.toBeInTheDocument()
+  })
+
   it('modifie l’adresse depuis l’onglet Adresse en appelant l’action', async () => {
     // GIVEN
     const modifierAdresseStructureAction = stubbedServerAction(['OK'])

--- a/src/components/Structure/EditionNomStructure.tsx
+++ b/src/components/Structure/EditionNomStructure.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import { ReactElement, SyntheticEvent, useContext, useId, useState } from 'react'
+import { ReactElement, SyntheticEvent, useContext, useId, useRef, useState } from 'react'
 
 import Modal from '../shared/Modal/Modal'
 import ModalTitle from '../shared/ModalTitle/ModalTitle'
+import { AdresseApercu } from '@/app/api/actions/previsualiserAdresseAction'
 import { clientContext } from '@/components/shared/ClientContext'
 import { Notification } from '@/components/shared/Notification/Notification'
 import { RattachementsStructureViewModel } from '@/presenters/rattachementsStructurePresenter'
@@ -15,13 +16,11 @@ export default function EditionNomStructure({
   rattachements,
   structureId,
 }: Props): ReactElement {
-  const { modifierAdresseStructureAction, modifierNomStructureAction, pathname } = useContext(clientContext)
+  const { modifierNomStructureAction, pathname } = useContext(clientContext)
   const modalId = useId()
   const labelId = useId()
   const inputNomId = useId()
-  const inputAdresseId = useId()
   const formNomId = useId()
-  const formAdresseId = useId()
   const [isOpen, setIsOpen] = useState(false)
   const [onglet, setOnglet] = useState<Onglet>('renommer')
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -29,7 +28,8 @@ export default function EditionNomStructure({
   // Une structure canonique (nom officiel SIRENE) ne se modifie pas — ni son nom (cela créerait un
   // libellé d'antenne), ni son adresse. L'édition ne vise que les structures « antenne ».
   const estCanonique = denominationAntenne === null
-  const afficherFooter = !estCanonique && (onglet === 'renommer' || onglet === 'adresse')
+  // L'onglet Adresse gère ses propres boutons (recherche en 2 temps) ; le footer ne sert qu'au renommage.
+  const afficherFooter = !estCanonique && onglet === 'renommer'
 
   function fermer(): void {
     setIsOpen(false)
@@ -53,17 +53,6 @@ export default function EditionNomStructure({
     setIsSubmitting(false)
 
     notifier(messages, 'Nom de la structure ', 'modifié')
-  }
-
-  async function handleSubmitAdresse(event: SyntheticEvent<HTMLFormElement>): Promise<void> {
-    event.preventDefault()
-    const adresseSaisie = (new FormData(event.currentTarget).get('adresse') as string).trim()
-
-    setIsSubmitting(true)
-    const messages = await modifierAdresseStructureAction({ adresse: adresseSaisie, path: pathname, structureId })
-    setIsSubmitting(false)
-
-    notifier(messages, 'Adresse de la structure ', 'modifiée')
   }
 
   return (
@@ -117,9 +106,8 @@ export default function EditionNomStructure({
             <OngletAdresse
               adresse={adresse}
               estCanonique={estCanonique}
-              formId={formAdresseId}
-              inputId={inputAdresseId}
-              onSubmit={handleSubmitAdresse}
+              onSuccess={fermer}
+              structureId={structureId}
             />
           ) : null}
 
@@ -132,12 +120,7 @@ export default function EditionNomStructure({
               <button aria-controls={modalId} className="fr-btn fr-btn--secondary" onClick={fermer} type="button">
                 Annuler
               </button>
-              <button
-                className="fr-btn"
-                disabled={isSubmitting}
-                form={onglet === 'adresse' ? formAdresseId : formNomId}
-                type="submit"
-              >
+              <button className="fr-btn" disabled={isSubmitting} form={formNomId} type="submit">
                 {isSubmitting ? 'Enregistrement…' : 'Enregistrer'}
               </button>
             </div>
@@ -207,36 +190,111 @@ function OngletRenommer({
   )
 }
 
-function OngletAdresse({ adresse, estCanonique, formId, inputId, onSubmit }: OngletAdresseProps): ReactElement {
+function OngletAdresse({ adresse, estCanonique, onSuccess, structureId }: OngletAdresseProps): ReactElement {
+  const { modifierAdresseStructureAction, pathname, previsualiserAdresseAction } = useContext(clientContext)
+  const inputId = useId()
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [apercu, setApercu] = useState<AdresseApercu | null>(null)
+  const [enCours, setEnCours] = useState(false)
+
   if (estCanonique) {
     return <NoticeCanonique>La modification de l’adresse n’est pas disponible.</NoticeCanonique>
   }
 
+  // Étape 1 : on géocode la saisie via la BAN et on présente la correspondance à valider.
+  async function rechercher(): Promise<void> {
+    setEnCours(true)
+    const resultat = await previsualiserAdresseAction(inputRef.current?.value.trim() ?? '')
+    setEnCours(false)
+
+    if (resultat === null) {
+      Notification('error', { description: 'Adresse introuvable — vérifiez la saisie', title: 'Erreur : ' })
+      return
+    }
+    setApercu(resultat)
+  }
+
+  // Étape 2 : l'utilisateur valide l'adresse trouvée, qui re-pointe la FK (jamais d'UPDATE adresse).
+  async function valider(): Promise<void> {
+    if (apercu === null) {
+      return
+    }
+    setEnCours(true)
+    const messages = await modifierAdresseStructureAction({ adresse: apercu.label, path: pathname, structureId })
+    setEnCours(false)
+
+    if (messages.includes('OK')) {
+      Notification('success', { description: 'modifiée', title: 'Adresse de la structure ' })
+      onSuccess()
+    } else {
+      Notification('error', { description: messages.join(', '), title: 'Erreur : ' })
+    }
+  }
+
   return (
-    <form
-      id={formId}
-      onSubmit={(event) => {
-        void onSubmit(event)
-      }}
-    >
+    <div>
       <p className="fr-text--sm fr-mb-2w">
         <span className="fr-text--bold">Adresse actuelle : </span>
         {adresse}
       </p>
       <label className="fr-label" htmlFor={inputId}>
         Nouvelle adresse
-        <span className="fr-hint-text">
-          Géocodée via la Base Adresse Nationale. Une nouvelle adresse est créée si elle n’existe pas déjà.
-        </span>
+        <span className="fr-hint-text">Recherchez via la Base Adresse Nationale, puis validez l’adresse trouvée.</span>
       </label>
       <input
         className="fr-input"
         id={inputId}
-        name="adresse"
+        onChange={() => {
+          setApercu(null)
+        }}
         placeholder="12 rue de la République, 75001 Paris"
+        ref={inputRef}
         type="text"
       />
-    </form>
+
+      {apercu === null ? (
+        <button
+          className="fr-btn fr-btn--secondary fr-mt-2w"
+          disabled={enCours}
+          onClick={() => {
+            void rechercher()
+          }}
+          type="button"
+        >
+          {enCours ? 'Recherche…' : 'Rechercher'}
+        </button>
+      ) : (
+        <div className="fr-mt-2w">
+          <div className="fr-alert fr-alert--info fr-alert--sm fr-mb-2w">
+            <p>
+              <span className="fr-text--bold">Adresse trouvée : </span>
+              {apercu.label}
+            </p>
+          </div>
+          <div className="fr-btns-group fr-btns-group--inline fr-btns-group--right fr-btns-group--inline-lg">
+            <button
+              className="fr-btn fr-btn--secondary"
+              onClick={() => {
+                setApercu(null)
+              }}
+              type="button"
+            >
+              Modifier la saisie
+            </button>
+            <button
+              className="fr-btn"
+              disabled={enCours}
+              onClick={() => {
+                void valider()
+              }}
+              type="button"
+            >
+              {enCours ? 'Enregistrement…' : 'Valider cette adresse'}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
   )
 }
 
@@ -277,9 +335,8 @@ type OngletRenommerProps = Readonly<{
 type OngletAdresseProps = Readonly<{
   adresse: string
   estCanonique: boolean
-  formId: string
-  inputId: string
-  onSubmit(event: SyntheticEvent<HTMLFormElement>): Promise<void>
+  onSuccess(): void
+  structureId: number
 }>
 
 type Onglet = 'adresse' | 'fusionner' | 'renommer'

--- a/src/components/Structure/EditionNomStructure.tsx
+++ b/src/components/Structure/EditionNomStructure.tsx
@@ -103,12 +103,7 @@ export default function EditionNomStructure({
           ) : null}
 
           {onglet === 'adresse' ? (
-            <OngletAdresse
-              adresse={adresse}
-              estCanonique={estCanonique}
-              onSuccess={fermer}
-              structureId={structureId}
-            />
+            <OngletAdresse adresse={adresse} estCanonique={estCanonique} onSuccess={fermer} structureId={structureId} />
           ) : null}
 
           {onglet === 'fusionner' ? <OngletFusionner /> : null}

--- a/src/components/Structure/EditionNomStructure.tsx
+++ b/src/components/Structure/EditionNomStructure.tsx
@@ -26,14 +26,22 @@ export default function EditionNomStructure({
   const [onglet, setOnglet] = useState<Onglet>('renommer')
   const [isSubmitting, setIsSubmitting] = useState(false)
 
-  const rattachementsNonNuls = rattachements.filter((rattachement) => rattachement.nombre > 0)
-  // Structure canonique (nom officiel SIRENE) : on n'autorise pas le renommage (cela créerait un
-  // libellé d'antenne). Le renommage ne vise que les structures « antenne ».
+  // Une structure canonique (nom officiel SIRENE) ne se modifie pas — ni son nom (cela créerait un
+  // libellé d'antenne), ni son adresse. L'édition ne vise que les structures « antenne ».
   const estCanonique = denominationAntenne === null
-  const afficherFooter = (onglet === 'renommer' && !estCanonique) || onglet === 'adresse'
+  const afficherFooter = !estCanonique && (onglet === 'renommer' || onglet === 'adresse')
 
   function fermer(): void {
     setIsOpen(false)
+  }
+
+  function notifier(messages: ReadonlyArray<string>, titre: string, succes: string): void {
+    if (messages.includes('OK')) {
+      Notification('success', { description: succes, title: titre })
+      fermer()
+    } else {
+      Notification('error', { description: messages.join(', '), title: 'Erreur : ' })
+    }
   }
 
   async function handleSubmitNom(event: SyntheticEvent<HTMLFormElement>): Promise<void> {
@@ -56,15 +64,6 @@ export default function EditionNomStructure({
     setIsSubmitting(false)
 
     notifier(messages, 'Adresse de la structure ', 'modifiée')
-  }
-
-  function notifier(messages: ReadonlyArray<string>, titre: string, succes: string): void {
-    if (messages.includes('OK')) {
-      Notification('success', { description: succes, title: titre })
-      fermer()
-    } else {
-      Notification('error', { description: messages.join(', '), title: 'Erreur : ' })
-    }
   }
 
   return (
@@ -104,93 +103,27 @@ export default function EditionNomStructure({
           </div>
 
           {onglet === 'renommer' ? (
-            <>
-              {estCanonique ? (
-                <div className="fr-alert fr-alert--info fr-alert--sm fr-mb-2w">
-                  <p>
-                    Cette structure utilise le nom officiel (SIRENE) — elle est « canonique ». Le renommage n’est pas
-                    disponible : il créerait un libellé d’antenne.
-                  </p>
-                </div>
-              ) : (
-                <form
-                  id={formNomId}
-                  onSubmit={(event) => {
-                    void handleSubmitNom(event)
-                  }}
-                >
-                  <label className="fr-label" htmlFor={inputNomId}>
-                    Nom d’affichage
-                    <span className="fr-hint-text">Laisser vide pour afficher le nom officiel (SIRENE).</span>
-                  </label>
-                  <input
-                    className="fr-input"
-                    defaultValue={denominationAntenne}
-                    id={inputNomId}
-                    maxLength={255}
-                    name="nomAffichage"
-                    type="text"
-                  />
-                </form>
-              )}
-
-              <div className="fr-mt-3w">
-                <p className="fr-text--sm fr-text--bold fr-mb-1v">Éléments rattachés à cette structure</p>
-                {estCanonique ? null : (
-                  <p className="fr-text--xs fr-text-mention--grey fr-mb-1w">
-                    Renommer la structure modifie son affichage partout où elle apparaît.
-                  </p>
-                )}
-                {rattachementsNonNuls.length === 0 ? (
-                  <p className="fr-text--sm">Aucun élément rattaché.</p>
-                ) : (
-                  <ul className="fr-text--sm">
-                    {rattachementsNonNuls.map((rattachement) => (
-                      <li key={rattachement.label}>
-                        {rattachement.label} : <span className="fr-text--bold">{rattachement.nombre}</span>
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </div>
-            </>
+            <OngletRenommer
+              denominationAntenne={denominationAntenne}
+              estCanonique={estCanonique}
+              formId={formNomId}
+              inputId={inputNomId}
+              onSubmit={handleSubmitNom}
+              rattachements={rattachements}
+            />
           ) : null}
 
           {onglet === 'adresse' ? (
-            <form
-              id={formAdresseId}
-              onSubmit={(event) => {
-                void handleSubmitAdresse(event)
-              }}
-            >
-              <p className="fr-text--sm fr-mb-2w">
-                <span className="fr-text--bold">Adresse actuelle : </span>
-                {adresse}
-              </p>
-              <label className="fr-label" htmlFor={inputAdresseId}>
-                Nouvelle adresse
-                <span className="fr-hint-text">
-                  Géocodée via la Base Adresse Nationale. Une nouvelle adresse est créée si elle n’existe pas déjà.
-                </span>
-              </label>
-              <input
-                className="fr-input"
-                id={inputAdresseId}
-                name="adresse"
-                placeholder="12 rue de la République, 75001 Paris"
-                type="text"
-              />
-            </form>
+            <OngletAdresse
+              adresse={adresse}
+              estCanonique={estCanonique}
+              formId={formAdresseId}
+              inputId={inputAdresseId}
+              onSubmit={handleSubmitAdresse}
+            />
           ) : null}
 
-          {onglet === 'fusionner' ? (
-            <div className="fr-py-4w" style={{ textAlign: 'center' }}>
-              <p className="fr-badge fr-badge--info fr-badge--no-icon fr-mb-1w">Fonctionnalité à venir</p>
-              <p className="fr-text--sm fr-text-mention--grey">
-                La fusion de structures sera proposée ici. L’interface reste à définir.
-              </p>
-            </div>
-          ) : null}
+          {onglet === 'fusionner' ? <OngletFusionner /> : null}
         </div>
 
         {afficherFooter ? (
@@ -215,11 +148,139 @@ export default function EditionNomStructure({
   )
 }
 
+function OngletRenommer({
+  denominationAntenne,
+  estCanonique,
+  formId,
+  inputId,
+  onSubmit,
+  rattachements,
+}: OngletRenommerProps): ReactElement {
+  const rattachementsNonNuls = rattachements.filter((rattachement) => rattachement.nombre > 0)
+
+  return (
+    <>
+      {estCanonique ? (
+        <NoticeCanonique>Le renommage n’est pas disponible : il créerait un libellé d’antenne.</NoticeCanonique>
+      ) : (
+        <form
+          id={formId}
+          onSubmit={(event) => {
+            void onSubmit(event)
+          }}
+        >
+          <label className="fr-label" htmlFor={inputId}>
+            Nom d’affichage
+            <span className="fr-hint-text">Laisser vide pour afficher le nom officiel (SIRENE).</span>
+          </label>
+          <input
+            className="fr-input"
+            defaultValue={denominationAntenne ?? ''}
+            id={inputId}
+            maxLength={255}
+            name="nomAffichage"
+            type="text"
+          />
+        </form>
+      )}
+
+      <div className="fr-mt-3w">
+        <p className="fr-text--sm fr-text--bold fr-mb-1v">Éléments rattachés à cette structure</p>
+        {estCanonique ? null : (
+          <p className="fr-text--xs fr-text-mention--grey fr-mb-1w">
+            Renommer la structure modifie son affichage partout où elle apparaît.
+          </p>
+        )}
+        {rattachementsNonNuls.length === 0 ? (
+          <p className="fr-text--sm">Aucun élément rattaché.</p>
+        ) : (
+          <ul className="fr-text--sm">
+            {rattachementsNonNuls.map((rattachement) => (
+              <li key={rattachement.label}>
+                {rattachement.label} : <span className="fr-text--bold">{rattachement.nombre}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </>
+  )
+}
+
+function OngletAdresse({ adresse, estCanonique, formId, inputId, onSubmit }: OngletAdresseProps): ReactElement {
+  if (estCanonique) {
+    return <NoticeCanonique>La modification de l’adresse n’est pas disponible.</NoticeCanonique>
+  }
+
+  return (
+    <form
+      id={formId}
+      onSubmit={(event) => {
+        void onSubmit(event)
+      }}
+    >
+      <p className="fr-text--sm fr-mb-2w">
+        <span className="fr-text--bold">Adresse actuelle : </span>
+        {adresse}
+      </p>
+      <label className="fr-label" htmlFor={inputId}>
+        Nouvelle adresse
+        <span className="fr-hint-text">
+          Géocodée via la Base Adresse Nationale. Une nouvelle adresse est créée si elle n’existe pas déjà.
+        </span>
+      </label>
+      <input
+        className="fr-input"
+        id={inputId}
+        name="adresse"
+        placeholder="12 rue de la République, 75001 Paris"
+        type="text"
+      />
+    </form>
+  )
+}
+
+function OngletFusionner(): ReactElement {
+  return (
+    <div className="fr-py-4w" style={{ textAlign: 'center' }}>
+      <p className="fr-badge fr-badge--info fr-badge--no-icon fr-mb-1w">Fonctionnalité à venir</p>
+      <p className="fr-text--sm fr-text-mention--grey">
+        La fusion de structures sera proposée ici. L’interface reste à définir.
+      </p>
+    </div>
+  )
+}
+
+function NoticeCanonique({ children }: Readonly<{ children: string }>): ReactElement {
+  return (
+    <div className="fr-alert fr-alert--info fr-alert--sm fr-mb-2w">
+      <p>Cette structure utilise le nom officiel (SIRENE) — elle est « canonique ». {children}</p>
+    </div>
+  )
+}
+
 const ONGLETS: ReadonlyArray<Readonly<{ id: Onglet; libelle: string }>> = [
   { id: 'renommer', libelle: 'Renommer' },
   { id: 'adresse', libelle: 'Adresse' },
   { id: 'fusionner', libelle: 'Fusionner' },
 ]
+
+type OngletRenommerProps = Readonly<{
+  denominationAntenne: null | string
+  estCanonique: boolean
+  formId: string
+  inputId: string
+  onSubmit(event: SyntheticEvent<HTMLFormElement>): Promise<void>
+  rattachements: RattachementsStructureViewModel
+}>
+
+type OngletAdresseProps = Readonly<{
+  adresse: string
+  estCanonique: boolean
+  formId: string
+  inputId: string
+  onSubmit(event: SyntheticEvent<HTMLFormElement>): Promise<void>
+}>
 
 type Onglet = 'adresse' | 'fusionner' | 'renommer'
 

--- a/src/components/Structure/EditionNomStructure.tsx
+++ b/src/components/Structure/EditionNomStructure.tsx
@@ -9,16 +9,19 @@ import { Notification } from '@/components/shared/Notification/Notification'
 import { RattachementsStructureViewModel } from '@/presenters/rattachementsStructurePresenter'
 
 export default function EditionNomStructure({
+  adresse,
   denominationAntenne,
   nom,
   rattachements,
   structureId,
 }: Props): ReactElement {
-  const { modifierNomStructureAction, pathname } = useContext(clientContext)
+  const { modifierAdresseStructureAction, modifierNomStructureAction, pathname } = useContext(clientContext)
   const modalId = useId()
   const labelId = useId()
-  const inputId = useId()
-  const formId = useId()
+  const inputNomId = useId()
+  const inputAdresseId = useId()
+  const formNomId = useId()
+  const formAdresseId = useId()
   const [isOpen, setIsOpen] = useState(false)
   const [onglet, setOnglet] = useState<Onglet>('renommer')
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -27,12 +30,13 @@ export default function EditionNomStructure({
   // Structure canonique (nom officiel SIRENE) : on n'autorise pas le renommage (cela créerait un
   // libellé d'antenne). Le renommage ne vise que les structures « antenne ».
   const estCanonique = denominationAntenne === null
+  const afficherFooter = (onglet === 'renommer' && !estCanonique) || onglet === 'adresse'
 
   function fermer(): void {
     setIsOpen(false)
   }
 
-  async function handleSubmit(event: SyntheticEvent<HTMLFormElement>): Promise<void> {
+  async function handleSubmitNom(event: SyntheticEvent<HTMLFormElement>): Promise<void> {
     event.preventDefault()
     const nomAffichage = (new FormData(event.currentTarget).get('nomAffichage') as string).trim()
 
@@ -40,8 +44,23 @@ export default function EditionNomStructure({
     const messages = await modifierNomStructureAction({ nomAffichage, path: pathname, structureId })
     setIsSubmitting(false)
 
+    notifier(messages, 'Nom de la structure ', 'modifié')
+  }
+
+  async function handleSubmitAdresse(event: SyntheticEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault()
+    const adresseSaisie = (new FormData(event.currentTarget).get('adresse') as string).trim()
+
+    setIsSubmitting(true)
+    const messages = await modifierAdresseStructureAction({ adresse: adresseSaisie, path: pathname, structureId })
+    setIsSubmitting(false)
+
+    notifier(messages, 'Adresse de la structure ', 'modifiée')
+  }
+
+  function notifier(messages: ReadonlyArray<string>, titre: string, succes: string): void {
     if (messages.includes('OK')) {
-      Notification('success', { description: 'modifié', title: 'Nom de la structure ' })
+      Notification('success', { description: succes, title: titre })
       fermer()
     } else {
       Notification('error', { description: messages.join(', '), title: 'Erreur : ' })
@@ -58,7 +77,7 @@ export default function EditionNomStructure({
           onClick={() => {
             setIsOpen(true)
           }}
-          title="Renommer ou fusionner la structure"
+          title="Modifier la structure"
           type="button"
         >
           Éditer
@@ -67,27 +86,21 @@ export default function EditionNomStructure({
 
       <Modal close={fermer} id={modalId} isOpen={isOpen} labelId={labelId}>
         <div className="fr-modal__content">
-          <ModalTitle id={labelId}>Renommer ou fusionner la structure</ModalTitle>
+          <ModalTitle id={labelId}>Modifier la structure</ModalTitle>
 
           <div className="fr-btns-group fr-btns-group--inline fr-btns-group--sm fr-mb-3w">
-            <button
-              className={onglet === 'renommer' ? 'fr-btn fr-btn--sm' : 'fr-btn fr-btn--sm fr-btn--secondary'}
-              onClick={() => {
-                setOnglet('renommer')
-              }}
-              type="button"
-            >
-              Renommer
-            </button>
-            <button
-              className={onglet === 'fusionner' ? 'fr-btn fr-btn--sm' : 'fr-btn fr-btn--sm fr-btn--secondary'}
-              onClick={() => {
-                setOnglet('fusionner')
-              }}
-              type="button"
-            >
-              Fusionner
-            </button>
+            {ONGLETS.map((definition) => (
+              <button
+                className={onglet === definition.id ? 'fr-btn fr-btn--sm' : 'fr-btn fr-btn--sm fr-btn--secondary'}
+                key={definition.id}
+                onClick={() => {
+                  setOnglet(definition.id)
+                }}
+                type="button"
+              >
+                {definition.libelle}
+              </button>
+            ))}
           </div>
 
           {onglet === 'renommer' ? (
@@ -101,19 +114,19 @@ export default function EditionNomStructure({
                 </div>
               ) : (
                 <form
-                  id={formId}
+                  id={formNomId}
                   onSubmit={(event) => {
-                    void handleSubmit(event)
+                    void handleSubmitNom(event)
                   }}
                 >
-                  <label className="fr-label" htmlFor={inputId}>
+                  <label className="fr-label" htmlFor={inputNomId}>
                     Nom d’affichage
                     <span className="fr-hint-text">Laisser vide pour afficher le nom officiel (SIRENE).</span>
                   </label>
                   <input
                     className="fr-input"
                     defaultValue={denominationAntenne}
-                    id={inputId}
+                    id={inputNomId}
                     maxLength={255}
                     name="nomAffichage"
                     type="text"
@@ -141,23 +154,57 @@ export default function EditionNomStructure({
                 )}
               </div>
             </>
-          ) : (
+          ) : null}
+
+          {onglet === 'adresse' ? (
+            <form
+              id={formAdresseId}
+              onSubmit={(event) => {
+                void handleSubmitAdresse(event)
+              }}
+            >
+              <p className="fr-text--sm fr-mb-2w">
+                <span className="fr-text--bold">Adresse actuelle : </span>
+                {adresse}
+              </p>
+              <label className="fr-label" htmlFor={inputAdresseId}>
+                Nouvelle adresse
+                <span className="fr-hint-text">
+                  Géocodée via la Base Adresse Nationale. Une nouvelle adresse est créée si elle n’existe pas déjà.
+                </span>
+              </label>
+              <input
+                className="fr-input"
+                id={inputAdresseId}
+                name="adresse"
+                placeholder="12 rue de la République, 75001 Paris"
+                type="text"
+              />
+            </form>
+          ) : null}
+
+          {onglet === 'fusionner' ? (
             <div className="fr-py-4w" style={{ textAlign: 'center' }}>
               <p className="fr-badge fr-badge--info fr-badge--no-icon fr-mb-1w">Fonctionnalité à venir</p>
               <p className="fr-text--sm fr-text-mention--grey">
                 La fusion de structures sera proposée ici. L’interface reste à définir.
               </p>
             </div>
-          )}
+          ) : null}
         </div>
 
-        {onglet === 'renommer' && !estCanonique ? (
+        {afficherFooter ? (
           <div className="fr-modal__footer">
             <div className="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg">
               <button aria-controls={modalId} className="fr-btn fr-btn--secondary" onClick={fermer} type="button">
                 Annuler
               </button>
-              <button className="fr-btn" disabled={isSubmitting} form={formId} type="submit">
+              <button
+                className="fr-btn"
+                disabled={isSubmitting}
+                form={onglet === 'adresse' ? formAdresseId : formNomId}
+                type="submit"
+              >
                 {isSubmitting ? 'Enregistrement…' : 'Enregistrer'}
               </button>
             </div>
@@ -168,9 +215,16 @@ export default function EditionNomStructure({
   )
 }
 
-type Onglet = 'fusionner' | 'renommer'
+const ONGLETS: ReadonlyArray<Readonly<{ id: Onglet; libelle: string }>> = [
+  { id: 'renommer', libelle: 'Renommer' },
+  { id: 'adresse', libelle: 'Adresse' },
+  { id: 'fusionner', libelle: 'Fusionner' },
+]
+
+type Onglet = 'adresse' | 'fusionner' | 'renommer'
 
 type Props = Readonly<{
+  adresse: string
   denominationAntenne: null | string
   nom: string
   rattachements: RattachementsStructureViewModel

--- a/src/components/Structure/StructureIdentite.tsx
+++ b/src/components/Structure/StructureIdentite.tsx
@@ -23,6 +23,7 @@ export default function StructureIdentite({
           <div className="color-grey">Raison sociale</div>
           {editionActive ? (
             <EditionNomStructure
+              adresse={identite.adresse}
               denominationAntenne={identite.denominationAntenne}
               nom={identite.nom}
               rattachements={rattachements}

--- a/src/components/shared/ClientContext.tsx
+++ b/src/components/shared/ClientContext.tsx
@@ -19,6 +19,7 @@ import { changerMonRoleAction } from '@/app/api/actions/changerMonRoleAction'
 import { definirUnCoPorteurAction } from '@/app/api/actions/definirUnCoPorteurAction'
 import { fusionnerStructuresAction } from '@/app/api/actions/fusionnerStructuresAction'
 import { inviterUnUtilisateurAction } from '@/app/api/actions/inviterUnUtilisateurAction'
+import { modifierAdresseStructureAction } from '@/app/api/actions/modifierAdresseStructureAction'
 import { modifierContactReferentStructureAction } from '@/app/api/actions/modifierContactReferentStructureAction'
 import { modifierLieuInclusionDescriptionAction } from '@/app/api/actions/modifierLieuInclusionDescriptionAction'
 import { modifierLieuInclusionInformationsPratiquesAction } from '@/app/api/actions/modifierLieuInclusionInformationsPratiquesAction'
@@ -74,6 +75,7 @@ export default function ClientContext({
       definirUnCoPorteurAction,
       fusionnerStructuresAction,
       inviterUnUtilisateurAction,
+      modifierAdresseStructureAction,
       modifierContactReferentStructureAction,
       modifierLieuInclusionDescriptionAction,
       modifierLieuInclusionInformationsPratiquesAction,
@@ -131,6 +133,7 @@ export type ClientContextProviderValue = Readonly<{
   definirUnCoPorteurAction: typeof definirUnCoPorteurAction
   fusionnerStructuresAction: typeof fusionnerStructuresAction
   inviterUnUtilisateurAction: typeof inviterUnUtilisateurAction
+  modifierAdresseStructureAction: typeof modifierAdresseStructureAction
   modifierContactReferentStructureAction: typeof modifierContactReferentStructureAction
   modifierLieuInclusionDescriptionAction: typeof modifierLieuInclusionDescriptionAction
   modifierLieuInclusionInformationsPratiquesAction: typeof modifierLieuInclusionInformationsPratiquesAction

--- a/src/components/shared/ClientContext.tsx
+++ b/src/components/shared/ClientContext.tsx
@@ -34,6 +34,7 @@ import { modifierUneFeuilleDeRouteAction } from '@/app/api/actions/modifierUneFe
 import { modifierUneNoteDeContexteAction } from '@/app/api/actions/modifierUneNoteDeContexteAction'
 import { modifierUneNoteDeContextualisationAction } from '@/app/api/actions/modifierUneNoteDeContextualisationAction'
 import { modifierUneNotePriveeAction } from '@/app/api/actions/modifierUneNotePriveeAction'
+import { previsualiserAdresseAction } from '@/app/api/actions/previsualiserAdresseAction'
 import { rechercherUneEntrepriseAction } from '@/app/api/actions/rechercherUneEntrepriseAction'
 import { reinviterUnUtilisateurAction } from '@/app/api/actions/reinviterUnUtilisateurAction'
 import { retirerUnCoPorteurAction } from '@/app/api/actions/retirerUnCoPorteurAction'
@@ -91,6 +92,7 @@ export default function ClientContext({
       modifierUneNoteDeContextualisationAction,
       modifierUneNotePriveeAction,
       pathname,
+      previsualiserAdresseAction,
       rechercherUneEntrepriseAction,
       reinviterUnUtilisateurAction,
       retirerUnCoPorteurAction,
@@ -149,6 +151,7 @@ export type ClientContextProviderValue = Readonly<{
   modifierUneNoteDeContextualisationAction: typeof modifierUneNoteDeContextualisationAction
   modifierUneNotePriveeAction: typeof modifierUneNotePriveeAction
   pathname: string
+  previsualiserAdresseAction: typeof previsualiserAdresseAction
   rechercherUneEntrepriseAction: typeof rechercherUneEntrepriseAction
   reinviterUnUtilisateurAction: typeof reinviterUnUtilisateurAction
   retirerUnCoPorteurAction: typeof retirerUnCoPorteurAction

--- a/src/components/testHelper.tsx
+++ b/src/components/testHelper.tsx
@@ -53,6 +53,7 @@ export function renderComponent(
     modifierUneNoteDeContextualisationAction: vi.fn(),
     modifierUneNotePriveeAction: vi.fn(),
     pathname: '/',
+    previsualiserAdresseAction: vi.fn(),
     rechercherUneEntrepriseAction: vi.fn(),
     reinviterUnUtilisateurAction: vi.fn(),
     retirerUnCoPorteurAction: vi.fn(),

--- a/src/components/testHelper.tsx
+++ b/src/components/testHelper.tsx
@@ -37,6 +37,7 @@ export function renderComponent(
     definirUnCoPorteurAction: vi.fn(),
     fusionnerStructuresAction: vi.fn(),
     inviterUnUtilisateurAction: vi.fn(),
+    modifierAdresseStructureAction: vi.fn(),
     modifierContactReferentStructureAction: vi.fn(),
     modifierLieuInclusionDescriptionAction: vi.fn(),
     modifierLieuInclusionInformationsPratiquesAction: vi.fn(),

--- a/src/gateways/PrismaStructureRepository.test.ts
+++ b/src/gateways/PrismaStructureRepository.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { PrismaStructureRepository } from './PrismaStructureRepository'
 import { creerUneStructure } from './testHelper'
 import prisma from '../../prisma/prismaClient'
+import { AdresseARattacher } from '@/use-cases/commands/shared/StructureRepository'
 
 describe('prisma structure repository', () => {
   beforeEach(async () => prisma.$queryRaw`START TRANSACTION`)
@@ -86,4 +87,53 @@ describe('prisma structure repository', () => {
       expect(succes).toBe(false)
     })
   })
+
+  describe('rattacher une adresse', () => {
+    it('crée une nouvelle adresse et re-pointe la structure dessus', async () => {
+      // GIVEN
+      await creerUneStructure({ id: 978 })
+
+      // WHEN
+      await new PrismaStructureRepository().rattacherAdresse(978, adresseARattacher())
+
+      // THEN
+      const structure = await prisma.main_structure_administrative.findUnique({
+        include: { adresse: true },
+        where: { id: 978 },
+      })
+      expect(structure?.adresse?.clef_interop).toBe('94017_aaaa')
+      expect(structure?.adresse?.nom_commune).toBe('Champigny-sur-Marne')
+    })
+
+    it('réutilise une adresse existante de même clef_interop (pas de doublon)', async () => {
+      // GIVEN
+      await creerUneStructure({ id: 978 })
+      await new PrismaStructureRepository().rattacherAdresse(978, adresseARattacher())
+      const premiere = await prisma.main_structure_administrative.findUnique({ where: { id: 978 } })
+
+      // WHEN
+      await creerUneStructure({ id: 979, siret: '99999999999999' })
+      await new PrismaStructureRepository().rattacherAdresse(979, adresseARattacher())
+      const seconde = await prisma.main_structure_administrative.findUnique({ where: { id: 979 } })
+
+      // THEN
+      expect(seconde?.adresse_id).toBe(premiere?.adresse_id)
+      await expect(prisma.adresse.count({ where: { clef_interop: '94017_aaaa' } })).resolves.toBe(1)
+    })
+  })
 })
+
+function adresseARattacher(): AdresseARattacher {
+  return {
+    clefInterop: '94017_aaaa',
+    codeBan: null,
+    codeInsee: '94017',
+    codePostal: '94500',
+    latitude: 48.81,
+    longitude: 2.51,
+    nomCommune: 'Champigny-sur-Marne',
+    nomVoie: 'Rue Louis Talamoni',
+    numeroVoie: 14,
+    repetition: null,
+  }
+}

--- a/src/gateways/PrismaStructureRepository.ts
+++ b/src/gateways/PrismaStructureRepository.ts
@@ -4,6 +4,8 @@ import prisma from '../../prisma/prismaClient'
 import { Structure, StructureAdresse } from '@/domain/Structure'
 import { ContactReferentRepository } from '@/use-cases/commands/ModifierContactReferentStructure'
 import {
+  AdresseARattacher,
+  ModifierAdresseStructureRepository,
   ModifierNomStructureData,
   ModifierNomStructureRepository,
   NomActuelStructure,
@@ -18,7 +20,11 @@ import {
 // SA.denomination_sirene (compatibilité ascendante avec le contrat actuel).
 
 export class PrismaStructureRepository
-  implements ContactReferentRepository, ModifierNomStructureRepository, StructureRepository
+  implements
+    ContactReferentRepository,
+    ModifierAdresseStructureRepository,
+    ModifierNomStructureRepository,
+    StructureRepository
 {
   async ajouterContact(structureId: number, data: ContactStructureData): Promise<void> {
     const contact = await prisma.main_contact.create({
@@ -137,6 +143,14 @@ export class PrismaStructureRepository
       }
       throw error
     }
+  }
+
+  async rattacherAdresse(structureId: number, adresse: AdresseARattacher): Promise<void> {
+    const adresseId = await this.trouverOuCreerAdresse(adresse)
+    await prisma.main_structure_administrative.update({
+      data: { adresse_id: adresseId },
+      where: { id: structureId },
+    })
   }
 
   async supprimerContact(structureId: number, contactId: number): Promise<void> {
@@ -357,6 +371,37 @@ export class PrismaStructureRepository
       repetition: adresseCreee.repetition,
       uid: { value: adresseCreee.id },
     })
+  }
+
+  // Re-pointage d'adresse : réutilise l'adresse de même clef_interop BAN si elle existe, sinon
+  // crée une nouvelle ligne (avec géométrie PostGIS). On ne modifie jamais une ligne adresse.
+  private async trouverOuCreerAdresse(adresse: AdresseARattacher): Promise<number> {
+    const existante = await prisma.adresse.findFirst({
+      where: { clef_interop: adresse.clefInterop },
+    })
+    if (existante) {
+      return existante.id
+    }
+
+    const resultat = await prisma.$queryRaw<Array<{ id: number }>>`
+      INSERT INTO main.adresse (
+        clef_interop, code_ban, code_insee, code_postal,
+        nom_commune, nom_voie, numero_voie, repetition, geom
+      ) VALUES (
+        ${adresse.clefInterop},
+        ${adresse.codeBan}::uuid,
+        ${adresse.codeInsee},
+        ${adresse.codePostal},
+        ${adresse.nomCommune},
+        ${adresse.nomVoie},
+        ${adresse.numeroVoie},
+        ${adresse.repetition},
+        public.ST_Point(${adresse.longitude}::double precision, ${adresse.latitude}::double precision, 4326)
+      )
+      RETURNING id
+    `
+
+    return resultat[0].id
   }
 }
 

--- a/src/use-cases/commands/ModifierAdresseStructure.test.ts
+++ b/src/use-cases/commands/ModifierAdresseStructure.test.ts
@@ -1,17 +1,17 @@
 import { describe, expect, it } from 'vitest'
 
 import { ModifierAdresseStructure } from './ModifierAdresseStructure'
-import { AdresseARattacher, ModifierAdresseStructureRepository } from './shared/StructureRepository'
+import { AdresseARattacher, ModifierAdresseStructureRepository, NomActuelStructure } from './shared/StructureRepository'
 import { AdresseGeocodeReadModel, BanGeocodingGateway, GeocodageParams } from '@/gateways/apiBan/BanGeocodingGateway'
 
 describe('modifier l’adresse d’une structure', () => {
   it('géocode l’adresse puis re-pointe la structure sur l’adresse correspondante', async () => {
     // GIVEN
     const geocoder = geocodage(adresseGeocodee())
-    const rattacherAdresse = rattachement()
+    const repository = repositoryStub({ denominationAntenne: 'antenne actuelle' })
 
     // WHEN
-    const result = await new ModifierAdresseStructure({ geocoder }, { rattacherAdresse }).handle({
+    const result = await new ModifierAdresseStructure({ geocoder }, repository).handle({
       adresse: '14 rue Louis Talamoni, Champigny',
       structureId: 978,
     })
@@ -19,7 +19,7 @@ describe('modifier l’adresse d’une structure', () => {
     // THEN
     expect(result).toBe('OK')
     expect(geocoder).toHaveBeenCalledWith({ adresse: '14 rue Louis Talamoni, Champigny' })
-    expect(rattacherAdresse).toHaveBeenCalledWith(978, {
+    expect(repository.rattacherAdresse).toHaveBeenCalledWith(978, {
       clefInterop: '94017_aaaa',
       codeBan: null,
       codeInsee: '94017',
@@ -33,20 +33,51 @@ describe('modifier l’adresse d’une structure', () => {
     })
   })
 
+  it('refuse de modifier l’adresse d’une structure canonique (denomination_antenne null)', async () => {
+    // GIVEN
+    const geocoder = geocodage(adresseGeocodee())
+    const repository = repositoryStub({ denominationAntenne: null })
+
+    // WHEN
+    const result = await new ModifierAdresseStructure({ geocoder }, repository).handle({
+      adresse: '14 rue Louis Talamoni',
+      structureId: 978,
+    })
+
+    // THEN
+    expect(result).toBe('structureCanoniqueNonModifiable')
+    expect(geocoder).not.toHaveBeenCalled()
+    expect(repository.rattacherAdresse).not.toHaveBeenCalled()
+  })
+
+  it('renvoie une erreur quand la structure est introuvable', async () => {
+    // GIVEN
+    const repository = repositoryStub(null)
+
+    // WHEN
+    const result = await new ModifierAdresseStructure({ geocoder: geocodage(adresseGeocodee()) }, repository).handle({
+      adresse: '14 rue Louis Talamoni',
+      structureId: 0,
+    })
+
+    // THEN
+    expect(result).toBe('structureIntrouvable')
+  })
+
   it('renvoie une erreur quand l’adresse n’est pas géocodable', async () => {
     // GIVEN
     const geocoder = geocodage(null)
-    const rattacherAdresse = rattachement()
+    const repository = repositoryStub({ denominationAntenne: 'antenne actuelle' })
 
     // WHEN
-    const result = await new ModifierAdresseStructure({ geocoder }, { rattacherAdresse }).handle({
+    const result = await new ModifierAdresseStructure({ geocoder }, repository).handle({
       adresse: 'azertyuiop',
       structureId: 978,
     })
 
     // THEN
     expect(result).toBe('adresseIntrouvable')
-    expect(rattacherAdresse).not.toHaveBeenCalled()
+    expect(repository.rattacherAdresse).not.toHaveBeenCalled()
   })
 })
 
@@ -54,8 +85,15 @@ function geocodage(resultat: AdresseGeocodeReadModel | null): BanGeocodingGatewa
   return vi.fn<(params: GeocodageParams) => Promise<AdresseGeocodeReadModel | null>>().mockResolvedValue(resultat)
 }
 
-function rattachement(): ModifierAdresseStructureRepository['rattacherAdresse'] {
-  return vi.fn<(structureId: number, adresse: AdresseARattacher) => Promise<void>>().mockResolvedValue(undefined)
+function repositoryStub(nomActuel: NomActuelStructure | null): ModifierAdresseStructureRepository {
+  return {
+    lireNomStructure: vi
+      .fn<(structureId: number) => Promise<NomActuelStructure | null>>()
+      .mockResolvedValue(nomActuel),
+    rattacherAdresse: vi
+      .fn<(structureId: number, adresse: AdresseARattacher) => Promise<void>>()
+      .mockResolvedValue(undefined),
+  }
 }
 
 function adresseGeocodee(): AdresseGeocodeReadModel {

--- a/src/use-cases/commands/ModifierAdresseStructure.test.ts
+++ b/src/use-cases/commands/ModifierAdresseStructure.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+
+import { ModifierAdresseStructure } from './ModifierAdresseStructure'
+import { AdresseARattacher, ModifierAdresseStructureRepository } from './shared/StructureRepository'
+import { AdresseGeocodeReadModel, BanGeocodingGateway, GeocodageParams } from '@/gateways/apiBan/BanGeocodingGateway'
+
+describe('modifier l’adresse d’une structure', () => {
+  it('géocode l’adresse puis re-pointe la structure sur l’adresse correspondante', async () => {
+    // GIVEN
+    const geocoder = geocodage(adresseGeocodee())
+    const rattacherAdresse = rattachement()
+
+    // WHEN
+    const result = await new ModifierAdresseStructure({ geocoder }, { rattacherAdresse }).handle({
+      adresse: '14 rue Louis Talamoni, Champigny',
+      structureId: 978,
+    })
+
+    // THEN
+    expect(result).toBe('OK')
+    expect(geocoder).toHaveBeenCalledWith({ adresse: '14 rue Louis Talamoni, Champigny' })
+    expect(rattacherAdresse).toHaveBeenCalledWith(978, {
+      clefInterop: '94017_aaaa',
+      codeBan: null,
+      codeInsee: '94017',
+      codePostal: '94500',
+      latitude: 48.81,
+      longitude: 2.51,
+      nomCommune: 'Champigny-sur-Marne',
+      nomVoie: 'Rue Louis Talamoni',
+      numeroVoie: 14,
+      repetition: null,
+    })
+  })
+
+  it('renvoie une erreur quand l’adresse n’est pas géocodable', async () => {
+    // GIVEN
+    const geocoder = geocodage(null)
+    const rattacherAdresse = rattachement()
+
+    // WHEN
+    const result = await new ModifierAdresseStructure({ geocoder }, { rattacherAdresse }).handle({
+      adresse: 'azertyuiop',
+      structureId: 978,
+    })
+
+    // THEN
+    expect(result).toBe('adresseIntrouvable')
+    expect(rattacherAdresse).not.toHaveBeenCalled()
+  })
+})
+
+function geocodage(resultat: AdresseGeocodeReadModel | null): BanGeocodingGateway['geocoder'] {
+  return vi.fn<(params: GeocodageParams) => Promise<AdresseGeocodeReadModel | null>>().mockResolvedValue(resultat)
+}
+
+function rattachement(): ModifierAdresseStructureRepository['rattacherAdresse'] {
+  return vi.fn<(structureId: number, adresse: AdresseARattacher) => Promise<void>>().mockResolvedValue(undefined)
+}
+
+function adresseGeocodee(): AdresseGeocodeReadModel {
+  return {
+    banClefInterop: '94017_aaaa',
+    banCodeBan: null,
+    banCodeInsee: '94017',
+    banCodePostal: '94500',
+    banLatitude: 48.81,
+    banLongitude: 2.51,
+    banNomCommune: 'Champigny-sur-Marne',
+    banNomVoie: 'Rue Louis Talamoni',
+    banNumeroVoie: 14,
+    banRepetition: null,
+    score: 0.95,
+    type: 'housenumber',
+  }
+}

--- a/src/use-cases/commands/ModifierAdresseStructure.test.ts
+++ b/src/use-cases/commands/ModifierAdresseStructure.test.ts
@@ -87,9 +87,7 @@ function geocodage(resultat: AdresseGeocodeReadModel | null): BanGeocodingGatewa
 
 function repositoryStub(nomActuel: NomActuelStructure | null): ModifierAdresseStructureRepository {
   return {
-    lireNomStructure: vi
-      .fn<(structureId: number) => Promise<NomActuelStructure | null>>()
-      .mockResolvedValue(nomActuel),
+    lireNomStructure: vi.fn<(structureId: number) => Promise<NomActuelStructure | null>>().mockResolvedValue(nomActuel),
     rattacherAdresse: vi
       .fn<(structureId: number, adresse: AdresseARattacher) => Promise<void>>()
       .mockResolvedValue(undefined),

--- a/src/use-cases/commands/ModifierAdresseStructure.ts
+++ b/src/use-cases/commands/ModifierAdresseStructure.ts
@@ -1,0 +1,46 @@
+import { CommandHandler, ResultAsync } from '../CommandHandler'
+import { ModifierAdresseStructureRepository } from './shared/StructureRepository'
+import { BanGeocodingGateway } from '@/gateways/apiBan/BanGeocodingGateway'
+
+export class ModifierAdresseStructure implements CommandHandler<Command> {
+  readonly #banGeocodingGateway: BanGeocodingGateway
+  readonly #structureRepository: ModifierAdresseStructureRepository
+
+  constructor(banGeocodingGateway: BanGeocodingGateway, structureRepository: ModifierAdresseStructureRepository) {
+    this.#banGeocodingGateway = banGeocodingGateway
+    this.#structureRepository = structureRepository
+  }
+
+  async handle(command: Command): ResultAsync<Failure> {
+    // La validation des permissions est effectuée au niveau de la Server Action.
+    // On géocode l'adresse saisie via la BAN ; sans correspondance, on refuse.
+    const geocode = await this.#banGeocodingGateway.geocoder({ adresse: command.adresse })
+    if (geocode === null) {
+      return 'adresseIntrouvable'
+    }
+
+    // On ne modifie jamais une ligne adresse : le repository réutilise une adresse existante
+    // (même clef_interop) ou en crée une nouvelle, puis re-pointe structure.adresse_id.
+    await this.#structureRepository.rattacherAdresse(command.structureId, {
+      clefInterop: geocode.banClefInterop,
+      codeBan: geocode.banCodeBan,
+      codeInsee: geocode.banCodeInsee,
+      codePostal: geocode.banCodePostal,
+      latitude: geocode.banLatitude,
+      longitude: geocode.banLongitude,
+      nomCommune: geocode.banNomCommune,
+      nomVoie: geocode.banNomVoie,
+      numeroVoie: geocode.banNumeroVoie,
+      repetition: geocode.banRepetition,
+    })
+
+    return 'OK'
+  }
+}
+
+export type Failure = 'adresseIntrouvable'
+
+type Command = Readonly<{
+  adresse: string
+  structureId: number
+}>

--- a/src/use-cases/commands/ModifierAdresseStructure.ts
+++ b/src/use-cases/commands/ModifierAdresseStructure.ts
@@ -13,6 +13,17 @@ export class ModifierAdresseStructure implements CommandHandler<Command> {
 
   async handle(command: Command): ResultAsync<Failure> {
     // La validation des permissions est effectuée au niveau de la Server Action.
+    const nomActuel = await this.#structureRepository.lireNomStructure(command.structureId)
+    if (nomActuel === null) {
+      return 'structureIntrouvable'
+    }
+
+    // Règle métier : on ne modifie pas une structure canonique (denomination_antenne null) —
+    // ni son nom, ni son adresse. L'édition ne vise que les structures « antenne ».
+    if (nomActuel.denominationAntenne === null) {
+      return 'structureCanoniqueNonModifiable'
+    }
+
     // On géocode l'adresse saisie via la BAN ; sans correspondance, on refuse.
     const geocode = await this.#banGeocodingGateway.geocoder({ adresse: command.adresse })
     if (geocode === null) {
@@ -38,7 +49,7 @@ export class ModifierAdresseStructure implements CommandHandler<Command> {
   }
 }
 
-export type Failure = 'adresseIntrouvable'
+export type Failure = 'adresseIntrouvable' | 'structureCanoniqueNonModifiable' | 'structureIntrouvable'
 
 type Command = Readonly<{
   adresse: string

--- a/src/use-cases/commands/shared/StructureRepository.ts
+++ b/src/use-cases/commands/shared/StructureRepository.ts
@@ -44,6 +44,8 @@ export type NomActuelStructure = Readonly<{
 }>
 
 export interface ModifierAdresseStructureRepository {
+  // null = structure introuvable. Sert à refuser la modification d'une structure canonique.
+  lireNomStructure(structureId: number): Promise<NomActuelStructure | null>
   // Re-pointe structure_administrative.adresse_id : on réutilise une adresse existante
   // (même clef_interop BAN) ou on en crée une nouvelle. On ne modifie JAMAIS une ligne adresse.
   rattacherAdresse(structureId: number, adresse: AdresseARattacher): Promise<void>

--- a/src/use-cases/commands/shared/StructureRepository.ts
+++ b/src/use-cases/commands/shared/StructureRepository.ts
@@ -43,6 +43,25 @@ export type NomActuelStructure = Readonly<{
   denominationAntenne: null | string
 }>
 
+export interface ModifierAdresseStructureRepository {
+  // Re-pointe structure_administrative.adresse_id : on réutilise une adresse existante
+  // (même clef_interop BAN) ou on en crée une nouvelle. On ne modifie JAMAIS une ligne adresse.
+  rattacherAdresse(structureId: number, adresse: AdresseARattacher): Promise<void>
+}
+
+export type AdresseARattacher = Readonly<{
+  clefInterop: string
+  codeBan: null | string
+  codeInsee: string
+  codePostal: string
+  latitude: number
+  longitude: number
+  nomCommune: string
+  nomVoie: null | string
+  numeroVoie: null | number
+  repetition: null | string
+}>
+
 export interface StructureRepository
   extends CreateStructureRepository, GetStructureBySiretEmployeuseRepository, GetStructureBySiretRepository {}
 


### PR DESCRIPTION
Refs #1570 — suite de #1634 (édition du nom, déjà mergée).

## Inclus
- Onglet **« Adresse »** dans la modale d'édition de structure, **saisie en 2 temps** :
  1. **Rechercher** → géocodage via l'**API Base Adresse Nationale** (`previsualiserAdresseAction`,
     côté serveur) → l'adresse normalisée trouvée s'affiche pour confirmation ;
  2. **Valider cette adresse** → re-pointage de `structure_administrative.adresse_id`.
  L'admin **prévisualise et confirme** la correspondance BAN avant toute écriture.
- **On ne modifie jamais une ligne `adresse`** : réutilisation d'une adresse de même
  `clef_interop`, sinon création d'une nouvelle ligne (géométrie PostGIS via `ST_Point`).
- **Réservé aux bêta-testeurs** (Administrateur dispositif + `is_beta_testeur`).
- **Structure canonique** (`denomination_antenne` null) : ni le nom ni l'adresse ne sont
  modifiables (notice à la place du formulaire ; refus côté command).
- Géocodage sans correspondance → message « Adresse introuvable ».
- **18 tests** (command, actions prévisualisation + mutation, repo intégration, composant).

## Évolution possible
Autocomplétion BAN en direct (suggestions pendant la frappe) — non retenue pour rester simple.

🤖 Generated with [Claude Code](https://claude.com/claude-code)