### PR TITLE
fix(structures-doublons): qualifier public.unaccent (crash prod, search_path Prisma)

### DIFF
--- a/src/gateways/PrismaStructuresDoublonsLoader.ts
+++ b/src/gateways/PrismaStructuresDoublonsLoader.ts
@@ -61,7 +61,9 @@ export class PrismaStructuresDoublonsLoader implements StructuresDoublonsLoader 
         -- d'un même SIREN (établissements primaire/secondaires INSEE, légitimement
         -- distincts). Seules les entités légales différentes au même nom + commune
         -- (erreur de saisie probable) sont des candidats.
-        SELECT LOWER(unaccent(sa.denomination_sirene)) AS d, a.code_insee
+        -- Préfixe public. obligatoire : Prisma fixe son propre search_path (sans public)
+        -- sur la connexion, donc un unaccent(...) non qualifié est introuvable en prod.
+        SELECT LOWER(public.unaccent(sa.denomination_sirene)) AS d, a.code_insee
         FROM sa
         JOIN main.adresse a ON a.id = sa.adresse_id
         WHERE sa.denomination_sirene IS NOT NULL AND a.code_insee IS NOT NULL
@@ -74,7 +76,7 @@ export class PrismaStructuresDoublonsLoader implements StructuresDoublonsLoader 
                sa.id
         FROM sa
         JOIN main.adresse a ON a.id = sa.adresse_id
-        JOIN dc ON dc.d = LOWER(unaccent(sa.denomination_sirene)) AND dc.code_insee = a.code_insee
+        JOIN dc ON dc.d = LOWER(public.unaccent(sa.denomination_sirene)) AND dc.code_insee = a.code_insee
       ),
       cand AS (
         SELECT * FROM cand_a


### PR DESCRIPTION
## Incident prod

`/structures-doublons` renvoyait un **Server Components render error** (digest `906648279`).
Logs Scalingo :

\`\`\`
ERROR: function unaccent(character varying) does not exist   (code 42883)
Invalid prisma.\$queryRaw() invocation ... at m.doublons (...structures-doublons/page.js)
\`\`\`

## Cause

Prisma fixe son **propre `search_path`** sur la connexion (sans `public`). Dans la requête de
détection des doublons (`PrismaStructuresDoublonsLoader`), `unaccent(...)` était la **seule
fonction non qualifiée** (tout le reste est préfixé `main.` / `min.` / `audit.`). L'extension
`unaccent` vivant dans `public`, elle était **introuvable en prod** — alors qu'elle résolvait en
psql via le `search_path` du rôle (faux négatif lors du diagnostic).

## Fix

Qualifier `public.unaccent(...)` (2 occurrences). Robuste quel que soit le `search_path`, aucune
dépendance au déploiement. Commentaire ajouté pour éviter un retrait « cleanup » futur.

## Note connexe (dataspace)

Diagnostic a aussi révélé que le rôle `min_scalingo` n'avait **aucun droit sur le schéma `audit`**
(jamais accordé depuis sa création en V037) — ce qui aurait fait échouer la **fusion** (écriture du
journal `audit.structure_merge_log`). Corrigé côté dataspace par un `GRANT` (appliqué en prod +
migration Flyway **V107** à merger séparément).

🤖 Generated with [Claude Code](https://claude.com/claude-code)