### PR TITLE
[Mon Inclusion Numérique] - Transfert/fusion des 6 notions d'une structure dans la vue de comparaison

### DIFF
--- a/src/app/api/actions/fusionnerStructuresAction.ts
+++ b/src/app/api/actions/fusionnerStructuresAction.ts
@@ -11,7 +11,11 @@ import { PrismaUtilisateurRepository } from '@/gateways/PrismaUtilisateurReposit
 import { FusionFailure, FusionnerStructures } from '@/use-cases/commands/FusionnerStructures'
 
 const MESSAGES_ECHEC: Readonly<Record<FusionFailure, string>> = {
+  collisionIdentifiantSource:
+    'Conflit d’identifiant de source (Coop, Idposte ou Aidants Connect) avec la survivante : tranchez-le avant de fusionner',
+  collisionMembreGouvernance: 'La survivante est déjà membre d’une gouvernance de la structure absorbée',
   fusionEchouee: 'La fusion a échoué, aucune modification effectuée',
+  fusionImpossibleCanoniqueAbsorbee: 'Une structure canonique (INSEE) ne peut pas être absorbée',
   fusionImpossibleMemeStructure: 'Impossible de fusionner une structure avec elle-même',
   structureIntrouvable: 'Structure introuvable ou déjà supprimée',
 }
@@ -36,10 +40,6 @@ export async function fusionnerStructuresAction(actionParams: ActionParams): Pro
   const echecs: Array<string> = []
   for (const idAbsorbee of actionParams.idsAbsorbees) {
     const result = await fusionnerStructures.handle({
-      champsRetenus: {
-        denominationAntenne: actionParams.denominationAntenne,
-        denominationSirene: actionParams.denominationSirene,
-      },
       idAbsorbee,
       idSurvivante: actionParams.idSurvivante,
       uidUtilisateur: sub,
@@ -59,16 +59,12 @@ export async function fusionnerStructuresAction(actionParams: ActionParams): Pro
 }
 
 type ActionParams = Readonly<{
-  denominationAntenne?: null | string
-  denominationSirene?: null | string
   idsAbsorbees: ReadonlyArray<number>
   idSurvivante: number
   path: string
 }>
 
 const validator = z.object({
-  denominationAntenne: z.string().nullish(),
-  denominationSirene: z.string().nullish(),
   idsAbsorbees: z
     .array(z.number().int().positive())
     .min(1, { message: 'Sélectionnez au moins une structure à fusionner' }),

--- a/src/app/api/actions/transfererNotionsStructureAction.test.ts
+++ b/src/app/api/actions/transfererNotionsStructureAction.test.ts
@@ -1,0 +1,90 @@
+import * as nextCache from 'next/cache'
+import { describe, expect, it } from 'vitest'
+
+import { transfererNotionsStructureAction } from './transfererNotionsStructureAction'
+import { utilisateurFactory } from '@/domain/testHelper'
+import * as ssoGateway from '@/gateways/NextAuthAuthentificationGateway'
+import { PrismaUtilisateurRepository } from '@/gateways/PrismaUtilisateurRepository'
+import { TransfererNotionsStructure } from '@/use-cases/commands/TransfererNotionsStructure'
+
+describe('transférer des notions de structure action', () => {
+  it('transfère les notions et purge le cache quand un administrateur autorisé confirme', async () => {
+    // GIVEN
+    vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce('userFooId')
+    vi.spyOn(PrismaUtilisateurRepository.prototype, 'get').mockResolvedValueOnce(
+      utilisateurFactory({ isBetaTesteur: true, role: 'Administrateur dispositif' })
+    )
+    vi.spyOn(TransfererNotionsStructure.prototype, 'handle').mockResolvedValueOnce('OK')
+    vi.spyOn(nextCache, 'revalidatePath').mockImplementationOnce(() => undefined)
+
+    // WHEN
+    const messages = await transfererNotionsStructureAction({
+      idCible: 3,
+      idSource: 7,
+      notions: ['membre', 'coop'],
+      path: '/structures-doublons/comparer',
+    })
+
+    // THEN
+    expect(TransfererNotionsStructure.prototype.handle).toHaveBeenCalledWith({
+      idCible: 3,
+      idSource: 7,
+      notions: ['membre', 'coop'],
+      uidUtilisateur: 'userFooId',
+    })
+    expect(nextCache.revalidatePath).toHaveBeenCalledWith('/structures-doublons/comparer')
+    expect(messages).toStrictEqual(['OK'])
+  })
+
+  it('renvoie une erreur de validation quand aucune notion n’est sélectionnée', async () => {
+    // WHEN
+    const messages = await transfererNotionsStructureAction({
+      idCible: 3,
+      idSource: 7,
+      notions: [],
+      path: '/structures-doublons/comparer',
+    })
+
+    // THEN
+    expect(messages).toStrictEqual(['Sélectionnez au moins une notion à transférer'])
+  })
+
+  it('refuse l’action à un utilisateur non administrateur autorisé', async () => {
+    // GIVEN
+    vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce('userFooId')
+    vi.spyOn(PrismaUtilisateurRepository.prototype, 'get').mockResolvedValueOnce(
+      utilisateurFactory({ isBetaTesteur: false, role: 'Gestionnaire structure' })
+    )
+
+    // WHEN
+    const messages = await transfererNotionsStructureAction({
+      idCible: 3,
+      idSource: 7,
+      notions: ['membre'],
+      path: '/structures-doublons/comparer',
+    })
+
+    // THEN
+    expect(messages).toStrictEqual(['Action réservée aux administrateurs autorisés'])
+  })
+
+  it('remonte le message d’échec métier renvoyé par la commande', async () => {
+    // GIVEN
+    vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce('userFooId')
+    vi.spyOn(PrismaUtilisateurRepository.prototype, 'get').mockResolvedValueOnce(
+      utilisateurFactory({ isBetaTesteur: true, role: 'Administrateur dispositif' })
+    )
+    vi.spyOn(TransfererNotionsStructure.prototype, 'handle').mockResolvedValueOnce('collisionMembreGouvernance')
+
+    // WHEN
+    const messages = await transfererNotionsStructureAction({
+      idCible: 3,
+      idSource: 7,
+      notions: ['membre'],
+      path: '/structures-doublons/comparer',
+    })
+
+    // THEN
+    expect(messages).toStrictEqual(['La structure cible est déjà membre d’une gouvernance de la structure source'])
+  })
+})

--- a/src/app/api/actions/transfererNotionsStructureAction.ts
+++ b/src/app/api/actions/transfererNotionsStructureAction.ts
@@ -1,0 +1,71 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { z } from 'zod'
+
+import prisma from '../../../../prisma/prismaClient'
+import { Administrateur } from '@/domain/Administrateur'
+import { getSessionSub } from '@/gateways/NextAuthAuthentificationGateway'
+import { PrismaStructureTransfertRepository } from '@/gateways/PrismaStructureTransfertRepository'
+import { PrismaUtilisateurRepository } from '@/gateways/PrismaUtilisateurRepository'
+import {
+  NotionCle,
+  TransfererNotionsStructure,
+  TransfertNotionsFailure,
+} from '@/use-cases/commands/TransfererNotionsStructure'
+
+const MESSAGES_ECHEC: Readonly<Record<TransfertNotionsFailure, string>> = {
+  aucuneNotionSelectionnee: 'Sélectionnez au moins une notion à transférer',
+  collisionIdentifiantSource:
+    'Un identifiant source (Coop, Idposte ou Aidants Connect) entre en collision avec la structure cible',
+  collisionMembreGouvernance: 'La structure cible est déjà membre d’une gouvernance de la structure source',
+  structureIntrouvable: 'Structure introuvable ou déjà supprimée',
+  transfertEchoue: 'Le transfert a échoué, aucune modification effectuée',
+  transfertImpossibleMemeStructure: 'La structure source et la structure cible sont identiques',
+}
+
+export async function transfererNotionsStructureAction(actionParams: ActionParams): Promise<ReadonlyArray<string>> {
+  const validationResult = validator.safeParse(actionParams)
+  if (validationResult.error) {
+    return validationResult.error.issues.map(({ message }) => message)
+  }
+
+  // Garde : seul un administrateur_dispositif porteur du flag beta testeur peut transférer.
+  const sub = await getSessionSub()
+  const utilisateur = await new PrismaUtilisateurRepository(prisma.utilisateurRecord).get(sub)
+  if (!(utilisateur instanceof Administrateur) || !utilisateur.isBetaTesteur) {
+    return ['Action réservée aux administrateurs autorisés']
+  }
+
+  const result = await new TransfererNotionsStructure(new PrismaStructureTransfertRepository()).handle({
+    idCible: actionParams.idCible,
+    idSource: actionParams.idSource,
+    notions: actionParams.notions,
+    uidUtilisateur: sub,
+  })
+
+  if (result !== 'OK') {
+    return [MESSAGES_ECHEC[result]]
+  }
+
+  revalidatePath(actionParams.path)
+
+  return ['OK']
+}
+
+type ActionParams = Readonly<{
+  idCible: number
+  idSource: number
+  notions: ReadonlyArray<NotionCle>
+  path: string
+}>
+
+// Les valeurs doivent rester alignées sur le type NotionCle (use-case TransfererNotionsStructure).
+const validator = z.object({
+  idCible: z.number().int().positive({ message: 'La structure cible doit être un entier positif' }),
+  idSource: z.number().int().positive({ message: 'La structure source doit être un entier positif' }),
+  notions: z
+    .array(z.enum(['aidantsConnect', 'contacts', 'coop', 'idposte', 'lieuInclusion', 'membre']))
+    .min(1, { message: 'Sélectionnez au moins une notion à transférer' }),
+  path: z.string().min(1, { message: 'Le chemin doit être renseigné' }),
+})

--- a/src/components/StructuresDoublons/ComparerStructures.test.tsx
+++ b/src/components/StructuresDoublons/ComparerStructures.test.tsx
@@ -3,26 +3,29 @@ import { describe, expect, it, vi } from 'vitest'
 
 import ComparerStructures from './ComparerStructures'
 import { renderComponent, stubbedServerAction } from '@/components/testHelper'
-import { ComparaisonViewModel, StructureComparaisonViewModel } from '@/presenters/comparaisonDoublonsPresenter'
+import {
+  ComparaisonViewModel,
+  ConceptViewModel,
+  StructureComparaisonViewModel,
+} from '@/presenters/comparaisonDoublonsPresenter'
 
-describe('examiner et fusionner un doublon', () => {
-  it('affiche les structures du groupe et le bouton de fusion', () => {
+describe('consolider un doublon (cible + transfert/fusion par notion)', () => {
+  it('affiche les cartes, prend la canonique comme cible par défaut et désactive Appliquer', () => {
     // WHEN
     renderComponent(<ComparerStructures viewModel={deuxStructures()} />)
 
-    // THEN
+    // THEN : la canonique (structure 3) est cible → carte source = structure 7.
     expect(screen.getByRole('heading', { level: 1, name: 'Examiner un doublon' })).toBeInTheDocument()
-    expect(screen.getByRole('heading', { level: 2, name: 'Conseil Départemental' })).toBeInTheDocument()
-    expect(screen.getByRole('heading', { level: 2, name: 'Antenne Sud' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Fusionner' })).toBeEnabled()
+    expect(screen.getByText('Concepts portés (destination)')).toBeInTheDocument()
+    expect(screen.getByLabelText(/Idposte/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Appliquer' })).toBeDisabled()
   })
 
-  it('confirme la fusion : appelle l’action avec survivante/absorbée, notifie et redirige', async () => {
+  it('coche une notion sur une source et la transfère via l’action de transfert', async () => {
     // GIVEN
-    const fusionnerStructuresAction = stubbedServerAction(['OK'])
+    const transfererNotionsStructureAction = stubbedServerAction(['OK'])
     const push = vi.fn<() => void>()
     renderComponent(<ComparerStructures viewModel={deuxStructures()} />, {
-      fusionnerStructuresAction,
       pathname: '/structures-doublons/comparer',
       router: {
         back: vi.fn<() => void>(),
@@ -32,94 +35,118 @@ describe('examiner et fusionner un doublon', () => {
         refresh: vi.fn<() => void>(),
         replace: vi.fn<() => void>(),
       },
+      transfererNotionsStructureAction,
     })
 
     // WHEN
-    fireEvent.click(screen.getByRole('button', { name: 'Fusionner' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Confirmer la fusion' }))
+    fireEvent.click(screen.getByLabelText(/Idposte/))
+    fireEvent.click(screen.getByRole('button', { name: 'Appliquer' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Confirmer' }))
 
     // THEN
-    const notification = await screen.findByRole('status')
-    expect(notification.textContent).toBe('Structures fusionnées')
-    expect(fusionnerStructuresAction).toHaveBeenCalledWith({
-      idsAbsorbees: [7],
-      idSurvivante: 3,
+    await screen.findByRole('status')
+    expect(transfererNotionsStructureAction).toHaveBeenCalledWith({
+      idCible: 3,
+      idSource: 7,
+      notions: ['idposte'],
       path: '/structures-doublons/comparer',
     })
     expect(push).toHaveBeenCalledWith('/structures-doublons')
   })
 
-  it('fusionne plusieurs structures dans la survivante', async () => {
+  it('la surcoche « Fusionner » coche toutes les notions et déclenche la fusion', async () => {
     // GIVEN
     const fusionnerStructuresAction = stubbedServerAction(['OK'])
-    renderComponent(<ComparerStructures viewModel={troisStructures()} />, {
+    renderComponent(<ComparerStructures viewModel={deuxStructures()} />, {
       fusionnerStructuresAction,
       pathname: '/structures-doublons/comparer',
     })
 
-    // WHEN : la 2e carte est absorbée par défaut, on ajoute la 3e
-    fireEvent.click(screen.getAllByRole('radio', { name: 'Fusionner dans la survivante' })[2])
-    fireEvent.click(screen.getByRole('button', { name: 'Fusionner' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Confirmer la fusion' }))
+    // WHEN
+    fireEvent.click(screen.getByLabelText(/Fusionner/))
+    fireEvent.click(screen.getByRole('button', { name: 'Appliquer' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Confirmer' }))
 
     // THEN
     await screen.findByRole('status')
     expect(fusionnerStructuresAction).toHaveBeenCalledWith({
-      idsAbsorbees: [7, 11],
+      idsAbsorbees: [7],
       idSurvivante: 3,
       path: '/structures-doublons/comparer',
     })
   })
 
-  it('affiche une notification d’erreur si la fusion échoue', async () => {
+  it('une carte canonique non-cible ne propose aucune coche (cible uniquement)', () => {
     // GIVEN
-    const fusionnerStructuresAction = stubbedServerAction(['Structure introuvable ou déjà supprimée'])
-    renderComponent(<ComparerStructures viewModel={deuxStructures()} />, { fusionnerStructuresAction })
+    renderComponent(<ComparerStructures viewModel={deuxStructures()} />)
+
+    // WHEN : on désigne la structure 7 (antenne) comme cible → la canonique (3) devient une carte non-cible.
+    fireEvent.click(screen.getAllByRole('radio', { name: 'Cible (destination)' })[1])
+
+    // THEN
+    expect(screen.getByText(/jamais transférée ni absorbée/)).toBeInTheDocument()
+  })
+
+  it('désactive une notion dont l’id scalaire entre en collision avec la cible', () => {
+    // GIVEN cible (3) et source (7) portent Aidants Connect avec un id externe différent.
+    const cible = carte({ concepts: [conceptAc('ac-cible')], denomination: 'Cible', estCanonique: true, id: 3 })
+    const source = carte({ concepts: [conceptAc('ac-source')], denomination: 'Source', id: 7 })
 
     // WHEN
-    fireEvent.click(screen.getByRole('button', { name: 'Fusionner' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Confirmer la fusion' }))
+    renderComponent(<ComparerStructures viewModel={[cible, source]} />)
+
+    // THEN
+    expect(screen.getByLabelText(/Aidants Connect/)).toBeDisabled()
+    expect(screen.getByText(/Identifiant déjà porté par la cible/)).toBeInTheDocument()
+  })
+
+  it('désactive un id scalaire déjà réclamé par une autre carte source', () => {
+    // GIVEN cible sans coop (3) + deux sources (7, 11) portant chacune coop.
+    const cible = carte({ denomination: 'Cible', estCanonique: true, id: 3 })
+    const sourceA = carte({ concepts: [conceptCoop('coop-a')], denomination: 'Source A', id: 7 })
+    const sourceB = carte({ concepts: [conceptCoop('coop-b')], denomination: 'Source B', id: 11 })
+    renderComponent(<ComparerStructures viewModel={[cible, sourceA, sourceB]} />)
+
+    // WHEN : on coche Coop sur la source A.
+    fireEvent.click(screen.getAllByLabelText(/Coop/)[0])
+
+    // THEN : Coop est désormais désactivé sur la source B.
+    expect(screen.getAllByLabelText(/Coop/)[1]).toBeDisabled()
+  })
+
+  it('agrège fusion et transfert et notifie en cas d’échec partiel', async () => {
+    // GIVEN la fusion réussit, le transfert échoue.
+    const fusionnerStructuresAction = stubbedServerAction(['OK'])
+    const transfererNotionsStructureAction = stubbedServerAction(['Conflit'])
+    renderComponent(<ComparerStructures viewModel={troisStructures()} />, {
+      fusionnerStructuresAction,
+      pathname: '/structures-doublons/comparer',
+      transfererNotionsStructureAction,
+    })
+
+    // WHEN : fusionner la 7, transférer une notion de la 11.
+    fireEvent.click(screen.getAllByLabelText(/Fusionner/)[0]) // surcoche de la 1re source (7)
+    fireEvent.click(screen.getByLabelText(/Coop/)) // notion coop de la 2e source (11)
+    fireEvent.click(screen.getByRole('button', { name: 'Appliquer' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Confirmer' }))
 
     // THEN
     const notification = await screen.findByRole('alert')
-    expect(notification.textContent).toBe('Erreur : Structure introuvable ou déjà supprimée')
+    expect(notification.textContent).toContain('Erreur :')
+    expect(fusionnerStructuresAction).toHaveBeenCalledWith({
+      idsAbsorbees: [7],
+      idSurvivante: 3,
+      path: '/structures-doublons/comparer',
+    })
+    expect(transfererNotionsStructureAction).toHaveBeenCalledWith({
+      idCible: 3,
+      idSource: 11,
+      notions: ['coop'],
+      path: '/structures-doublons/comparer',
+    })
   })
 
-  it('marque la structure canonique d’un tag et l’autre comme antenne', () => {
-    // WHEN
-    renderComponent(<ComparerStructures viewModel={deuxStructures()} />)
-
-    // THEN
-    expect(screen.getByText('Canonique')).toBeInTheDocument()
-    expect(screen.getByText('Antenne')).toBeInTheDocument()
-  })
-
-  it('marque d’un tag Membre la structure qui porte un membre de gouvernance', () => {
-    // WHEN
-    renderComponent(<ComparerStructures viewModel={deuxStructures()} />)
-
-    // THEN
-    expect(screen.getByText('Membre')).toBeInTheDocument()
-  })
-
-  it('marque d’un tag Lieu d’inclusion la structure associée à un lieu d’inclusion', () => {
-    // WHEN
-    renderComponent(<ComparerStructures viewModel={deuxStructures()} />)
-
-    // THEN
-    expect(screen.getByText('Lieu d’inclusion rattaché')).toBeInTheDocument()
-  })
-
-  it('affiche le détail des rattachements de chaque structure', () => {
-    // WHEN
-    renderComponent(<ComparerStructures viewModel={deuxStructures()} />)
-
-    // THEN
-    expect(screen.getAllByText('Détail des rattachements')).toHaveLength(2)
-    expect(screen.getAllByText('Postes :', { exact: false }).length).toBeGreaterThan(0)
-  })
-
-  it('bascule sur la vue Distances et affiche la matrice de distances entre structures', () => {
+  it('bascule sur la vue Distances et affiche la matrice', () => {
     // GIVEN
     renderComponent(<ComparerStructures viewModel={deuxStructures()} />)
 
@@ -127,48 +154,60 @@ describe('examiner et fusionner un doublon', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Distances' }))
 
     // THEN
-    expect(screen.getByRole('columnheader', { name: 'Conseil Départemental' })).toBeInTheDocument()
-    expect(screen.getByRole('columnheader', { name: 'Antenne Sud' })).toBeInTheDocument()
-    expect(screen.queryByRole('radio', { name: 'Conserver (survivante)' })).not.toBeInTheDocument()
-  })
-
-  it('« Ne pas toucher » retire la carte de la fusion et désactive le bouton', () => {
-    // GIVEN
-    renderComponent(<ComparerStructures viewModel={deuxStructures()} />)
-
-    // WHEN : on retire la survivante par défaut (1re carte)
-    fireEvent.click(screen.getAllByRole('radio', { name: 'Ne pas toucher' })[0])
-
-    // THEN
-    expect(screen.getByRole('button', { name: 'Fusionner' })).toBeDisabled()
+    expect(screen.getByRole('columnheader', { name: 'Cible' })).toBeInTheDocument()
+    expect(screen.queryByRole('checkbox', { name: /Fusionner/ })).not.toBeInTheDocument()
   })
 })
 
 function deuxStructures(): ComparaisonViewModel {
-  return [structureComparaison(3, 'Conseil Départemental'), structureComparaison(7, 'Antenne Sud')]
+  return [
+    carte({ denomination: 'Cible', estCanonique: true, id: 3 }),
+    carte({ concepts: [conceptIdposte(), conceptAc('ac-xyz')], denomination: 'Antenne', id: 7 }),
+  ]
 }
 
 function troisStructures(): ComparaisonViewModel {
   return [
-    structureComparaison(3, 'Conseil Départemental'),
-    structureComparaison(7, 'Antenne Sud'),
-    structureComparaison(11, 'Antenne Est'),
+    carte({ denomination: 'Cible', estCanonique: true, id: 3 }),
+    carte({ concepts: [conceptIdposte()], denomination: 'Source A', id: 7 }),
+    carte({ concepts: [conceptCoop('coop-b')], denomination: 'Source B', id: 11 }),
   ]
 }
 
-function structureComparaison(id: number, denomination: string): StructureComparaisonViewModel {
+function conceptIdposte(): ConceptViewModel {
   return {
-    adresse: '1 Place Chatelet 28000 Chartres',
+    cle: 'idposte',
+    idExterne: null,
+    label: 'Idposte',
+    present: true,
+    resume: '1 poste · 0 contrat · 0 affectation',
+  }
+}
+
+function conceptAc(idExterne: string): ConceptViewModel {
+  return { cle: 'aidantsConnect', idExterne, label: 'Aidants Connect', present: true, resume: '0 aidant' }
+}
+
+function conceptCoop(idExterne: string): ConceptViewModel {
+  return { cle: 'coop', idExterne, label: 'Coop', present: true, resume: '1 affectation' }
+}
+
+function carte(
+  overrides: Partial<StructureComparaisonViewModel> & Readonly<{ denomination: string; id: number }>
+): StructureComparaisonViewModel {
+  const notionsVides: ReadonlyArray<ConceptViewModel> = []
+  return {
+    adresse: '1 rue de Test 28000 Chartres',
     champs: [{ label: 'SIRET', valeur: '22280001300013' }],
-    denomination,
-    denominationSirene: denomination,
-    estAssocieLieuInclusion: id === 7,
-    estCanonique: id === 3,
-    estMembre: id === 7,
-    id,
-    latitude: id === 3 ? 48.45 : 48.5,
-    longitude: id === 3 ? 1.49 : 1.6,
-    rattachements: [{ label: 'Postes', nombre: 15 }],
-    rattachementsTotal: 15,
+    concepts: notionsVides,
+    denominationSirene: overrides.denomination,
+    estAssocieLieuInclusion: false,
+    estCanonique: false,
+    estMembre: false,
+    latitude: 48.45,
+    longitude: 1.49,
+    rattachements: [{ label: 'Postes', nombre: 1 }],
+    rattachementsTotal: 1,
+    ...overrides,
   }
 }

--- a/src/components/StructuresDoublons/ComparerStructures.tsx
+++ b/src/components/StructuresDoublons/ComparerStructures.tsx
@@ -8,84 +8,140 @@ import { Notification } from '../shared/Notification/Notification'
 import { clientContext } from '@/components/shared/ClientContext'
 import {
   ComparaisonViewModel,
+  ConceptViewModel,
   matriceDistances,
   MatriceDistancesViewModel,
   NiveauDistance,
   StructureComparaisonViewModel,
 } from '@/presenters/comparaisonDoublonsPresenter'
+import { NotionCle } from '@/use-cases/commands/TransfererNotionsStructure'
 
-type Choix = 'conserver' | 'fusionner' | 'ignorer'
+type RoleCarte = 'cible' | 'fusionner' | 'rien' | 'transferer'
 
 type Vue = 'comparer' | 'distances'
 
-const CHOIX_OPTIONS: ReadonlyArray<Readonly<{ label: string; valeur: Choix }>> = [
-  { label: 'Conserver (survivante)', valeur: 'conserver' },
-  { label: 'Fusionner dans la survivante', valeur: 'fusionner' },
-  { label: 'Ne pas toucher', valeur: 'ignorer' },
-]
+// État de sélection d'une carte source : les notions cochées + le flag « fusionner » (surcoche qui
+// coche toutes les notions et marque la structure pour suppression). La carte cible n'a pas d'état.
+type EtatCarte = Readonly<{
+  fusionner: boolean
+  notions: ReadonlyArray<NotionCle>
+}>
+
+const ETAT_VIDE: EtatCarte = { fusionner: false, notions: [] }
 
 export default function ComparerStructures({ viewModel }: Props): ReactElement {
-  const { fusionnerStructuresAction, pathname, router } = useContext(clientContext)
+  const { fusionnerStructuresAction, pathname, router, transfererNotionsStructureAction } = useContext(clientContext)
 
-  const [idSurvivante, setIdSurvivante] = useState(viewModel[0]?.id ?? 0)
-  const [idsAbsorbees, setIdsAbsorbees] = useState<ReadonlyArray<number>>(
-    viewModel.slice(1, 2).map((structure) => structure.id)
-  )
+  // Cible par défaut : la canonique (INSEE) si elle existe — c'est la destination naturelle.
+  const canoniqueParDefaut = viewModel.find((structure) => structure.estCanonique)
+  const [idCible, setIdCible] = useState(canoniqueParDefaut?.id ?? viewModel[0].id)
+  const [etats, setEtats] = useState<Readonly<Record<number, EtatCarte | undefined>>>({})
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [vue, setVue] = useState<Vue>('comparer')
 
-  const survivante = viewModel.find((structure) => structure.id === idSurvivante)
-  const absorbees = viewModel.filter((structure) => idsAbsorbees.includes(structure.id))
-  const fusionPossible = survivante !== undefined && absorbees.length > 0
+  const cible = viewModel.find((structure) => structure.id === idCible)
+  const cartesFusion = viewModel.filter((structure) => etats[structure.id]?.fusionner)
+  const cartesTransfert = viewModel.filter((structure) => {
+    const etat = etats[structure.id]
+    return etat !== undefined && !etat.fusionner && etat.notions.length > 0
+  })
+  const operationPossible = cible !== undefined && (cartesFusion.length > 0 || cartesTransfert.length > 0)
 
-  function choixDe(id: number): Choix {
-    if (id === idSurvivante) {
-      return 'conserver'
-    }
-    if (idsAbsorbees.includes(id)) {
-      return 'fusionner'
-    }
-    return 'ignorer'
+  function etatDe(id: number): EtatCarte {
+    return etats[id] ?? ETAT_VIDE
   }
 
-  // La survivante est unique ; on peut en revanche fusionner PLUSIEURS structures dans celle-ci.
-  // Choisir un rôle sur une carte la retire des autres rôles. « Ne pas toucher » = neutre.
-  function definirChoix(id: number, choix: Choix): void {
-    if (choix === 'conserver') {
-      setIdSurvivante(id)
-      setIdsAbsorbees((ids) => ids.filter((autre) => autre !== id))
-    } else if (choix === 'fusionner') {
-      setIdsAbsorbees((ids) => (ids.includes(id) ? ids : [...ids, id]))
-      if (id === idSurvivante) {
-        setIdSurvivante(0)
-      }
-    } else {
-      setIdsAbsorbees((ids) => ids.filter((autre) => autre !== id))
-      if (id === idSurvivante) {
-        setIdSurvivante(0)
-      }
+  // Un id de source (coop/tp/ac) ne peut alimenter la cible qu'une fois : indisponible s'il entre en
+  // collision avec celui de la cible, ou s'il est déjà réclamé par une autre carte cochée.
+  function idScalaireDisponible(concept: ConceptViewModel, idCarte: number): boolean {
+    if (concept.idExterne === null) {
+      return true
     }
-  }
+    const conceptCible = cible?.concepts.find((autre) => autre.cle === concept.cle)
+    if (conceptCible !== undefined && conceptCible.idExterne !== null && conceptCible.idExterne !== concept.idExterne) {
+      return false
+    }
 
-  async function confirmerFusion(): Promise<void> {
-    if (!fusionPossible) {
-      return
-    }
-    setIsSubmitting(true)
-    const messages = await fusionnerStructuresAction({
-      idsAbsorbees,
-      idSurvivante,
-      path: pathname,
+    return !viewModel.some((autre) => {
+      if (autre.id === idCarte || autre.id === idCible) {
+        return false
+      }
+      const etatAutre = etats[autre.id]
+      if (etatAutre === undefined || !etatAutre.notions.includes(concept.cle)) {
+        return false
+      }
+      const conceptAutre = autre.concepts.find((candidat) => candidat.cle === concept.cle)
+
+      return conceptAutre !== undefined && conceptAutre.idExterne !== null
     })
+  }
+
+  function definirCible(id: number): void {
+    setIdCible(id)
+    setEtats((precedent) => sansClef(precedent, id))
+  }
+
+  function basculerFusion(structure: StructureComparaisonViewModel): void {
+    setEtats((precedent) => {
+      if (precedent[structure.id]?.fusionner) {
+        return sansClef(precedent, structure.id)
+      }
+      const notions = structure.concepts
+        .filter((concept) => concept.present && idScalaireDisponible(concept, structure.id))
+        .map((concept) => concept.cle)
+
+      return { ...precedent, [structure.id]: { fusionner: true, notions } }
+    })
+  }
+
+  function basculerNotion(structure: StructureComparaisonViewModel, cle: NotionCle): void {
+    setEtats((precedent) => {
+      const actuel = precedent[structure.id] ?? ETAT_VIDE
+      const notions = actuel.notions.includes(cle)
+        ? actuel.notions.filter((autre) => autre !== cle)
+        : [...actuel.notions, cle]
+      if (notions.length === 0) {
+        return sansClef(precedent, structure.id)
+      }
+
+      return { ...precedent, [structure.id]: { fusionner: false, notions } }
+    })
+  }
+
+  async function appliquer(): Promise<void> {
+    setIsSubmitting(true)
+    const echecs: Array<string> = []
+
+    if (cartesFusion.length > 0) {
+      const messages = await fusionnerStructuresAction({
+        idsAbsorbees: cartesFusion.map((structure) => structure.id),
+        idSurvivante: idCible,
+        path: pathname,
+      })
+      if (!messages.includes('OK')) {
+        echecs.push(...messages)
+      }
+    }
+    for (const carte of cartesTransfert) {
+      const messages = await transfererNotionsStructureAction({
+        idCible,
+        idSource: carte.id,
+        notions: [...etatDe(carte.id).notions],
+        path: pathname,
+      })
+      if (!messages.includes('OK')) {
+        echecs.push(`${carte.denomination} : ${messages.join(', ')}`)
+      }
+    }
+
     setIsSubmitting(false)
     setIsModalOpen(false)
-
-    if (messages.includes('OK')) {
-      Notification('success', { description: 'fusionnées', title: 'Structures ' })
+    if (echecs.length === 0) {
+      Notification('success', { description: 'appliquées', title: 'Opérations ' })
       router.push('/structures-doublons')
     } else {
-      Notification('error', { description: messages.join(', '), title: 'Erreur : ' })
+      Notification('error', { description: echecs.join(' · '), title: 'Erreur : ' })
     }
   }
 
@@ -93,8 +149,9 @@ export default function ComparerStructures({ viewModel }: Props): ReactElement {
     <section>
       <h1>Examiner un doublon</h1>
       <p className="fr-text--sm fr-text-mention--grey">
-        Choisissez la structure à conserver (survivante) et celle à fusionner. Tous les rattachements de la structure
-        absorbée seront déplacés vers la survivante, qui conserve ses propres identifiants (SIRET, RNA…).
+        Choisissez la structure <span className="fr-text--bold">cible (destination)</span>, puis sur chaque autre carte
+        cochez les notions à transférer — ou « Fusionner » pour tout déplacer et supprimer la structure. Une canonique
+        (INSEE) ne peut être que cible.
       </p>
 
       <div className="fr-btns-group fr-btns-group--inline fr-btns-group--sm fr-mb-2w">
@@ -123,9 +180,17 @@ export default function ComparerStructures({ viewModel }: Props): ReactElement {
           {viewModel.map((structure) => (
             <div className="fr-col-12 fr-col-md-6" key={structure.id}>
               <CarteStructure
-                choix={choixDe(structure.id)}
-                onChoix={(choix) => {
-                  definirChoix(structure.id, choix)
+                estCible={structure.id === idCible}
+                etat={etatDe(structure.id)}
+                idScalaireDisponible={(concept) => idScalaireDisponible(concept, structure.id)}
+                onCible={() => {
+                  definirCible(structure.id)
+                }}
+                onToggleFusion={() => {
+                  basculerFusion(structure)
+                }}
+                onToggleNotion={(cle) => {
+                  basculerNotion(structure, cle)
                 }}
                 structure={structure}
               />
@@ -139,35 +204,42 @@ export default function ComparerStructures({ viewModel }: Props): ReactElement {
       <div className="fr-mt-4w">
         <button
           className="fr-btn"
-          disabled={!fusionPossible}
+          disabled={!operationPossible}
           onClick={() => {
             setIsModalOpen(true)
           }}
           type="button"
         >
-          Fusionner
+          Appliquer
         </button>
-        {fusionPossible ? null : (
+        {operationPossible ? null : (
           <p className="fr-text--sm fr-text-mention--grey fr-mt-1w">
-            Sélectionnez une structure à conserver et au moins une à fusionner.
+            Choisissez une cible et, sur au moins une autre carte, une notion à transférer ou « Fusionner ».
           </p>
         )}
       </div>
 
       <ConfirmationModal
-        confirmLabel={isSubmitting ? 'Fusion en cours…' : 'Confirmer la fusion'}
+        confirmLabel={isSubmitting ? 'Application…' : 'Confirmer'}
         confirmVariant="error"
-        id="confirmer-fusion"
+        id="confirmer-consolidation"
         isOpen={isModalOpen}
         onCancel={() => {
           setIsModalOpen(false)
         }}
         onConfirm={() => {
-          void confirmerFusion()
+          void appliquer()
         }}
-        title="Confirmer la fusion des structures"
+        title="Confirmer les opérations"
       >
-        {fusionPossible ? <AvertissementFusion absorbees={absorbees} survivante={survivante} /> : null}
+        {cible === undefined ? null : (
+          <RecapitulatifOperations
+            cartesFusion={cartesFusion}
+            cartesTransfert={cartesTransfert}
+            cible={cible}
+            etatDe={etatDe}
+          />
+        )}
       </ConfirmationModal>
     </section>
   )
@@ -226,18 +298,94 @@ function MatriceDistances({ matrice }: Readonly<{ matrice: MatriceDistancesViewM
 }
 
 function CarteStructure({
-  choix,
-  onChoix,
+  estCible,
+  etat,
+  idScalaireDisponible,
+  onCible,
+  onToggleFusion,
+  onToggleNotion,
   structure,
 }: Readonly<{
-  choix: Choix
-  onChoix(choix: Choix): void
+  estCible: boolean
+  etat: EtatCarte
+  idScalaireDisponible(concept: ConceptViewModel): boolean
+  onCible(): void
+  onToggleFusion(): void
+  onToggleNotion(cle: NotionCle): void
   structure: StructureComparaisonViewModel
 }>): ReactElement {
   const rattachementsDetail = structure.rattachements.filter((rattachement) => rattachement.nombre > 0)
+  const conceptsPortes = structure.concepts.filter((concept) => concept.present)
+
+  function roleDe(): RoleCarte {
+    if (estCible) {
+      return 'cible'
+    }
+    if (etat.fusionner) {
+      return 'fusionner'
+    }
+
+    return etat.notions.length > 0 ? 'transferer' : 'rien'
+  }
+
+  function controles(): ReactElement {
+    if (estCible) {
+      return <ConceptsPortes conceptsPortes={conceptsPortes} legende="Concepts portés (destination)" />
+    }
+    if (structure.estCanonique) {
+      return (
+        <p className="fr-text--xs fr-text-mention--grey fr-mt-2w">
+          Structure canonique (INSEE) : elle ne peut être que cible, jamais transférée ni absorbée.
+        </p>
+      )
+    }
+    if (conceptsPortes.length === 0) {
+      return <p className="fr-text--sm fr-text-mention--grey fr-mt-2w">Aucune notion à transférer.</p>
+    }
+
+    return (
+      <fieldset className="fr-fieldset fr-mt-2w">
+        <legend className="fr-fieldset__legend fr-text--bold">Notions à déplacer vers la cible</legend>
+        <div className="fr-fieldset__content">
+          <div className="fr-checkbox-group">
+            <input checked={etat.fusionner} id={`fusion-${structure.id}`} onChange={onToggleFusion} type="checkbox" />
+            <label className="fr-label" htmlFor={`fusion-${structure.id}`}>
+              Fusionner (tout transférer puis supprimer la structure)
+            </label>
+          </div>
+          {conceptsPortes.map((concept) => {
+            const disponible = idScalaireDisponible(concept)
+            return (
+              <div className="fr-checkbox-group" key={concept.cle}>
+                <input
+                  checked={etat.notions.includes(concept.cle)}
+                  disabled={!disponible}
+                  id={`notion-${concept.cle}-${structure.id}`}
+                  onChange={() => {
+                    onToggleNotion(concept.cle)
+                  }}
+                  type="checkbox"
+                />
+                <label className="fr-label" htmlFor={`notion-${concept.cle}-${structure.id}`}>
+                  {concept.label} — {concept.resume}
+                  {concept.idExterne === null ? null : ` · id ${concept.idExterne}`}
+                  {disponible ? null : (
+                    <span className="fr-error-text">
+                      Identifiant déjà porté par la cible ou réclamé par une autre structure. Avant d’abandonner cet id,
+                      vérifiez qu’il n’existe plus côté source externe, sinon le doublon réapparaîtra au resync.
+                    </span>
+                  )}
+                </label>
+              </div>
+            )
+          })}
+        </div>
+      </fieldset>
+    )
+  }
 
   return (
-    <div className="fr-p-3w" style={{ borderStyle: 'solid', borderWidth: 1, ...styleCarte(choix) }}>
+    <div className="fr-p-3w" style={{ borderStyle: 'solid', borderWidth: 1, ...styleCarte(roleDe()) }}>
       <p className="fr-mb-1w">
         {structure.estCanonique ? (
           <span className="fr-badge fr-badge--no-icon fr-badge--sm fr-badge--success">Canonique</span>
@@ -283,94 +431,125 @@ function CarteStructure({
 
       <fieldset className="fr-fieldset fr-mt-2w">
         <div className="fr-fieldset__content">
-          {CHOIX_OPTIONS.map((option) => (
-            <div className="fr-radio-group" key={option.valeur}>
-              <input
-                checked={choix === option.valeur}
-                id={`choix-${option.valeur}-${structure.id}`}
-                name={`choix-${structure.id}`}
-                onChange={() => {
-                  onChoix(option.valeur)
-                }}
-                type="radio"
-              />
-              <label className="fr-label" htmlFor={`choix-${option.valeur}-${structure.id}`}>
-                {option.label}
-              </label>
-            </div>
-          ))}
+          <div className="fr-radio-group">
+            <input
+              checked={estCible}
+              id={`cible-${structure.id}`}
+              name="cible-doublon"
+              onChange={onCible}
+              type="radio"
+            />
+            <label className="fr-label" htmlFor={`cible-${structure.id}`}>
+              Cible (destination)
+            </label>
+          </div>
         </div>
       </fieldset>
+
+      {controles()}
     </div>
   )
 }
 
-function AvertissementFusion({
-  absorbees,
-  survivante,
+function ConceptsPortes({
+  conceptsPortes,
+  legende,
 }: Readonly<{
-  absorbees: ReadonlyArray<StructureComparaisonViewModel>
-  survivante: StructureComparaisonViewModel
+  conceptsPortes: ReadonlyArray<ConceptViewModel>
+  legende: string
 }>): ReactElement {
-  const rattachementsDeplaces = agregerRattachements(absorbees)
-
   return (
     <>
-      <div className="fr-alert fr-alert--warning fr-mb-2w">
-        <p>
-          Chaque structure ci-dessous sera marquée comme supprimée (réversible via le journal d&apos;audit) et ses
-          rattachements déplacés vers <span className="fr-text--bold">{survivante.denomination}</span> :
-        </p>
-        <ul>
-          {absorbees.map((absorbee) => (
-            <li key={absorbee.id}>
-              <span className="fr-text--bold">{absorbee.denomination}</span>
-            </li>
-          ))}
-        </ul>
-      </div>
-
-      <p className="fr-text--bold">Ce que la fusion implique :</p>
-      {rattachementsDeplaces.length === 0 ? (
-        <p>Aucun rattachement à déplacer.</p>
+      <p className="fr-text--sm fr-text--bold fr-mb-1v fr-mt-2w">{legende}</p>
+      {conceptsPortes.length === 0 ? (
+        <p className="fr-text--sm fr-text-mention--grey">Aucun concept porté — structure candidate à la suppression.</p>
       ) : (
-        <ul>
-          {rattachementsDeplaces.map((rattachement) => (
-            <li key={rattachement.label}>
-              {rattachement.nombre} {rattachement.label.toLowerCase()}
+        <ul className="fr-text--sm">
+          {conceptsPortes.map((concept) => (
+            <li key={concept.cle}>
+              {concept.label} : <span className="fr-text--bold">{concept.resume}</span>
+              {concept.idExterne === null ? null : (
+                <span className="fr-text-mention--grey"> · id {concept.idExterne}</span>
+              )}
             </li>
           ))}
         </ul>
       )}
+    </>
+  )
+}
+
+function RecapitulatifOperations({
+  cartesFusion,
+  cartesTransfert,
+  cible,
+  etatDe,
+}: Readonly<{
+  cartesFusion: ReadonlyArray<StructureComparaisonViewModel>
+  cartesTransfert: ReadonlyArray<StructureComparaisonViewModel>
+  cible: StructureComparaisonViewModel
+  etatDe(id: number): EtatCarte
+}>): ReactElement {
+  return (
+    <>
+      <div className="fr-alert fr-alert--warning fr-mb-2w">
+        <p>
+          Destination : <span className="fr-text--bold">{cible.denomination}</span>. Elle conserve tous ses champs
+          descriptifs (rien n’est repris des structures source).
+        </p>
+      </div>
+
+      {cartesFusion.length === 0 ? null : (
+        <>
+          <p className="fr-text--bold">Fusion (déplacement total puis suppression) :</p>
+          <ul>
+            {cartesFusion.map((structure) => (
+              <li key={structure.id}>{structure.denomination}</li>
+            ))}
+          </ul>
+        </>
+      )}
+
+      {cartesTransfert.length === 0 ? null : (
+        <>
+          <p className="fr-text--bold">Transferts partiels :</p>
+          <ul>
+            {cartesTransfert.map((structure) => (
+              <li key={structure.id}>
+                {structure.denomination} — {etatDe(structure.id).notions.length} notion
+                {etatDe(structure.id).notions.length > 1 ? 's' : ''}
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
 
       <p className="fr-text--sm fr-text-mention--grey">
-        Les identifiants uniques des structures absorbées (SIRET, RNA, identifiants Coop/AC…) seront conservés dans le
-        journal d&apos;audit puis perdus. Cette action est tracée.
+        Les identifiants de source (Coop, Idposte, AC) sont transférés vers la cible ; les identifiants d’identité des
+        structures fusionnées (SIRET, RIDET, RNA) sont consignés au journal d’audit puis perdus. Action tracée et
+        réversible via le journal.
       </p>
     </>
   )
 }
 
-// Cumule les rattachements (par libellé) de toutes les absorbées, ne garde que les non nuls.
-function agregerRattachements(
-  absorbees: ReadonlyArray<StructureComparaisonViewModel>
-): ReadonlyArray<Readonly<{ label: string; nombre: number }>> {
-  const totaux = new Map<string, number>()
-  for (const absorbee of absorbees) {
-    for (const rattachement of absorbee.rattachements) {
-      totaux.set(rattachement.label, (totaux.get(rattachement.label) ?? 0) + rattachement.nombre)
-    }
-  }
-
-  return Array.from(totaux, ([label, nombre]) => ({ label, nombre })).filter((rattachement) => rattachement.nombre > 0)
+// Retire l'entrée d'une structure de l'état (devenue cible, ou plus aucune notion cochée).
+function sansClef(
+  record: Readonly<Record<number, EtatCarte | undefined>>,
+  id: number
+): Readonly<Record<number, EtatCarte | undefined>> {
+  return Object.fromEntries(Object.entries(record).filter(([clef]) => Number(clef) !== id))
 }
 
-// Couleur de carte selon le rôle : conservée (vert), fusionnée (bleu), non touchée (gris).
-function styleCarte(choix: Choix): CSSProperties {
-  if (choix === 'conserver') {
+// Couleur de carte selon le rôle : cible (vert), fusionnée (rouge), transfert partiel (bleu), neutre (gris).
+function styleCarte(role: RoleCarte): CSSProperties {
+  if (role === 'cible') {
     return { backgroundColor: 'var(--background-contrast-success)', borderColor: 'var(--border-plain-success)' }
   }
-  if (choix === 'fusionner') {
+  if (role === 'fusionner') {
+    return { backgroundColor: 'var(--background-contrast-error)', borderColor: 'var(--border-plain-error)' }
+  }
+  if (role === 'transferer') {
     return { backgroundColor: 'var(--background-contrast-info)', borderColor: 'var(--border-plain-info)' }
   }
 

--- a/src/components/shared/ClientContext.tsx
+++ b/src/components/shared/ClientContext.tsx
@@ -48,6 +48,7 @@ import { supprimerUneNotePriveeAction } from '@/app/api/actions/supprimerUneNote
 import { supprimerUnMembreOuCandidatAction } from '@/app/api/actions/supprimerUnMembreOuCandidatAction'
 import { supprimerUnUtilisateurAction } from '@/app/api/actions/supprimerUnUtilisateurAction'
 import { transfererMembreAction } from '@/app/api/actions/transfererMembreAction'
+import { transfererNotionsStructureAction } from '@/app/api/actions/transfererNotionsStructureAction'
 import { SessionUtilisateurViewModel } from '@/presenters/sessionUtilisateurPresenter'
 
 export default function ClientContext({
@@ -110,6 +111,7 @@ export default function ClientContext({
       supprimerUnMembreOuCandidatAction,
       supprimerUnUtilisateurAction,
       transfererMembreAction,
+      transfererNotionsStructureAction,
       utilisateursParPage,
     }),
     [pathname, roles, router, searchParams, sessionUtilisateurViewModel, utilisateursParPage]
@@ -169,6 +171,7 @@ export type ClientContextProviderValue = Readonly<{
   supprimerUnMembreOuCandidatAction: typeof supprimerUnMembreOuCandidatAction
   supprimerUnUtilisateurAction: typeof supprimerUnUtilisateurAction
   transfererMembreAction: typeof transfererMembreAction
+  transfererNotionsStructureAction: typeof transfererNotionsStructureAction
   utilisateursParPage: number
 }>
 type Props = PropsWithChildren<

--- a/src/components/testHelper.tsx
+++ b/src/components/testHelper.tsx
@@ -78,6 +78,7 @@ export function renderComponent(
     supprimerUnMembreOuCandidatAction: vi.fn(),
     supprimerUnUtilisateurAction: vi.fn(),
     transfererMembreAction: vi.fn(),
+    transfererNotionsStructureAction: vi.fn(),
     utilisateursParPage: 10,
   }
 

--- a/src/gateways/PrismaStructureFusionRepository.test.ts
+++ b/src/gateways/PrismaStructureFusionRepository.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { PrismaStructureFusionRepository } from './PrismaStructureFusionRepository'
+import {
+  creerUnDepartement,
+  creerUneGouvernance,
+  creerUnePersonne,
+  creerUnePersonneAffectation,
+  creerUneRegion,
+  creerUneStructure,
+  creerUnMembre,
+} from './testHelper'
+import prisma from '../../prisma/prismaClient'
+
+// Survivante = canonique (INSEE) ; absorbée = antenne. Ids/codes dédiés ; nettoyage manuel.
+const SURVIVANTE = 990021
+const ABSORBEE = 990022
+const REGION = 'TV'
+const DEPT = '993'
+const MEMBRE = 'fusion-test-membre'
+const COOP_ID = '44444444-4444-4444-4444-444444444444'
+const COOP_ID_SURVIVANTE = '55555555-5555-5555-5555-555555555555'
+
+let personnesCreees: Array<number> = []
+
+describe('fusion de structures (repository Prisma)', () => {
+  afterEach(nettoyer)
+
+  it('déplace les notions (ids de source inclus), balaie les FK résiduelles, soft-delete l’absorbée et préserve les champs de la survivante', async () => {
+    // GIVEN une survivante canonique (APE 84.11Z) et une absorbée antenne portant membre, coop et une
+    // affectation source='min' (résiduelle, hors notions).
+    await seedBase()
+    await creerUneStructure({
+      code_activite_principale: '84.11Z',
+      id: SURVIVANTE,
+      nom: 'SURVIVANTE',
+      siret: '99002100000001',
+    })
+    await creerUneStructure({
+      code_activite_principale: '99.99Z',
+      denomination_antenne: 'Antenne absorbée',
+      id: ABSORBEE,
+      nom: 'ABSORBEE',
+      siret: '99002100000002',
+      structure_coop_id: COOP_ID,
+    })
+    await creerUnMembre({ gouvernanceDepartementCode: DEPT, id: MEMBRE, structureId: ABSORBEE })
+    await affecter(ABSORBEE, 'coop')
+    await affecter(ABSORBEE, 'min')
+
+    // WHEN
+    const result = await fusionner()
+
+    // THEN
+    expect(result).toBe('OK')
+    await expect(structureIdDuMembre()).resolves.toBe(SURVIVANTE)
+    await expect(coopIdDe(SURVIVANTE)).resolves.toBe(COOP_ID) // id de source transféré
+    await expect(apeDe(SURVIVANTE)).resolves.toBe('84.11Z') // champ descriptif de la survivante intact
+    await expect(nbAffectations(ABSORBEE)).resolves.toBe(0) // coop ET source='min' déplacées
+    await expect(nbAffectations(SURVIVANTE)).resolves.toBe(2)
+    await expect(estSupprimee(ABSORBEE)).resolves.toBe(true)
+    await expect(dernierAuditReussi()).resolves.toMatchObject({ moved_identifiers: { siret: '99002100000002' } })
+  })
+
+  it('refuse de fusionner quand l’absorbée est une canonique (INSEE)', async () => {
+    // GIVEN absorbée canonique (pas de denomination_antenne).
+    await seedBase()
+    await creerUneStructure({ id: SURVIVANTE, nom: 'SURVIVANTE', siret: '99002100000001' })
+    await creerUneStructure({ id: ABSORBEE, nom: 'ABSORBEE-CANONIQUE', siret: '99002100000002' })
+
+    // WHEN
+    const result = await fusionner()
+
+    // THEN
+    expect(result).toBe('fusionImpossibleCanoniqueAbsorbee')
+    await expect(estSupprimee(ABSORBEE)).resolves.toBe(false)
+  })
+
+  it('refuse la fusion en cas de collision d’id de source et ne supprime pas l’absorbée', async () => {
+    // GIVEN survivante et absorbée portent chacune un structure_coop_id différent.
+    await seedBase()
+    await creerUneStructure({
+      id: SURVIVANTE,
+      nom: 'SURVIVANTE',
+      siret: '99002100000001',
+      structure_coop_id: COOP_ID_SURVIVANTE,
+    })
+    await creerUneStructure({
+      denomination_antenne: 'Antenne absorbée',
+      id: ABSORBEE,
+      nom: 'ABSORBEE',
+      siret: '99002100000002',
+      structure_coop_id: COOP_ID,
+    })
+
+    // WHEN
+    const result = await fusionner()
+
+    // THEN
+    expect(result).toBe('collisionIdentifiantSource')
+    await expect(estSupprimee(ABSORBEE)).resolves.toBe(false)
+    await expect(coopIdDe(SURVIVANTE)).resolves.toBe(COOP_ID_SURVIVANTE)
+  })
+
+  it('retourne structureIntrouvable quand la survivante n’existe pas', async () => {
+    // GIVEN seule l'absorbée existe.
+    await seedBase()
+    await creerUneStructure({ denomination_antenne: 'Antenne', id: ABSORBEE, nom: 'ABSORBEE', siret: '99002100000002' })
+
+    // WHEN
+    const result = await new PrismaStructureFusionRepository().fusionner({
+      idAbsorbee: ABSORBEE,
+      idSurvivante: 999999,
+      parUtilisateur: 'admin-test',
+    })
+
+    // THEN
+    expect(result).toBe('structureIntrouvable')
+  })
+})
+
+async function fusionner(): Promise<string> {
+  return new PrismaStructureFusionRepository().fusionner({
+    idAbsorbee: ABSORBEE,
+    idSurvivante: SURVIVANTE,
+    parUtilisateur: 'admin-test',
+  })
+}
+
+async function seedBase(): Promise<void> {
+  await creerUneRegion({ code: REGION, nom: 'Région de test fusion' })
+  await creerUnDepartement({ code: DEPT, nom: 'Département de test fusion', regionCode: REGION })
+  await creerUneGouvernance({ departementCode: DEPT })
+}
+
+async function affecter(structureId: number, source: string): Promise<void> {
+  const personneId = await creerUnePersonne()
+  personnesCreees.push(personneId)
+  await creerUnePersonneAffectation({
+    personne_id: personneId,
+    source,
+    structure_id: structureId,
+    type: 'structure_emploi',
+  })
+}
+
+async function structureIdDuMembre(): Promise<number | undefined> {
+  const membre = await prisma.membreRecord.findUnique({ where: { id: MEMBRE } })
+  return membre?.structureId
+}
+
+async function coopIdDe(id: number): Promise<null | string> {
+  const structure = await prisma.main_structure_administrative.findUnique({ where: { id } })
+  return structure?.structure_coop_id ?? null
+}
+
+async function apeDe(id: number): Promise<null | string> {
+  const structure = await prisma.main_structure_administrative.findUnique({ where: { id } })
+  return structure?.code_activite_principale ?? null
+}
+
+async function nbAffectations(structureId: number): Promise<number> {
+  return prisma.main_personne_affectations_emploi.count({ where: { structure_administrative_id: structureId } })
+}
+
+async function estSupprimee(id: number): Promise<boolean> {
+  const structure = await prisma.main_structure_administrative.findUnique({ where: { id } })
+  return structure?.deleted_at != null
+}
+
+async function dernierAuditReussi(): Promise<Record<string, unknown> | undefined> {
+  const lignes = await prisma.$queryRaw<Array<Record<string, unknown>>>`
+    SELECT moved_identifiers FROM audit.structure_merge_log
+    WHERE status = 'SUCCESS' AND dag_id = 'min-ui' AND winner_id = ${SURVIVANTE} AND loser_id = ${ABSORBEE}
+    ORDER BY id DESC LIMIT 1
+  `
+  return lignes.at(0)
+}
+
+async function nettoyer(): Promise<void> {
+  await prisma.$executeRaw`
+    DELETE FROM audit.structure_merge_log
+    WHERE winner_id IN (${SURVIVANTE}, ${ABSORBEE}) OR loser_id IN (${SURVIVANTE}, ${ABSORBEE})
+  `
+  await prisma.main_personne_affectations_emploi.deleteMany({
+    where: { structure_administrative_id: { in: [SURVIVANTE, ABSORBEE] } },
+  })
+  await prisma.membreRecord.deleteMany({ where: { structureId: { in: [SURVIVANTE, ABSORBEE] } } })
+  if (personnesCreees.length > 0) {
+    await prisma.personne.deleteMany({ where: { id: { in: personnesCreees } } })
+    personnesCreees = []
+  }
+  await prisma.main_structure_administrative.deleteMany({ where: { id: { in: [SURVIVANTE, ABSORBEE] } } })
+  await prisma.gouvernanceRecord.deleteMany({ where: { departementCode: DEPT } })
+  await prisma.departementRecord.deleteMany({ where: { code: DEPT } })
+  await prisma.regionRecord.deleteMany({ where: { code: REGION } })
+}

--- a/src/gateways/PrismaStructureFusionRepository.ts
+++ b/src/gateways/PrismaStructureFusionRepository.ts
@@ -1,9 +1,14 @@
 import { Prisma } from '@prisma/client'
 
+import { deplacerNotionsDansTransaction, soumettreSoftDelete, TOUTES_NOTIONS } from './shared/deplacerNotions'
 import prisma from '../../prisma/prismaClient'
 import { ResultAsync } from '@/use-cases/CommandHandler'
 import { Fusion, FusionFailure, StructureFusionRepository } from '@/use-cases/commands/FusionnerStructures'
 
+// Fusion = déplacer les 6 notions de l'absorbée vers la survivante (via le moteur partagé, qui
+// transfère aussi les ids de source coop/tp/ac — c'est le correctif du bug d'abandon), balayer les
+// FK résiduelles non rattachées à une notion (affectations source='min'…), puis soft-delete
+// l'absorbée. La survivante conserve TOUS ses champs descriptifs (aucun import depuis l'absorbée).
 export class PrismaStructureFusionRepository implements StructureFusionRepository {
   async fusionner(fusion: Fusion): ResultAsync<FusionFailure> {
     try {
@@ -14,46 +19,11 @@ export class PrismaStructureFusionRepository implements StructureFusionRepositor
     }
   }
 
-  // Fusion des champs informatifs NON-uniques : COALESCE(survivante, absorbée),
-  // avec arbitrage explicite de l'admin sur dénomination / antenne / adresse.
-  async #fusionnerChampsInformatifs(
-    tx: Prisma.TransactionClient,
-    fusion: Fusion,
-    survivante: LigneStructure,
-    absorbee: LigneStructure
-  ): Promise<void> {
-    const { champsRetenus } = fusion
-    const denominationSirene =
-      champsRetenus.denominationSirene ?? survivante.denomination_sirene ?? absorbee.denomination_sirene
-    const denominationAntenne =
-      champsRetenus.denominationAntenne ?? survivante.denomination_antenne ?? absorbee.denomination_antenne
-    const adresseId = champsRetenus.adresseId ?? survivante.adresse_id ?? absorbee.adresse_id
-
-    await tx.$executeRaw`
-      UPDATE main.structure_administrative w
-      SET denomination_sirene = ${denominationSirene},
-          denomination_antenne = ${denominationAntenne},
-          adresse_id = ${adresseId},
-          etat_administratif = COALESCE(w.etat_administratif, l.etat_administratif),
-          code_activite_principale = COALESCE(w.code_activite_principale, l.code_activite_principale),
-          categorie_juridique = COALESCE(w.categorie_juridique, l.categorie_juridique),
-          publique = COALESCE(w.publique, l.publique),
-          nb_mandats_ac = COALESCE(w.nb_mandats_ac, l.nb_mandats_ac),
-          contact = COALESCE(w.contact, l.contact),
-          last_sirene_enrich_at = GREATEST(w.last_sirene_enrich_at, l.last_sirene_enrich_at),
-          updated_at = now()
-      FROM main.structure_administrative l
-      WHERE w.id = ${fusion.idSurvivante} AND l.id = ${fusion.idAbsorbee}
-    `
-  }
-
   async #fusionnerDansTransaction(tx: Prisma.TransactionClient, fusion: Fusion): ResultAsync<FusionFailure> {
-    const { idAbsorbee, idSurvivante } = fusion
+    const { idAbsorbee, idSurvivante, parUtilisateur } = fusion
 
     const lignes = await tx.$queryRaw<Array<LigneStructure>>`
-      SELECT id, deleted_at, denomination_sirene, denomination_antenne, adresse_id,
-             siret, ridet, rna, structure_coop_id, structure_ac_id, structure_tp_id,
-             to_jsonb(sa.*) AS snapshot
+      SELECT id, deleted_at, denomination_antenne, siret, ridet, rna, to_jsonb(sa.*) AS snapshot
       FROM main.structure_administrative sa
       WHERE id IN (${idSurvivante}, ${idAbsorbee})
     `
@@ -65,10 +35,25 @@ export class PrismaStructureFusionRepository implements StructureFusionRepositor
     if (survivante.deleted_at !== null || absorbee.deleted_at !== null) {
       return 'structureIntrouvable'
     }
+    // Une canonique (forme INSEE, sans denomination_antenne) ne peut pas être l'absorbée : on ne
+    // supprime jamais une entité INSEE.
+    if (absorbee.denomination_antenne === null) {
+      return 'fusionImpossibleCanoniqueAbsorbee'
+    }
 
-    await this.#fusionnerChampsInformatifs(tx, fusion, survivante, absorbee)
-    await this.#repointerToutesLesFk(tx, idSurvivante, idAbsorbee)
-    await this.#soumettreSoftDelete(tx, idAbsorbee, fusion.parUtilisateur)
+    // Déplacement des 6 notions (ids de source inclus) + gardes C1/C2 du moteur partagé.
+    const resultat = await deplacerNotionsDansTransaction(tx, {
+      idCible: idSurvivante,
+      idSource: idAbsorbee,
+      notions: TOUTES_NOTIONS,
+    })
+    if (resultat !== 'OK') {
+      return resultat
+    }
+
+    // Balayage des FK résiduelles que les notions ne couvrent pas (affectations source='min'…).
+    await this.#repointerAffectationsResiduelles(tx, idSurvivante, idAbsorbee)
+    await soumettreSoftDelete(tx, idAbsorbee, parUtilisateur)
     await this.#journaliserSucces(tx, fusion, survivante, absorbee)
 
     return 'OK'
@@ -110,29 +95,13 @@ export class PrismaStructureFusionRepository implements StructureFusionRepositor
     `
   }
 
-  // Repointe les 7 FK de l'absorbée vers la survivante. Pour les 4 tables à
-  // contrainte UNIQUE, on repointe d'abord les lignes non-collisionnantes puis
-  // on supprime les lignes restantes de l'absorbée (déjà représentées côté survivante).
-  async #repointerToutesLesFk(tx: Prisma.TransactionClient, idSurvivante: number, idAbsorbee: number): Promise<void> {
-    // Sans contrainte d'unicité sur la FK → UPDATE direct.
-    await tx.$executeRaw`UPDATE min.utilisateur SET structure_id = ${idSurvivante} WHERE structure_id = ${idAbsorbee}`
-    await tx.$executeRaw`UPDATE min.membre SET structure_id = ${idSurvivante} WHERE structure_id = ${idAbsorbee}`
-    await tx.$executeRaw`UPDATE main.contrat SET structure_id = ${idSurvivante} WHERE structure_id = ${idAbsorbee}`
-
-    // poste : UNIQUE(poste_conum_id, structure_id, personne_id)
-    await tx.$executeRaw`
-      UPDATE main.poste p SET structure_id = ${idSurvivante}
-      WHERE p.structure_id = ${idAbsorbee}
-        AND NOT EXISTS (
-          SELECT 1 FROM main.poste q
-          WHERE q.structure_id = ${idSurvivante}
-            AND q.poste_conum_id = p.poste_conum_id
-            AND q.personne_id IS NOT DISTINCT FROM p.personne_id
-        )
-    `
-    await tx.$executeRaw`DELETE FROM main.poste WHERE structure_id = ${idAbsorbee}`
-
-    // personne_affectations_emploi : UNIQUE(personne_id, structure_administrative_id, source)
+  // Repointe les affectations de l'absorbée non rattachées à une notion de source (typiquement
+  // source='min') vers la survivante. Collision-aware sur la clé unique (personne, structure, source).
+  async #repointerAffectationsResiduelles(
+    tx: Prisma.TransactionClient,
+    idSurvivante: number,
+    idAbsorbee: number
+  ): Promise<void> {
     await tx.$executeRaw`
       UPDATE main.personne_affectations_emploi e SET structure_administrative_id = ${idSurvivante}
       WHERE e.structure_administrative_id = ${idAbsorbee}
@@ -143,67 +112,25 @@ export class PrismaStructureFusionRepository implements StructureFusionRepositor
         )
     `
     await tx.$executeRaw`DELETE FROM main.personne_affectations_emploi WHERE structure_administrative_id = ${idAbsorbee}`
-
-    // contact_structure_administrative : UNIQUE(structure_administrative_id, contact_id)
-    await tx.$executeRaw`
-      UPDATE main.contact_structure_administrative c SET structure_administrative_id = ${idSurvivante}
-      WHERE c.structure_administrative_id = ${idAbsorbee}
-        AND NOT EXISTS (
-          SELECT 1 FROM main.contact_structure_administrative d
-          WHERE d.structure_administrative_id = ${idSurvivante} AND d.contact_id = c.contact_id
-        )
-    `
-    await tx.$executeRaw`DELETE FROM main.contact_structure_administrative WHERE structure_administrative_id = ${idAbsorbee}`
-
-    // lieu_inclusion_structure_administrative : UNIQUE(lieu_id, structure_administrative_id)
-    await tx.$executeRaw`
-      UPDATE main.lieu_inclusion_structure_administrative a SET structure_administrative_id = ${idSurvivante}
-      WHERE a.structure_administrative_id = ${idAbsorbee}
-        AND NOT EXISTS (
-          SELECT 1 FROM main.lieu_inclusion_structure_administrative b
-          WHERE b.structure_administrative_id = ${idSurvivante} AND b.lieu_id = a.lieu_id
-        )
-    `
-    await tx.$executeRaw`DELETE FROM main.lieu_inclusion_structure_administrative WHERE structure_administrative_id = ${idAbsorbee}`
-  }
-
-  async #soumettreSoftDelete(tx: Prisma.TransactionClient, idAbsorbee: number, parUtilisateur: string): Promise<void> {
-    await tx.$executeRaw`
-      UPDATE main.structure_administrative
-      SET deleted_at = now(),
-          deleted_by = array_append(COALESCE(deleted_by, '{}'), ${parUtilisateur}),
-          updated_at = now()
-      WHERE id = ${idAbsorbee}
-    `
   }
 }
 
-// Identifiants UNIQUE de structure_administrative. Jamais transférés au winner
-// (contraintes UNIQUE non partielles : l'absorbée soft-deletée garde sa ligne,
-// donc copier son SIRET/RNA/… violerait l'unicité). Consignés dans le journal.
 interface LigneStructure {
-  adresse_id: null | number
   deleted_at: Date | null
   denomination_antenne: null | string
-  denomination_sirene: null | string
   id: number
   ridet: null | string
   rna: null | string
   siret: null | string
   snapshot: Prisma.JsonValue
-  structure_ac_id: null | string
-  structure_coop_id: null | string
-  structure_tp_id: null | number
 }
 
-// Identifiants UNIQUE de l'absorbée, perdus par la fusion → tracés dans le journal.
-function identifiantsAbandonnes(absorbee: LigneStructure): Record<string, null | number | string> {
+// Identifiants d'IDENTITÉ de l'absorbée, perdus par la fusion (la survivante garde les siens) →
+// tracés dans le journal. Les ids de SOURCE (coop/tp/ac) n'y figurent plus : ils sont transférés.
+function identifiantsAbandonnes(absorbee: LigneStructure): Record<string, null | string> {
   return {
     ridet: absorbee.ridet,
     rna: absorbee.rna,
     siret: absorbee.siret,
-    structure_ac_id: absorbee.structure_ac_id,
-    structure_coop_id: absorbee.structure_coop_id,
-    structure_tp_id: absorbee.structure_tp_id,
   }
 }

--- a/src/gateways/PrismaStructureTransfertRepository.test.ts
+++ b/src/gateways/PrismaStructureTransfertRepository.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { PrismaStructureTransfertRepository } from './PrismaStructureTransfertRepository'
+import {
+  creerUnContact,
+  creerUnDepartement,
+  creerUneGouvernance,
+  creerUnePersonne,
+  creerUnePersonneAffectation,
+  creerUneRegion,
+  creerUneStructure,
+  creerUnMembre,
+  creerUnUtilisateur,
+} from './testHelper'
+import prisma from '../../prisma/prismaClient'
+import { NotionCle } from '@/use-cases/commands/TransfererNotionsStructure'
+
+// Ids/codes dédiés (le repository ouvre sa PROPRE transaction qui commit ; on nettoie à la main).
+const SOURCE = 990011
+const CIBLE = 990012
+const REGION = 'TU'
+const DEPT = '992'
+const MEMBRE = 'transfert-notions-source'
+const COOP_ID_SOURCE = '11111111-1111-1111-1111-111111111111'
+const AC_ID_SOURCE = '22222222-2222-2222-2222-222222222222'
+const COOP_ID_CIBLE = '33333333-3333-3333-3333-333333333333'
+const TP_ID_SOURCE = 880011
+
+let personnesCreees: Array<number> = []
+
+describe('transfert des notions d’une structure (repository Prisma)', () => {
+  afterEach(nettoyer)
+
+  it('transfère les notions portées, déplace les ids scalaires, vide la source et la soft-delete', async () => {
+    // GIVEN une source portant les 6 notions (idposte/coop/ac via affectations + ids scalaires).
+    await seedBase()
+    await creerUneStructure({
+      id: SOURCE,
+      nb_mandats_ac: 4,
+      siret: '99001100000001',
+      structure_ac_id: AC_ID_SOURCE,
+      structure_coop_id: COOP_ID_SOURCE,
+      structure_tp_id: TP_ID_SOURCE,
+    })
+    await creerUneStructure({ id: CIBLE, siret: '99001100000002' })
+    await creerUnMembre({ gouvernanceDepartementCode: DEPT, id: MEMBRE, structureId: SOURCE })
+    await creerUnUtilisateur({ ssoEmail: 'tn.user@example.com', ssoId: 'tn-user', structureId: SOURCE })
+    await lierContact(SOURCE)
+    await affecter(SOURCE, 'coop')
+    await affecter(SOURCE, 'idposte')
+    await affecter(SOURCE, 'aidants-connect')
+
+    // WHEN on transfère les 6 notions.
+    const result = await transferer(['aidantsConnect', 'contacts', 'coop', 'idposte', 'lieuInclusion', 'membre'])
+
+    // THEN la source est vidée puis supprimée, et la cible porte les 3 ids scalaires.
+    expect(result).toBe('OK')
+    await expect(structureIdDuMembre()).resolves.toBe(CIBLE)
+    await expect(idsScalaires(CIBLE)).resolves.toStrictEqual({
+      ac: AC_ID_SOURCE,
+      coop: COOP_ID_SOURCE,
+      mandats: 4,
+      tp: TP_ID_SOURCE,
+    })
+    await expect(idsScalaires(SOURCE)).resolves.toStrictEqual({ ac: null, coop: null, mandats: null, tp: null })
+    await expect(estSupprimee(SOURCE)).resolves.toBe(true)
+    await expect(nombreAudits()).resolves.toBe(1)
+  })
+
+  it('transfert partiel : ne déplace que la notion choisie et conserve la source non supprimée', async () => {
+    // GIVEN une source portant coop ET un membre.
+    await seedBase()
+    await creerUneStructure({ id: SOURCE, siret: '99001100000001', structure_coop_id: COOP_ID_SOURCE })
+    await creerUneStructure({ id: CIBLE, siret: '99001100000002' })
+    await creerUnMembre({ gouvernanceDepartementCode: DEPT, id: MEMBRE, structureId: SOURCE })
+    await affecter(SOURCE, 'coop')
+
+    // WHEN on ne transfère que coop.
+    const result = await transferer(['coop'])
+
+    // THEN coop est déplacé, le membre reste sur la source, qui n'est pas supprimée.
+    expect(result).toBe('OK')
+    await expect(idsScalaires(CIBLE)).resolves.toMatchObject({ coop: COOP_ID_SOURCE })
+    await expect(idsScalaires(SOURCE)).resolves.toMatchObject({ coop: null })
+    await expect(structureIdDuMembre()).resolves.toBe(SOURCE)
+    await expect(estSupprimee(SOURCE)).resolves.toBe(false)
+  })
+
+  it('refuse en cas de collision d’id scalaire et ne modifie rien', async () => {
+    // GIVEN source et cible portent chacune un structure_coop_id différent.
+    await seedBase()
+    await creerUneStructure({ id: SOURCE, siret: '99001100000001', structure_coop_id: COOP_ID_SOURCE })
+    await creerUneStructure({ id: CIBLE, siret: '99001100000002', structure_coop_id: COOP_ID_CIBLE })
+
+    // WHEN
+    const result = await transferer(['coop'])
+
+    // THEN
+    expect(result).toBe('collisionIdentifiantSource')
+    await expect(idsScalaires(SOURCE)).resolves.toMatchObject({ coop: COOP_ID_SOURCE })
+    await expect(nombreAudits()).resolves.toBe(0)
+  })
+
+  it('refuse en cas de collision de membre sur la même gouvernance', async () => {
+    // GIVEN source et cible déjà membres de la même gouvernance.
+    await seedBase()
+    await creerUneStructure({ id: SOURCE, siret: '99001100000001' })
+    await creerUneStructure({ id: CIBLE, siret: '99001100000002' })
+    await creerUnMembre({ gouvernanceDepartementCode: DEPT, id: MEMBRE, structureId: SOURCE })
+    await creerUnMembre({ gouvernanceDepartementCode: DEPT, id: 'transfert-notions-cible', structureId: CIBLE })
+
+    // WHEN
+    const result = await transferer(['membre'])
+
+    // THEN
+    expect(result).toBe('collisionMembreGouvernance')
+    await expect(structureIdDuMembre()).resolves.toBe(SOURCE)
+  })
+
+  it('retourne structureIntrouvable quand une structure n’existe pas', async () => {
+    // GIVEN seule la source existe.
+    await seedBase()
+    await creerUneStructure({ id: SOURCE, siret: '99001100000001' })
+
+    // WHEN
+    const result = await new PrismaStructureTransfertRepository().transfererNotions({
+      idCible: 999999,
+      idSource: SOURCE,
+      notions: ['contacts'],
+      parUtilisateur: 'admin-test',
+    })
+
+    // THEN
+    expect(result).toBe('structureIntrouvable')
+  })
+})
+
+async function transferer(notions: ReadonlyArray<NotionCle>): Promise<string> {
+  return new PrismaStructureTransfertRepository().transfererNotions({
+    idCible: CIBLE,
+    idSource: SOURCE,
+    notions,
+    parUtilisateur: 'admin-test',
+  })
+}
+
+async function seedBase(): Promise<void> {
+  await creerUneRegion({ code: REGION, nom: 'Région de test notions' })
+  await creerUnDepartement({ code: DEPT, nom: 'Département de test notions', regionCode: REGION })
+  await creerUneGouvernance({ departementCode: DEPT })
+}
+
+async function lierContact(structureId: number): Promise<void> {
+  const contactId = await creerUnContact({ email: 'tn.contact@example.com', nom: 'TransfertNotionsContact' })
+  await prisma.contact_structure_administrative.create({
+    data: { contact_id: contactId, structure_administrative_id: structureId },
+  })
+}
+
+async function affecter(structureId: number, source: string): Promise<void> {
+  const personneId = await creerUnePersonne()
+  personnesCreees.push(personneId)
+  await creerUnePersonneAffectation({
+    personne_id: personneId,
+    source,
+    structure_id: structureId,
+    type: 'structure_emploi',
+  })
+}
+
+async function structureIdDuMembre(): Promise<number | undefined> {
+  const membre = await prisma.membreRecord.findUnique({ where: { id: MEMBRE } })
+  return membre?.structureId
+}
+
+async function idsScalaires(id: number): Promise<Record<string, null | number | string>> {
+  const structure = await prisma.main_structure_administrative.findUnique({ where: { id } })
+  return {
+    ac: structure?.structure_ac_id ?? null,
+    coop: structure?.structure_coop_id ?? null,
+    mandats: structure?.nb_mandats_ac ?? null,
+    tp: structure?.structure_tp_id ?? null,
+  }
+}
+
+async function estSupprimee(id: number): Promise<boolean> {
+  const structure = await prisma.main_structure_administrative.findUnique({ where: { id } })
+  return structure?.deleted_at != null
+}
+
+async function nombreAudits(): Promise<number> {
+  const lignes = await prisma.$queryRaw<Array<{ total: bigint }>>`
+    SELECT COUNT(*) AS total FROM audit.structure_merge_log
+    WHERE dag_id = 'min-ui-transfert' AND loser_id = ${SOURCE}
+  `
+  return Number(lignes.at(0)?.total ?? 0)
+}
+
+async function nettoyer(): Promise<void> {
+  await prisma.$executeRaw`
+    DELETE FROM audit.structure_merge_log WHERE dag_id = 'min-ui-transfert' AND loser_id IN (${SOURCE}, ${CIBLE})
+  `
+  await prisma.main_personne_affectations_emploi.deleteMany({
+    where: { structure_administrative_id: { in: [SOURCE, CIBLE] } },
+  })
+  await prisma.membreRecord.deleteMany({ where: { structureId: { in: [SOURCE, CIBLE] } } })
+  await prisma.utilisateurRecord.deleteMany({ where: { structureId: { in: [SOURCE, CIBLE] } } })
+  await prisma.contact_structure_administrative.deleteMany({
+    where: { structure_administrative_id: { in: [SOURCE, CIBLE] } },
+  })
+  await prisma.main_contact.deleteMany({ where: { nom: 'TransfertNotionsContact' } })
+  if (personnesCreees.length > 0) {
+    await prisma.personne.deleteMany({ where: { id: { in: personnesCreees } } })
+    personnesCreees = []
+  }
+  await prisma.main_structure_administrative.deleteMany({ where: { id: { in: [SOURCE, CIBLE] } } })
+  await prisma.gouvernanceRecord.deleteMany({ where: { departementCode: DEPT } })
+  await prisma.departementRecord.deleteMany({ where: { code: DEPT } })
+  await prisma.regionRecord.deleteMany({ where: { code: REGION } })
+}

--- a/src/gateways/PrismaStructureTransfertRepository.ts
+++ b/src/gateways/PrismaStructureTransfertRepository.ts
@@ -1,0 +1,60 @@
+import { Prisma } from '@prisma/client'
+
+import { deplacerNotionsDansTransaction, soumettreSoftDelete, sourceEstVide } from './shared/deplacerNotions'
+import prisma from '../../prisma/prismaClient'
+import { ResultAsync } from '@/use-cases/CommandHandler'
+import {
+  StructureTransfertRepository,
+  TransfertNotions,
+  TransfertNotionsFailure,
+} from '@/use-cases/commands/TransfererNotionsStructure'
+
+// Transfert d'un sous-ensemble de notions d'une structure source vers une cible. S'appuie sur le
+// moteur partagé `deplacerNotions` (mutations + gardes C1/C2), puis soft-delete la source si elle
+// ne porte plus rien et journalise l'opération. La fusion réutilise le même moteur (cf.
+// PrismaStructureFusionRepository) avec la totalité des notions.
+export class PrismaStructureTransfertRepository implements StructureTransfertRepository {
+  async transfererNotions(transfert: TransfertNotions): ResultAsync<TransfertNotionsFailure> {
+    try {
+      return await prisma.$transaction(async (tx) => this.#transfererDansTransaction(tx, transfert))
+    } catch {
+      return 'transfertEchoue'
+    }
+  }
+
+  async #journaliser(
+    tx: Prisma.TransactionClient,
+    transfert: TransfertNotions,
+    sourceSupprimee: boolean
+  ): Promise<void> {
+    await tx.$executeRaw`
+      INSERT INTO audit.structure_merge_log
+        (status, dag_id, task_id, winner_id, loser_id, moved_identifiers)
+      VALUES (
+        'SUCCESS', 'min-ui-transfert', ${transfert.parUtilisateur},
+        ${transfert.idCible}, ${transfert.idSource},
+        ${JSON.stringify({ notions: transfert.notions, sourceSupprimee })}::jsonb
+      )
+    `
+  }
+
+  async #transfererDansTransaction(
+    tx: Prisma.TransactionClient,
+    transfert: TransfertNotions
+  ): ResultAsync<TransfertNotionsFailure> {
+    const { idCible, idSource, notions, parUtilisateur } = transfert
+
+    const resultat = await deplacerNotionsDansTransaction(tx, { idCible, idSource, notions })
+    if (resultat !== 'OK') {
+      return resultat
+    }
+
+    const sourceSupprimee = await sourceEstVide(tx, idSource)
+    if (sourceSupprimee) {
+      await soumettreSoftDelete(tx, idSource, parUtilisateur)
+    }
+    await this.#journaliser(tx, transfert, sourceSupprimee)
+
+    return 'OK'
+  }
+}

--- a/src/gateways/PrismaStructuresComparaisonLoader.ts
+++ b/src/gateways/PrismaStructuresComparaisonLoader.ts
@@ -22,6 +22,10 @@ export class PrismaStructuresComparaisonLoader implements ComparaisonDoublonsLoa
         sa.etat_administratif,
         sa.code_activite_principale,
         sa.edited_by AS source,
+        sa.structure_coop_id,
+        sa.structure_tp_id,
+        sa.structure_ac_id,
+        sa.nb_mandats_ac,
         EXISTS (
           SELECT 1 FROM audit.structure_merge_log ml
           WHERE ml.winner_id = sa.id AND ml.status = 'SUCCESS' AND ml.dag_id = 'min-ui'
@@ -36,6 +40,12 @@ export class PrismaStructuresComparaisonLoader implements ComparaisonDoublonsLoa
         (SELECT COUNT(*) FROM main.contrat ct WHERE ct.structure_id = sa.id)::int AS nb_contrats,
         (SELECT COUNT(*) FROM main.personne_affectations_emploi pae
          WHERE pae.structure_administrative_id = sa.id)::int AS nb_affectations_emploi,
+        (SELECT COUNT(*) FROM main.personne_affectations_emploi pae
+         WHERE pae.structure_administrative_id = sa.id AND pae.source = 'coop')::int AS nb_affectations_coop,
+        (SELECT COUNT(*) FROM main.personne_affectations_emploi pae
+         WHERE pae.structure_administrative_id = sa.id AND pae.source = 'idposte')::int AS nb_affectations_idposte,
+        (SELECT COUNT(*) FROM main.personne_affectations_emploi pae
+         WHERE pae.structure_administrative_id = sa.id AND pae.source = 'aidants-connect')::int AS nb_affectations_ac,
         (SELECT COUNT(*) FROM main.contact_structure_administrative cs
          WHERE cs.structure_administrative_id = sa.id)::int AS nb_contacts,
         (SELECT COUNT(*) FROM main.lieu_inclusion_structure_administrative li
@@ -72,13 +82,17 @@ interface LigneDetail {
   id: number
   latitude: null | number
   longitude: null | number
+  nb_affectations_ac: number
+  nb_affectations_coop: number
   nb_affectations_emploi: number
+  nb_affectations_idposte: number
   nb_associations_lieux: number
   nb_contacts: number
   nb_contacts_membre: number
   nb_contrats: number
   nb_feuilles_de_route: number
   nb_gouvernances: number
+  nb_mandats_ac: null | number
   nb_membres_min: number
   nb_postes: number
   nb_utilisateurs_min: number
@@ -87,6 +101,9 @@ interface LigneDetail {
   rna: null | string
   siret: null | string
   source: null | string
+  structure_ac_id: null | string
+  structure_coop_id: null | string
+  structure_tp_id: null | number
 }
 
 function versDetail(ligne: LigneDetail): StructureDetailReadModel {
@@ -111,8 +128,12 @@ function versDetail(ligne: LigneDetail): StructureDetailReadModel {
     id: ligne.id,
     latitude: ligne.latitude,
     longitude: ligne.longitude,
+    nbMandatsAc: ligne.nb_mandats_ac,
     rattachements: {
+      affectationsAc: ligne.nb_affectations_ac,
+      affectationsCoop: ligne.nb_affectations_coop,
       affectationsEmploi: ligne.nb_affectations_emploi,
+      affectationsIdposte: ligne.nb_affectations_idposte,
       associationsLieux: ligne.nb_associations_lieux,
       contacts: ligne.nb_contacts,
       contactsMembre: ligne.nb_contacts_membre,
@@ -128,5 +149,8 @@ function versDetail(ligne: LigneDetail): StructureDetailReadModel {
     rna: ligne.rna,
     siret: ligne.siret,
     source: ligne.source,
+    structureAcId: ligne.structure_ac_id,
+    structureCoopId: ligne.structure_coop_id,
+    structureTpId: ligne.structure_tp_id,
   }
 }

--- a/src/gateways/shared/deplacerNotions.ts
+++ b/src/gateways/shared/deplacerNotions.ts
@@ -1,0 +1,276 @@
+import { Prisma } from '@prisma/client'
+
+import { NotionCle } from '@/use-cases/commands/TransfererNotionsStructure'
+
+// Les 6 notions transférables — une fusion = déplacer la totalité.
+export const TOUTES_NOTIONS: ReadonlyArray<NotionCle> = [
+  'aidantsConnect',
+  'contacts',
+  'coop',
+  'idposte',
+  'lieuInclusion',
+  'membre',
+]
+
+// Cœur transactionnel partagé entre le transfert (sous-ensemble de notions) et la fusion (les 6).
+// Charge les structures, applique les gardes C1/C2 puis les mutations des notions choisies. Ne gère
+// NI la transaction (fournie par l'appelant), NI le soft-delete, NI l'audit, NI le balayage résiduel
+// — laissés à chaque repository selon sa sémantique.
+export async function deplacerNotionsDansTransaction(
+  tx: Prisma.TransactionClient,
+  deplacement: Deplacement
+): Promise<'OK' | DeplacementFailure> {
+  const { idCible, idSource, notions } = deplacement
+  function choisi(notion: NotionCle): boolean {
+    return notions.includes(notion)
+  }
+
+  const lignes = await tx.$queryRaw<Array<LigneStructure>>`
+    SELECT id, deleted_at, structure_coop_id, structure_tp_id, structure_ac_id, nb_mandats_ac
+    FROM main.structure_administrative WHERE id IN (${idSource}, ${idCible})
+  `
+  const source = lignes.find((ligne) => ligne.id === idSource)
+  const cible = lignes.find((ligne) => ligne.id === idCible)
+  if (source === undefined || cible === undefined || source.deleted_at !== null || cible.deleted_at !== null) {
+    return 'structureIntrouvable'
+  }
+
+  if (collisionIdentifiantSource(choisi, source, cible)) {
+    return 'collisionIdentifiantSource'
+  }
+  if (choisi('membre') && (await collisionMembreGouvernance(tx, idSource, idCible))) {
+    return 'collisionMembreGouvernance'
+  }
+
+  if (choisi('membre')) {
+    await transfererMembre(tx, idSource, idCible)
+  }
+  if (choisi('contacts')) {
+    await transfererContacts(tx, idSource, idCible)
+  }
+  if (choisi('coop')) {
+    await transfererCoop(tx, idSource, idCible, source)
+  }
+  if (choisi('idposte')) {
+    await transfererIdposte(tx, idSource, idCible, source)
+  }
+  if (choisi('aidantsConnect')) {
+    await transfererAidantsConnect(tx, idSource, idCible, source)
+  }
+  if (choisi('lieuInclusion')) {
+    await transfererLieuInclusion(tx, idSource, idCible)
+  }
+
+  return 'OK'
+}
+
+// La source ne porte plus rien = 0 ligne sur les 7 FK ET 0 id scalaire sortant (coop/tp/ac). Les
+// champs d'identité (siret/ridet/rna) ne comptent pas : ce ne sont pas des vecteurs de resync.
+export async function sourceEstVide(tx: Prisma.TransactionClient, idSource: number): Promise<boolean> {
+  const lignes = await tx.$queryRaw<Array<{ vide: boolean }>>`
+    SELECT NOT (
+      EXISTS (SELECT 1 FROM min.utilisateur WHERE structure_id = ${idSource})
+      OR EXISTS (SELECT 1 FROM min.membre WHERE structure_id = ${idSource})
+      OR EXISTS (SELECT 1 FROM main.poste WHERE structure_id = ${idSource})
+      OR EXISTS (SELECT 1 FROM main.contrat WHERE structure_id = ${idSource})
+      OR EXISTS (SELECT 1 FROM main.personne_affectations_emploi WHERE structure_administrative_id = ${idSource})
+      OR EXISTS (SELECT 1 FROM main.contact_structure_administrative WHERE structure_administrative_id = ${idSource})
+      OR EXISTS (SELECT 1 FROM main.lieu_inclusion_structure_administrative WHERE structure_administrative_id = ${idSource})
+      OR EXISTS (
+        SELECT 1 FROM main.structure_administrative
+        WHERE id = ${idSource}
+          AND (structure_coop_id IS NOT NULL OR structure_tp_id IS NOT NULL OR structure_ac_id IS NOT NULL)
+      )
+    ) AS vide
+  `
+
+  return lignes.at(0)?.vide === true
+}
+
+export async function soumettreSoftDelete(
+  tx: Prisma.TransactionClient,
+  idSource: number,
+  parUtilisateur: string
+): Promise<void> {
+  await tx.$executeRaw`
+    UPDATE main.structure_administrative
+    SET deleted_at = now(),
+        deleted_by = array_append(COALESCE(deleted_by, '{}'), ${parUtilisateur}),
+        updated_at = now()
+    WHERE id = ${idSource}
+  `
+}
+
+type DeplacementFailure = 'collisionIdentifiantSource' | 'collisionMembreGouvernance' | 'structureIntrouvable'
+
+type Deplacement = Readonly<{
+  idCible: number
+  idSource: number
+  notions: ReadonlyArray<NotionCle>
+}>
+
+interface LigneStructure {
+  deleted_at: Date | null
+  id: number
+  nb_mandats_ac: null | number
+  structure_ac_id: null | string
+  structure_coop_id: null | string
+  structure_tp_id: null | number
+}
+
+// Une notion source sélectionnée porte un id scalaire alors que la cible en porte déjà un autre.
+function collisionIdentifiantSource(
+  choisi: (notion: NotionCle) => boolean,
+  source: LigneStructure,
+  cible: LigneStructure
+): boolean {
+  function conflit(valeurSource: null | number | string, valeurCible: null | number | string): boolean {
+    return valeurSource !== null && valeurCible !== null && valeurSource !== valeurCible
+  }
+
+  return (
+    (choisi('coop') && conflit(source.structure_coop_id, cible.structure_coop_id)) ||
+    (choisi('idposte') && conflit(source.structure_tp_id, cible.structure_tp_id)) ||
+    (choisi('aidantsConnect') && conflit(source.structure_ac_id, cible.structure_ac_id))
+  )
+}
+
+async function collisionMembreGouvernance(
+  tx: Prisma.TransactionClient,
+  idSource: number,
+  idCible: number
+): Promise<boolean> {
+  const lignes = await tx.$queryRaw<Array<{ collision: boolean }>>`
+    SELECT EXISTS (
+      SELECT 1 FROM min.membre source
+      JOIN min.membre cible ON cible.gouvernance_departement_code = source.gouvernance_departement_code
+      WHERE source.structure_id = ${idSource} AND cible.structure_id = ${idCible}
+    ) AS collision
+  `
+
+  return lignes.at(0)?.collision === true
+}
+
+async function deplacerAffectations(
+  tx: Prisma.TransactionClient,
+  idSource: number,
+  idCible: number,
+  source: string
+): Promise<void> {
+  // personne_affectations_emploi : UNIQUE(personne_id, structure_administrative_id, source).
+  await tx.$executeRaw`
+    UPDATE main.personne_affectations_emploi e SET structure_administrative_id = ${idCible}
+    WHERE e.structure_administrative_id = ${idSource} AND e.source = ${source}
+      AND NOT EXISTS (
+        SELECT 1 FROM main.personne_affectations_emploi f
+        WHERE f.structure_administrative_id = ${idCible} AND f.personne_id = e.personne_id AND f.source = e.source
+      )
+  `
+  await tx.$executeRaw`
+    DELETE FROM main.personne_affectations_emploi
+    WHERE structure_administrative_id = ${idSource} AND source = ${source}
+  `
+}
+
+async function transfererAidantsConnect(
+  tx: Prisma.TransactionClient,
+  idSource: number,
+  idCible: number,
+  source: LigneStructure
+): Promise<void> {
+  await deplacerAffectations(tx, idSource, idCible, 'aidants-connect')
+  if (source.structure_ac_id === null) {
+    return
+  }
+  await tx.$executeRaw`
+    UPDATE main.structure_administrative SET structure_ac_id = NULL, nb_mandats_ac = NULL WHERE id = ${idSource}
+  `
+  await tx.$executeRaw`
+    UPDATE main.structure_administrative
+    SET structure_ac_id = ${source.structure_ac_id}::uuid, nb_mandats_ac = ${source.nb_mandats_ac}
+    WHERE id = ${idCible}
+  `
+}
+
+async function transfererContacts(tx: Prisma.TransactionClient, idSource: number, idCible: number): Promise<void> {
+  // contact_structure_administrative : UNIQUE(structure_administrative_id, contact_id).
+  await tx.$executeRaw`
+    UPDATE main.contact_structure_administrative c SET structure_administrative_id = ${idCible}
+    WHERE c.structure_administrative_id = ${idSource}
+      AND NOT EXISTS (
+        SELECT 1 FROM main.contact_structure_administrative d
+        WHERE d.structure_administrative_id = ${idCible} AND d.contact_id = c.contact_id
+      )
+  `
+  await tx.$executeRaw`
+    DELETE FROM main.contact_structure_administrative WHERE structure_administrative_id = ${idSource}
+  `
+}
+
+async function transfererCoop(
+  tx: Prisma.TransactionClient,
+  idSource: number,
+  idCible: number,
+  source: LigneStructure
+): Promise<void> {
+  await deplacerAffectations(tx, idSource, idCible, 'coop')
+  if (source.structure_coop_id === null) {
+    return
+  }
+  await tx.$executeRaw`UPDATE main.structure_administrative SET structure_coop_id = NULL WHERE id = ${idSource}`
+  await tx.$executeRaw`
+    UPDATE main.structure_administrative SET structure_coop_id = ${source.structure_coop_id}::uuid WHERE id = ${idCible}
+  `
+}
+
+async function transfererIdposte(
+  tx: Prisma.TransactionClient,
+  idSource: number,
+  idCible: number,
+  source: LigneStructure
+): Promise<void> {
+  // poste : UNIQUE(poste_conum_id, structure_id, personne_id).
+  await tx.$executeRaw`
+    UPDATE main.poste p SET structure_id = ${idCible}
+    WHERE p.structure_id = ${idSource}
+      AND NOT EXISTS (
+        SELECT 1 FROM main.poste q
+        WHERE q.structure_id = ${idCible}
+          AND q.poste_conum_id = p.poste_conum_id
+          AND q.personne_id IS NOT DISTINCT FROM p.personne_id
+      )
+  `
+  await tx.$executeRaw`DELETE FROM main.poste WHERE structure_id = ${idSource}`
+  // contrat : pas de contrainte d'unicité sur structure_id → UPDATE direct.
+  await tx.$executeRaw`UPDATE main.contrat SET structure_id = ${idCible} WHERE structure_id = ${idSource}`
+  await deplacerAffectations(tx, idSource, idCible, 'idposte')
+  if (source.structure_tp_id === null) {
+    return
+  }
+  await tx.$executeRaw`UPDATE main.structure_administrative SET structure_tp_id = NULL WHERE id = ${idSource}`
+  await tx.$executeRaw`
+    UPDATE main.structure_administrative SET structure_tp_id = ${source.structure_tp_id} WHERE id = ${idCible}
+  `
+}
+
+async function transfererLieuInclusion(tx: Prisma.TransactionClient, idSource: number, idCible: number): Promise<void> {
+  // lieu_inclusion_structure_administrative : UNIQUE(lieu_id, structure_administrative_id).
+  await tx.$executeRaw`
+    UPDATE main.lieu_inclusion_structure_administrative a SET structure_administrative_id = ${idCible}
+    WHERE a.structure_administrative_id = ${idSource}
+      AND NOT EXISTS (
+        SELECT 1 FROM main.lieu_inclusion_structure_administrative b
+        WHERE b.structure_administrative_id = ${idCible} AND b.lieu_id = a.lieu_id
+      )
+  `
+  await tx.$executeRaw`
+    DELETE FROM main.lieu_inclusion_structure_administrative WHERE structure_administrative_id = ${idSource}
+  `
+}
+
+async function transfererMembre(tx: Prisma.TransactionClient, idSource: number, idCible: number): Promise<void> {
+  // Re-pointage des membres et de tous les utilisateurs : les dépendants (feuilles de route,
+  // subventions, porteurs d'action, cofinancements) suivent via le membre.id inchangé.
+  await tx.$executeRaw`UPDATE min.membre SET structure_id = ${idCible} WHERE structure_id = ${idSource}`
+  await tx.$executeRaw`UPDATE min.utilisateur SET structure_id = ${idCible} WHERE structure_id = ${idSource}`
+}

--- a/src/presenters/comparaisonDoublonsPresenter.test.ts
+++ b/src/presenters/comparaisonDoublonsPresenter.test.ts
@@ -23,8 +23,12 @@ describe('comparaison doublons presenter', () => {
         id: 4555,
         latitude: 48.45,
         longitude: 1.49,
+        nbMandatsAc: 3,
         rattachements: {
+          affectationsAc: 2,
+          affectationsCoop: 5,
           affectationsEmploi: 37,
+          affectationsIdposte: 30,
           associationsLieux: 0,
           contacts: 2,
           contactsMembre: 1,
@@ -40,6 +44,9 @@ describe('comparaison doublons presenter', () => {
         rna: null,
         siret: '22280001300013',
         source: 'sonum',
+        structureAcId: 'ac-uuid',
+        structureCoopId: 'coop-uuid',
+        structureTpId: 77,
       },
     ]
 
@@ -75,42 +82,58 @@ describe('comparaison doublons presenter', () => {
       { label: 'Contacts référents', nombre: 2 },
       { label: "Associations à des lieux d'inclusion", nombre: 0 },
     ])
+    expect(structure.concepts).toStrictEqual([
+      {
+        cle: 'membre',
+        idExterne: null,
+        label: 'Membre de gouvernance + utilisateurs',
+        present: true,
+        resume: '1 membre · 2 utilisateurs',
+      },
+      { cle: 'contacts', idExterne: null, label: 'Contacts référents', present: true, resume: '2 contacts' },
+      { cle: 'coop', idExterne: 'coop-uuid', label: 'Coop', present: true, resume: '5 affectations' },
+      {
+        cle: 'idposte',
+        idExterne: '77',
+        label: 'Idposte',
+        present: true,
+        resume: '15 postes · 1 contrat · 30 affectations',
+      },
+      { cle: 'aidantsConnect', idExterne: 'ac-uuid', label: 'Aidants Connect', present: true, resume: '2 aidants' },
+      { cle: 'lieuInclusion', idExterne: null, label: 'Lieu d’inclusion', present: false, resume: '0 lieu' },
+    ])
   })
 
-  it('applique les valeurs de repli quand les champs sont absents', () => {
-    // GIVEN
+  it('marque un concept source comme présent dès que son id scalaire existe, même sans aucune ligne', () => {
+    // GIVEN une structure sans affectation AC mais portant un structure_ac_id (id sans ligne).
     const readModel: ReadonlyArray<StructureDetailReadModel> = [
       {
-        adresse: null,
-        codeActivitePrincipale: null,
-        commune: null,
-        dejaFusionnee: false,
-        denominationAntenne: null,
-        denominationSirene: null,
-        estBeneficiaire: false,
-        etatAdministratif: null,
-        id: 99,
-        latitude: null,
-        longitude: null,
-        rattachements: {
-          affectationsEmploi: 0,
-          associationsLieux: 0,
-          contacts: 0,
-          contactsMembre: 0,
-          contrats: 0,
-          feuillesDeRoute: 0,
-          gouvernances: 0,
-          membresMin: 0,
-          postes: 0,
-          total: 0,
-          utilisateursMin: 0,
-        },
-        ridet: null,
-        rna: null,
-        siret: null,
-        source: null,
+        ...structureVide(7),
+        nbMandatsAc: 0,
+        structureAcId: 'ac-sans-ligne',
       },
     ]
+
+    // WHEN
+    const [structure] = comparaisonDoublonsPresenter(readModel)
+
+    // THEN — concept AC présent (id non-NULL) avec 0 ligne, et lieu non porté pour le pluriel « 0 lieu ».
+    const aidantsConnect = structure.concepts.find((concept) => concept.cle === 'aidantsConnect')
+    expect(aidantsConnect).toStrictEqual({
+      cle: 'aidantsConnect',
+      idExterne: 'ac-sans-ligne',
+      label: 'Aidants Connect',
+      present: true,
+      resume: '0 aidant',
+    })
+    expect(structure.concepts.filter((concept) => concept.present).map((concept) => concept.cle)).toStrictEqual([
+      'aidantsConnect',
+    ])
+  })
+
+  it('applique les valeurs de repli quand les champs sont absents et ne porte aucun concept', () => {
+    // GIVEN
+    const readModel: ReadonlyArray<StructureDetailReadModel> = [structureVide(99)]
 
     // WHEN
     const [structure] = comparaisonDoublonsPresenter(readModel)
@@ -119,6 +142,7 @@ describe('comparaison doublons presenter', () => {
     expect(structure.denomination).toBe('Structure #99')
     expect(structure.adresse).toBe('—')
     expect(structure.denominationSirene).toBe('')
+    expect(structure.concepts.every((concept) => !concept.present)).toBe(true)
   })
 
   it('matriceDistances classe chaque distance par niveau (identique / proche / normal / éloigné / inconnu)', () => {
@@ -155,6 +179,7 @@ function structureAvecCoords(
   return {
     adresse: `Adresse ${id}`,
     champs: [],
+    concepts: [],
     denomination: `Structure ${id}`,
     denominationSirene: `Structure ${id}`,
     estAssocieLieuInclusion: false,
@@ -165,5 +190,46 @@ function structureAvecCoords(
     longitude,
     rattachements: [],
     rattachementsTotal: 0,
+  }
+}
+
+// Structure read-model totalement vide (aucune ligne, aucun id scalaire) — base des cas de repli.
+function structureVide(id: number): StructureDetailReadModel {
+  return {
+    adresse: null,
+    codeActivitePrincipale: null,
+    commune: null,
+    dejaFusionnee: false,
+    denominationAntenne: null,
+    denominationSirene: null,
+    estBeneficiaire: false,
+    etatAdministratif: null,
+    id,
+    latitude: null,
+    longitude: null,
+    nbMandatsAc: null,
+    rattachements: {
+      affectationsAc: 0,
+      affectationsCoop: 0,
+      affectationsEmploi: 0,
+      affectationsIdposte: 0,
+      associationsLieux: 0,
+      contacts: 0,
+      contactsMembre: 0,
+      contrats: 0,
+      feuillesDeRoute: 0,
+      gouvernances: 0,
+      membresMin: 0,
+      postes: 0,
+      total: 0,
+      utilisateursMin: 0,
+    },
+    ridet: null,
+    rna: null,
+    siret: null,
+    source: null,
+    structureAcId: null,
+    structureCoopId: null,
+    structureTpId: null,
   }
 }

--- a/src/presenters/comparaisonDoublonsPresenter.ts
+++ b/src/presenters/comparaisonDoublonsPresenter.ts
@@ -1,4 +1,5 @@
 import { libelleSource } from '@/presenters/shared/libelleSource'
+import { NotionCle } from '@/use-cases/commands/TransfererNotionsStructure'
 import {
   ComparaisonDoublonsReadModel,
   RattachementsReadModel,
@@ -33,9 +34,22 @@ export function comparaisonDoublonsPresenter(readModel: ComparaisonDoublonsReadM
 
 export type ComparaisonViewModel = ReadonlyArray<StructureComparaisonViewModel>
 
+// Une des 6 notions transférables portées par une structure. `present` pilote l'affichage
+// de la case (concept absent = pas de case). `idExterne` rend lisible le cas « 0 ligne mais
+// id scalaire présent » (ex. structure_ac_id sans aucun aidant) pour les sources agrégées.
+export type ConceptViewModel = Readonly<{
+  cle: NotionCle
+  idExterne: null | string
+  label: string
+  present: boolean
+  resume: string
+}>
+
 export type StructureComparaisonViewModel = Readonly<{
   adresse: string
   champs: ReadonlyArray<ChampViewModel>
+  // Les 6 notions transférables, dans l'ordre d'affichage (toujours les 6, `present` filtre).
+  concepts: ReadonlyArray<ConceptViewModel>
   denomination: string
   denominationSirene: string
   // true si la structure est associée à au moins un lieu d'inclusion
@@ -160,6 +174,7 @@ function versStructureComparaison(structure: StructureDetailReadModel): Structur
       { label: 'Bénéficiaire de subvention', valeur: structure.estBeneficiaire ? 'Oui' : 'Non' },
       { label: 'Issue d’une fusion précédente', valeur: structure.dejaFusionnee ? 'Oui' : 'Non' },
     ],
+    concepts: construireConcepts(structure),
     denomination: structure.denominationAntenne ?? structure.denominationSirene ?? `Structure #${structure.id}`,
     denominationSirene: structure.denominationSirene ?? '',
     estAssocieLieuInclusion: structure.rattachements.associationsLieux > 0,
@@ -175,6 +190,65 @@ function versStructureComparaison(structure: StructureDetailReadModel): Structur
     })),
     rattachementsTotal: structure.rattachements.total,
   }
+}
+
+// Construit les 6 notions transférables d'une structure. Une notion est « présente » dès qu'elle
+// porte au moins une ligne OU un id scalaire non-NULL — d'où l'inclusion des ids coop/tp/ac, qui
+// font qu'une structure « porte » la source même avec 0 affectation (le resync la repeuplerait).
+function construireConcepts(structure: StructureDetailReadModel): ReadonlyArray<ConceptViewModel> {
+  const liens = structure.rattachements
+  const idTp = structure.structureTpId === null ? null : String(structure.structureTpId)
+
+  return [
+    {
+      cle: 'membre',
+      idExterne: null,
+      label: 'Membre de gouvernance + utilisateurs',
+      present: liens.membresMin > 0 || liens.utilisateursMin > 0,
+      resume: `${unite(liens.membresMin, 'membre')} · ${unite(liens.utilisateursMin, 'utilisateur')}`,
+    },
+    {
+      cle: 'contacts',
+      idExterne: null,
+      label: 'Contacts référents',
+      present: liens.contacts > 0,
+      resume: unite(liens.contacts, 'contact'),
+    },
+    {
+      cle: 'coop',
+      idExterne: structure.structureCoopId,
+      label: 'Coop',
+      present: liens.affectationsCoop > 0 || structure.structureCoopId !== null,
+      resume: unite(liens.affectationsCoop, 'affectation'),
+    },
+    {
+      cle: 'idposte',
+      idExterne: idTp,
+      label: 'Idposte',
+      present:
+        liens.postes > 0 || liens.contrats > 0 || liens.affectationsIdposte > 0 || structure.structureTpId !== null,
+      resume: `${unite(liens.postes, 'poste')} · ${unite(liens.contrats, 'contrat')} · ${unite(liens.affectationsIdposte, 'affectation')}`,
+    },
+    {
+      cle: 'aidantsConnect',
+      idExterne: structure.structureAcId,
+      label: 'Aidants Connect',
+      present: liens.affectationsAc > 0 || structure.structureAcId !== null,
+      resume: unite(liens.affectationsAc, 'aidant'),
+    },
+    {
+      cle: 'lieuInclusion',
+      idExterne: null,
+      label: 'Lieu d’inclusion',
+      present: liens.associationsLieux > 0,
+      resume: unite(liens.associationsLieux, 'lieu', 'lieux'),
+    },
+  ]
+}
+
+// « 2 membres », « 1 contact », « 0 aidant » — pluriel à partir de 2.
+function unite(nombre: number, singulier: string, pluriel = `${singulier}s`): string {
+  return `${nombre} ${nombre > 1 ? pluriel : singulier}`
 }
 
 // Distance à vol d'oiseau (Haversine) en km entre deux structures, ou null si une coordonnée manque.

--- a/src/use-cases/commands/FusionnerStructures.test.ts
+++ b/src/use-cases/commands/FusionnerStructures.test.ts
@@ -14,7 +14,6 @@ describe('fusionner deux structures', () => {
 
     // WHEN
     const result = await fusionner.handle({
-      champsRetenus: {},
       idAbsorbee: 42,
       idSurvivante: 42,
       uidUtilisateur: 'admin-1',
@@ -31,7 +30,6 @@ describe('fusionner deux structures', () => {
 
     // WHEN
     const result = await fusionner.handle({
-      champsRetenus: { denominationAntenne: 'Siège' },
       idAbsorbee: 7,
       idSurvivante: 3,
       uidUtilisateur: 'admin-1',
@@ -40,7 +38,6 @@ describe('fusionner deux structures', () => {
     // THEN
     expect(result).toBe('OK')
     expect(spiedFusion).toStrictEqual({
-      champsRetenus: { denominationAntenne: 'Siège' },
       idAbsorbee: 7,
       idSurvivante: 3,
       parUtilisateur: 'admin-1',

--- a/src/use-cases/commands/FusionnerStructures.ts
+++ b/src/use-cases/commands/FusionnerStructures.ts
@@ -13,7 +13,6 @@ export class FusionnerStructures implements CommandHandler<Command, FusionFailur
     }
 
     return this.#repository.fusionner({
-      champsRetenus: command.champsRetenus,
       idAbsorbee: command.idAbsorbee,
       idSurvivante: command.idSurvivante,
       parUtilisateur: command.uidUtilisateur,
@@ -25,28 +24,27 @@ export interface StructureFusionRepository {
   fusionner(fusion: Fusion): ResultAsync<FusionFailure>
 }
 
+// La fusion = déplacer la TOTALITÉ des notions de l'absorbée vers la survivante puis soft-delete
+// l'absorbée. On ne récupère JAMAIS les champs descriptifs de l'absorbée (dénomination, adresse, APE,
+// catégorie juridique…) : la survivante garde les siens — importer ceux d'un doublon casserait la
+// cohérence INSEE. Les identifiants d'identité (siret/ridet/rna) de l'absorbée sont abandonnés (loggés) ;
+// les ids de source (coop/tp/ac) sont, eux, transférés (sinon le doublon ressuscite au resync).
 export type Fusion = Readonly<{
-  champsRetenus: ChampsRetenus
   idAbsorbee: number
   idSurvivante: number
   parUtilisateur: string
 }>
 
-// Champs informatifs que l'admin peut explicitement arbitrer côté survivante.
-// Les autres champs sont fusionnés automatiquement en COALESCE(survivante, absorbée).
-// Les identifiants UNIQUE (siret, ridet, coop_id, ac_id, tp_id) ne sont JAMAIS
-// transférés : la survivante conserve les siens, ceux de l'absorbée sont consignés
-// dans le journal d'audit (`moved_identifiers`) puis perdus.
-export type ChampsRetenus = Readonly<{
-  adresseId?: null | number
-  denominationAntenne?: null | string
-  denominationSirene?: null | string
-}>
-
-export type FusionFailure = 'fusionEchouee' | 'fusionImpossibleMemeStructure' | 'structureIntrouvable'
+export type FusionFailure =
+  | 'collisionIdentifiantSource'
+  | 'collisionMembreGouvernance'
+  | 'fusionEchouee'
+  // Une canonique vient de l'INSEE : on ne la supprime jamais, donc elle ne peut pas être absorbée.
+  | 'fusionImpossibleCanoniqueAbsorbee'
+  | 'fusionImpossibleMemeStructure'
+  | 'structureIntrouvable'
 
 type Command = Readonly<{
-  champsRetenus: ChampsRetenus
   idAbsorbee: number
   idSurvivante: number
   uidUtilisateur: string

--- a/src/use-cases/commands/TransfererNotionsStructure.test.ts
+++ b/src/use-cases/commands/TransfererNotionsStructure.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  StructureTransfertRepository,
+  TransfererNotionsStructure,
+  TransfertNotions,
+  TransfertNotionsFailure,
+} from './TransfererNotionsStructure'
+import { ResultAsync } from '@/use-cases/CommandHandler'
+
+describe('transférer des notions entre structures', () => {
+  beforeEach(() => {
+    spiedTransfert = null
+  })
+
+  it('refuse de transférer une structure vers elle-même, sans toucher au repository', async () => {
+    // GIVEN
+    const transferer = new TransfererNotionsStructure(repositoryQuiRend('OK'))
+
+    // WHEN
+    const result = await transferer.handle({ idCible: 5, idSource: 5, notions: ['membre'], uidUtilisateur: 'bob' })
+
+    // THEN
+    expect(result).toBe('transfertImpossibleMemeStructure')
+    expect(spiedTransfert).toBeNull()
+  })
+
+  it('refuse un transfert sans aucune notion sélectionnée, sans toucher au repository', async () => {
+    // GIVEN
+    const transferer = new TransfererNotionsStructure(repositoryQuiRend('OK'))
+
+    // WHEN
+    const result = await transferer.handle({ idCible: 2, idSource: 1, notions: [], uidUtilisateur: 'bob' })
+
+    // THEN
+    expect(result).toBe('aucuneNotionSelectionnee')
+    expect(spiedTransfert).toBeNull()
+  })
+
+  it('délègue au repository les notions sélectionnées et l’utilisateur, puis renvoie son résultat', async () => {
+    // GIVEN
+    const transferer = new TransfererNotionsStructure(repositoryQuiRend('OK'))
+
+    // WHEN
+    const result = await transferer.handle({
+      idCible: 2,
+      idSource: 1,
+      notions: ['membre', 'coop'],
+      uidUtilisateur: 'alice',
+    })
+
+    // THEN
+    expect(result).toBe('OK')
+    expect(spiedTransfert).toStrictEqual({
+      idCible: 2,
+      idSource: 1,
+      notions: ['membre', 'coop'],
+      parUtilisateur: 'alice',
+    })
+  })
+
+  it('propage un échec métier remonté par le repository', async () => {
+    // GIVEN
+    const transferer = new TransfererNotionsStructure(repositoryQuiRend('collisionIdentifiantSource'))
+
+    // WHEN
+    const result = await transferer.handle({ idCible: 2, idSource: 1, notions: ['coop'], uidUtilisateur: 'alice' })
+
+    // THEN
+    expect(result).toBe('collisionIdentifiantSource')
+  })
+})
+
+let spiedTransfert: null | TransfertNotions
+
+function repositoryQuiRend(resultat: 'OK' | TransfertNotionsFailure): StructureTransfertRepository {
+  return {
+    transfererNotions(transfert: TransfertNotions): ResultAsync<TransfertNotionsFailure> {
+      spiedTransfert = transfert
+      return Promise.resolve(resultat)
+    },
+  }
+}

--- a/src/use-cases/commands/TransfererNotionsStructure.ts
+++ b/src/use-cases/commands/TransfererNotionsStructure.ts
@@ -1,0 +1,60 @@
+import { CommandHandler, ResultAsync } from '../CommandHandler'
+
+export class TransfererNotionsStructure implements CommandHandler<Command, TransfertNotionsFailure> {
+  readonly #repository: StructureTransfertRepository
+
+  constructor(repository: StructureTransfertRepository) {
+    this.#repository = repository
+  }
+
+  async handle(command: Command): ResultAsync<TransfertNotionsFailure> {
+    if (command.idSource === command.idCible) {
+      return 'transfertImpossibleMemeStructure'
+    }
+    if (command.notions.length === 0) {
+      return 'aucuneNotionSelectionnee'
+    }
+
+    return this.#repository.transfererNotions({
+      idCible: command.idCible,
+      idSource: command.idSource,
+      notions: command.notions,
+      parUtilisateur: command.uidUtilisateur,
+    })
+  }
+}
+
+export interface StructureTransfertRepository {
+  transfererNotions(transfert: TransfertNotions): ResultAsync<TransfertNotionsFailure>
+}
+
+// Une des 6 notions transférables d'une structure_administrative vers une autre. Type canonique
+// partagé : le presenter (affichage des concepts) et l'UI (cases à cocher) s'y réfèrent.
+export type NotionCle = 'aidantsConnect' | 'contacts' | 'coop' | 'idposte' | 'lieuInclusion' | 'membre'
+
+// Déplacement d'un sous-ensemble de notions de la source vers la cible. La source n'est supprimée
+// (soft-delete) que si elle ne porte plus aucune notion après le transfert. La fusion est le cas
+// particulier où l'on transfère les 6 notions (cf. étape 2c).
+export type TransfertNotions = Readonly<{
+  idCible: number
+  idSource: number
+  notions: ReadonlyArray<NotionCle>
+  parUtilisateur: string
+}>
+
+export type TransfertNotionsFailure =
+  | 'aucuneNotionSelectionnee'
+  // Une notion source porte un id scalaire (coop/tp/ac) alors que la cible en a déjà un différent.
+  | 'collisionIdentifiantSource'
+  // La cible est déjà membre d'une gouvernance dont la source est aussi membre (double rattachement).
+  | 'collisionMembreGouvernance'
+  | 'structureIntrouvable'
+  | 'transfertEchoue'
+  | 'transfertImpossibleMemeStructure'
+
+type Command = Readonly<{
+  idCible: number
+  idSource: number
+  notions: ReadonlyArray<NotionCle>
+  uidUtilisateur: string
+}>

--- a/src/use-cases/queries/ComparerStructuresAFusionner.test.ts
+++ b/src/use-cases/queries/ComparerStructuresAFusionner.test.ts
@@ -52,7 +52,10 @@ function loaderAvec(structures: ComparaisonDoublonsReadModel): ComparaisonDoublo
 
 function structureDetail(id: number, total: number): StructureDetailReadModel {
   const rattachements: RattachementsReadModel = {
+    affectationsAc: 0,
+    affectationsCoop: 0,
     affectationsEmploi: total,
+    affectationsIdposte: 0,
     associationsLieux: 0,
     contacts: 0,
     contactsMembre: 0,
@@ -76,10 +79,14 @@ function structureDetail(id: number, total: number): StructureDetailReadModel {
     id,
     latitude: null,
     longitude: null,
+    nbMandatsAc: null,
     rattachements,
     ridet: null,
     rna: null,
     siret: null,
     source: null,
+    structureAcId: null,
+    structureCoopId: null,
+    structureTpId: null,
   }
 }

--- a/src/use-cases/queries/ComparerStructuresAFusionner.ts
+++ b/src/use-cases/queries/ComparerStructuresAFusionner.ts
@@ -40,12 +40,19 @@ export type StructureDetailReadModel = Readonly<{
   // structures candidates : des antennes d'un même SIRET peuvent avoir des adresses distinctes.
   latitude: null | number
   longitude: null | number
+  // Nombre de mandats Aidants Connect (porté par la SA, indépendant des affectations).
+  nbMandatsAc: null | number
   rattachements: RattachementsReadModel
   ridet: null | string
   rna: null | string
   siret: null | string
   // Source de la donnée (edited_by) : coop, carto, aidants-connect, idposte, MIN…
   source: null | string
+  // Identifiants scalaires des sources agrégées portés inline par la SA. Une SA « porte » le
+  // concept source dès que l'id est non-NULL, même sans aucune affectation (0 ligne + id ≠ NULL).
+  structureAcId: null | string
+  structureCoopId: null | string
+  structureTpId: null | number
 }>
 
 // Ventilation des liens (FK) qui seront déplacés vers la survivante lors d'une
@@ -54,7 +61,12 @@ export type StructureDetailReadModel = Readonly<{
 // gouvernance (gouvernances, feuillesDeRoute, contactsMembre) sont des vues dérivées
 // de la relation membre, fournies pour informer la décision sans gonfler `total`.
 export type RattachementsReadModel = Readonly<{
+  // Affectations emploi ventilées par source agrégée (sous-ensembles de affectationsEmploi).
+  affectationsAc: number
+  affectationsCoop: number
+  // Total toutes sources (coop + idposte + aidants-connect + min) — conservé pour `total`.
   affectationsEmploi: number
+  affectationsIdposte: number
   associationsLieux: number
   contacts: number
   contactsMembre: number


### PR DESCRIPTION
## Contexte

Généralise la consolidation des doublons de `structure_administrative` : on peut désormais **transférer un sous-ensemble de notions** d'une structure à une autre, la **fusion** devenant le cas particulier « tout transférer + supprimer ». Couvre les étapes de l'issue (transfert des notions sources, vue de fusion, conflits C1/C2, fusion = transfert∅).

## Changements

**Moteur de transfert** (`feat`)
- Le read-model de comparaison expose les **6 notions** portées par une structure (membre+utilisateurs, contacts, coop, idposte, aidants-connect, lieu d'inclusion), affectations ventilées par source + ids scalaires `coop/tp/ac` (une notion source est « portée » dès l'id présent, même sans ligne).
- Module transactionnel partagé `deplacerNotions` (mutations par notion collision-aware, **transfert des ids scalaires avec leurs lignes**, gardes **C1** membre / **C2** id de source), opération `TransfererNotionsStructure` (use-case + gateway + action gatée Administrateur/bêta), soft-delete de la source si vidée.

**Refonte de la fusion** (`refactor`)
- La fusion s'appuie sur le moteur → **transfère** coop/tp/ac au lieu de les abandonner (fin du bug `moved_identifiers` faisant ressusciter le doublon au resync) + balayage des FK résiduelles (`source='min'`).
- La survivante **conserve tous ses champs descriptifs** (plus de récupération des infos de l'absorbée → cohérence INSEE préservée, ex. APE).
- Une **canonique** (INSEE) ne peut plus être absorbée ; la fusion **échoue** sur collision d'id de source.

**UI unifiée** (`feat`)
- Plus de double workflow Fusion/Transfert : chaque carte porte une **cible** (destination), une surcoche **Fusionner** et des **cases par notion**. Ids scalaires en collision désactivés (avec la cible ou réclamés par une autre carte). Bouton **Appliquer** = fusion groupée + N transferts, retour par structure.

## Tests
- Couverture par couche : presenter, query, command, **gateways sur base réelle** (transfert + fusion : ids scalaires transférés, `source='min'` balayée, champs survivante intacts, canonique/C2 refusées), action, composant.

Closes #1624

🤖 Generated with [Claude Code](https://claude.com/claude-code)