### PR TITLE
feat(structures-doublons): canoniser une antenne par synchronisation INSEE

### DIFF
--- a/src/app/api/actions/canoniserStructureAction.test.ts
+++ b/src/app/api/actions/canoniserStructureAction.test.ts
@@ -1,0 +1,65 @@
+import * as nextCache from 'next/cache'
+import { describe, expect, it } from 'vitest'
+
+import { canoniserStructureAction } from './canoniserStructureAction'
+import { utilisateurFactory } from '@/domain/testHelper'
+import * as ssoGateway from '@/gateways/NextAuthAuthentificationGateway'
+import { PrismaUtilisateurRepository } from '@/gateways/PrismaUtilisateurRepository'
+import { CanoniserStructure } from '@/use-cases/commands/CanoniserStructure'
+
+describe('canoniser une structure action', () => {
+  it('canonise et purge le cache quand un bêta-testeur confirme', async () => {
+    // GIVEN
+    vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce('userFooId')
+    vi.spyOn(PrismaUtilisateurRepository.prototype, 'get').mockResolvedValueOnce(
+      utilisateurFactory({ isBetaTesteur: true, role: 'Administrateur dispositif' })
+    )
+    vi.spyOn(CanoniserStructure.prototype, 'handle').mockResolvedValueOnce('OK')
+    vi.spyOn(nextCache, 'revalidatePath').mockImplementationOnce(() => undefined)
+
+    // WHEN
+    const messages = await canoniserStructureAction({ path: '/structures-doublons/comparer?ids=3,4', structureId: 3 })
+
+    // THEN
+    expect(CanoniserStructure.prototype.handle).toHaveBeenCalledWith({ structureId: 3, uidUtilisateur: 'userFooId' })
+    expect(nextCache.revalidatePath).toHaveBeenCalledWith('/structures-doublons/comparer?ids=3,4')
+    expect(messages).toStrictEqual(['OK'])
+  })
+
+  it('renvoie une erreur de validation quand l’identifiant est invalide', async () => {
+    // WHEN
+    const messages = await canoniserStructureAction({ path: '/structures-doublons', structureId: 0 })
+
+    // THEN
+    expect(messages).toStrictEqual(["L'identifiant de la structure doit être un entier positif"])
+  })
+
+  it('traduit le refus de canoniser quand une canonique de même SIRET existe', async () => {
+    // GIVEN
+    vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce('userFooId')
+    vi.spyOn(PrismaUtilisateurRepository.prototype, 'get').mockResolvedValueOnce(
+      utilisateurFactory({ isBetaTesteur: true, role: 'Administrateur dispositif' })
+    )
+    vi.spyOn(CanoniserStructure.prototype, 'handle').mockResolvedValueOnce('canoniqueExistante')
+
+    // WHEN
+    const messages = await canoniserStructureAction({ path: '/structures-doublons', structureId: 3 })
+
+    // THEN
+    expect(messages).toStrictEqual(['Une structure canonique existe déjà pour ce SIRET : fusionnez-la plutôt'])
+  })
+
+  it('refuse l’action à un utilisateur non bêta-testeur', async () => {
+    // GIVEN
+    vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce('userFooId')
+    vi.spyOn(PrismaUtilisateurRepository.prototype, 'get').mockResolvedValueOnce(
+      utilisateurFactory({ isBetaTesteur: false, role: 'Administrateur dispositif' })
+    )
+
+    // WHEN
+    const messages = await canoniserStructureAction({ path: '/structures-doublons', structureId: 3 })
+
+    // THEN
+    expect(messages).toStrictEqual(['Action réservée aux administrateurs autorisés'])
+  })
+})

--- a/src/app/api/actions/canoniserStructureAction.ts
+++ b/src/app/api/actions/canoniserStructureAction.ts
@@ -1,0 +1,60 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { z } from 'zod'
+
+import prisma from '../../../../prisma/prismaClient'
+import { Administrateur } from '@/domain/Administrateur'
+import { ApiBanGeocodingGateway } from '@/gateways/apiBan/ApiBanGeocodingGateway'
+import { ApiSireneLoader } from '@/gateways/apiEntreprise/ApiSireneLoader'
+import { getSessionSub } from '@/gateways/NextAuthAuthentificationGateway'
+import { PrismaStructureCanonisationRepository } from '@/gateways/PrismaStructureCanonisationRepository'
+import { PrismaUtilisateurRepository } from '@/gateways/PrismaUtilisateurRepository'
+import { CanoniserFailure, CanoniserStructure } from '@/use-cases/commands/CanoniserStructure'
+
+const MESSAGES_ECHEC: Readonly<Record<CanoniserFailure, string>> = {
+  canoniqueExistante: 'Une structure canonique existe déjà pour ce SIRET : fusionnez-la plutôt',
+  canonisationEchouee: 'La canonisation a échoué, aucune modification effectuée',
+  entrepriseIntrouvable: 'Aucun établissement actif trouvé à l’INSEE pour ce SIRET',
+  siretManquant: 'La structure n’a pas de SIRET : impossible d’interroger l’INSEE',
+  structureDejaCanonique: 'Cette structure est déjà canonique',
+  structureIntrouvable: 'Structure introuvable ou déjà supprimée',
+}
+
+export async function canoniserStructureAction(actionParams: ActionParams): Promise<ReadonlyArray<string>> {
+  const validationResult = validator.safeParse(actionParams)
+  if (validationResult.error) {
+    return validationResult.error.issues.map(({ message }) => message)
+  }
+
+  // Garde : opération réservée aux bêta-testeurs (administrateur dispositif + flag is_beta_testeur).
+  const sub = await getSessionSub()
+  const utilisateur = await new PrismaUtilisateurRepository(prisma.utilisateurRecord).get(sub)
+  if (!(utilisateur instanceof Administrateur) || !utilisateur.isBetaTesteur) {
+    return ['Action réservée aux administrateurs autorisés']
+  }
+
+  const result = await new CanoniserStructure(
+    new ApiSireneLoader(),
+    new ApiBanGeocodingGateway(),
+    new PrismaStructureCanonisationRepository()
+  ).handle({ structureId: validationResult.data.structureId, uidUtilisateur: sub })
+
+  if (result !== 'OK') {
+    return [MESSAGES_ECHEC[result]]
+  }
+
+  revalidatePath(validationResult.data.path)
+
+  return ['OK']
+}
+
+type ActionParams = Readonly<{
+  path: string
+  structureId: number
+}>
+
+const validator = z.object({
+  path: z.string().min(1, { message: 'Le chemin doit être renseigné' }),
+  structureId: z.number().int().positive({ message: "L'identifiant de la structure doit être un entier positif" }),
+})

--- a/src/components/StructuresDoublons/ComparerStructures.test.tsx
+++ b/src/components/StructuresDoublons/ComparerStructures.test.tsx
@@ -163,7 +163,7 @@ describe('consolider un doublon (cible + transfert/fusion par notion)', () => {
     renderComponent(<ComparerStructures viewModel={deuxStructures()} />)
 
     // THEN
-    expect(screen.getByRole('button', { name: 'Synchroniser avec INSEE' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Synchroniser avec l’INSEE' })).toBeDisabled()
     expect(screen.getByText(/Une structure canonique de même SIRET est déjà présente/)).toBeInTheDocument()
   })
 
@@ -178,7 +178,27 @@ describe('consolider un doublon (cible + transfert/fusion par notion)', () => {
     renderComponent(<ComparerStructures viewModel={viewModel} />)
 
     // THEN
-    expect(screen.getByRole('button', { name: 'Synchroniser avec INSEE' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Synchroniser avec l’INSEE' })).toBeEnabled()
+  })
+
+  it('ouvre la modale de canonisation au clic et déclenche la récupération INSEE', async () => {
+    // GIVEN une antenne sans canonique de même SIRET dans le groupe.
+    const rechercherUneEntrepriseAction = vi
+      .fn<(actionParam: Readonly<{ siret: string }>) => Promise<ReadonlyArray<string>>>()
+      .mockResolvedValue(['x'])
+    const viewModel: ComparaisonViewModel = [
+      carte({ denomination: 'Cible', estCanonique: true, id: 3 }),
+      carte({ denomination: 'Antenne', id: 7, siret: '99999999900099' }),
+    ]
+    renderComponent(<ComparerStructures viewModel={viewModel} />, { rechercherUneEntrepriseAction })
+
+    // WHEN
+    fireEvent.click(screen.getByRole('button', { name: 'Synchroniser avec l’INSEE' }))
+
+    // THEN : l'ouverture de la modale déclenche la requête INSEE pour ce SIRET.
+    await vi.waitFor(() => {
+      expect(rechercherUneEntrepriseAction).toHaveBeenCalledWith({ siret: '99999999900099' })
+    })
   })
 })
 

--- a/src/components/StructuresDoublons/ComparerStructures.test.tsx
+++ b/src/components/StructuresDoublons/ComparerStructures.test.tsx
@@ -157,6 +157,29 @@ describe('consolider un doublon (cible + transfert/fusion par notion)', () => {
     expect(screen.getByRole('columnheader', { name: 'Cible' })).toBeInTheDocument()
     expect(screen.queryByRole('checkbox', { name: /Fusionner/ })).not.toBeInTheDocument()
   })
+
+  it('désactive le CTA « Synchroniser avec INSEE » quand une canonique de même SIRET est présente', () => {
+    // WHEN : l'antenne 7 partage son SIRET avec la canonique 3.
+    renderComponent(<ComparerStructures viewModel={deuxStructures()} />)
+
+    // THEN
+    expect(screen.getByRole('button', { name: 'Synchroniser avec INSEE' })).toBeDisabled()
+    expect(screen.getByText(/Une structure canonique de même SIRET est déjà présente/)).toBeInTheDocument()
+  })
+
+  it('active le CTA « Synchroniser avec INSEE » sur une antenne sans canonique de même SIRET', () => {
+    // GIVEN : antenne 7 avec un SIRET distinct de la canonique 3.
+    const viewModel: ComparaisonViewModel = [
+      carte({ denomination: 'Cible', estCanonique: true, id: 3 }),
+      carte({ denomination: 'Antenne', id: 7, siret: '99999999900099' }),
+    ]
+
+    // WHEN
+    renderComponent(<ComparerStructures viewModel={viewModel} />)
+
+    // THEN
+    expect(screen.getByRole('button', { name: 'Synchroniser avec INSEE' })).toBeEnabled()
+  })
 })
 
 function deuxStructures(): ComparaisonViewModel {
@@ -208,6 +231,7 @@ function carte(
     longitude: 1.49,
     rattachements: [{ label: 'Postes', nombre: 1 }],
     rattachementsTotal: 1,
+    siret: '22280001300013',
     ...overrides,
   }
 }

--- a/src/components/StructuresDoublons/ComparerStructures.tsx
+++ b/src/components/StructuresDoublons/ComparerStructures.tsx
@@ -259,15 +259,13 @@ export default function ComparerStructures({ viewModel }: Props): ReactElement {
         )}
       </ConfirmationModal>
 
-      {structureCanonisation === undefined ? null : (
-        <ModaleCanonisation
-          isOpen={idCanonisation !== null}
-          onClose={() => {
-            setIdCanonisation(null)
-          }}
-          structure={structureCanonisation}
-        />
-      )}
+      <ModaleCanonisation
+        isOpen={idCanonisation !== null}
+        onClose={() => {
+          setIdCanonisation(null)
+        }}
+        structure={structureCanonisation ?? viewModel[0]}
+      />
     </section>
   )
 }
@@ -454,7 +452,7 @@ function CarteStructure({
             onClick={onCanoniser}
             type="button"
           >
-            Synchroniser avec INSEE
+            Synchroniser avec l’INSEE
           </button>
           {structure.siret === null ? (
             <p className="fr-text--xs fr-text-mention--grey fr-mt-1v">

--- a/src/components/StructuresDoublons/ComparerStructures.tsx
+++ b/src/components/StructuresDoublons/ComparerStructures.tsx
@@ -2,6 +2,7 @@
 
 import { CSSProperties, ReactElement, useContext, useState } from 'react'
 
+import ModaleCanonisation from './ModaleCanonisation'
 import Information from '../shared/Information/Information'
 import ConfirmationModal from '../shared/Modal/ConfirmationModal'
 import { Notification } from '../shared/Notification/Notification'
@@ -38,7 +39,19 @@ export default function ComparerStructures({ viewModel }: Props): ReactElement {
   const [etats, setEtats] = useState<Readonly<Record<number, EtatCarte | undefined>>>({})
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [idCanonisation, setIdCanonisation] = useState<null | number>(null)
   const [vue, setVue] = useState<Vue>('comparer')
+
+  // Une antenne ne peut être canonisée s'il existe déjà une canonique de même SIRET dans le groupe :
+  // la contrainte UNIQUE (siret, denomination_antenne) l'interdirait (garde aussi appliquée côté serveur).
+  function collisionCanonique(structure: StructureComparaisonViewModel): boolean {
+    return viewModel.some(
+      (autre) =>
+        autre.id !== structure.id && autre.estCanonique && autre.siret !== null && autre.siret === structure.siret
+    )
+  }
+
+  const structureCanonisation = viewModel.find((structure) => structure.id === idCanonisation)
 
   const cible = viewModel.find((structure) => structure.id === idCible)
   const cartesFusion = viewModel.filter((structure) => etats[structure.id]?.fusionner)
@@ -180,9 +193,13 @@ export default function ComparerStructures({ viewModel }: Props): ReactElement {
           {viewModel.map((structure) => (
             <div className="fr-col-12 fr-col-md-6" key={structure.id}>
               <CarteStructure
+                collisionCanonique={collisionCanonique(structure)}
                 estCible={structure.id === idCible}
                 etat={etatDe(structure.id)}
                 idScalaireDisponible={(concept) => idScalaireDisponible(concept, structure.id)}
+                onCanoniser={() => {
+                  setIdCanonisation(structure.id)
+                }}
                 onCible={() => {
                   definirCible(structure.id)
                 }}
@@ -241,6 +258,16 @@ export default function ComparerStructures({ viewModel }: Props): ReactElement {
           />
         )}
       </ConfirmationModal>
+
+      {structureCanonisation === undefined ? null : (
+        <ModaleCanonisation
+          isOpen={idCanonisation !== null}
+          onClose={() => {
+            setIdCanonisation(null)
+          }}
+          structure={structureCanonisation}
+        />
+      )}
     </section>
   )
 }
@@ -298,17 +325,21 @@ function MatriceDistances({ matrice }: Readonly<{ matrice: MatriceDistancesViewM
 }
 
 function CarteStructure({
+  collisionCanonique,
   estCible,
   etat,
   idScalaireDisponible,
+  onCanoniser,
   onCible,
   onToggleFusion,
   onToggleNotion,
   structure,
 }: Readonly<{
+  collisionCanonique: boolean
   estCible: boolean
   etat: EtatCarte
   idScalaireDisponible(concept: ConceptViewModel): boolean
+  onCanoniser(): void
   onCible(): void
   onToggleFusion(): void
   onToggleNotion(cle: NotionCle): void
@@ -414,6 +445,30 @@ function CarteStructure({
           </div>
         ))}
       </dl>
+
+      {structure.estCanonique ? null : (
+        <div className="fr-mb-2w">
+          <button
+            className="fr-btn fr-btn--secondary fr-btn--sm fr-icon-refresh-line fr-btn--icon-left"
+            disabled={collisionCanonique || structure.siret === null}
+            onClick={onCanoniser}
+            type="button"
+          >
+            Synchroniser avec INSEE
+          </button>
+          {structure.siret === null ? (
+            <p className="fr-text--xs fr-text-mention--grey fr-mt-1v">
+              Sans SIRET, la structure ne peut pas être canonisée depuis l’INSEE.
+            </p>
+          ) : null}
+          {collisionCanonique ? (
+            <p className="fr-text--xs fr-text-mention--grey fr-mt-1v">
+              Une structure canonique de même SIRET est déjà présente : fusionnez-la plutôt que de canoniser cette
+              antenne.
+            </p>
+          ) : null}
+        </div>
+      )}
 
       <p className="fr-text--sm fr-text--bold fr-mb-1v">Détail des rattachements</p>
       {rattachementsDetail.length === 0 ? (

--- a/src/components/StructuresDoublons/ModaleCanonisation.test.tsx
+++ b/src/components/StructuresDoublons/ModaleCanonisation.test.tsx
@@ -14,13 +14,13 @@ describe('modale de canonisation (comparaison structure / INSEE)', () => {
     const previsualiserAdresseAction = vi
       .fn<(adresse: string) => Promise<null | Readonly<{ label: string; score: number }>>>()
       .mockResolvedValueOnce({ label: '20 Avenue de Ségur, 75007 Paris', score: 0.97 })
-    const push = vi.fn<() => void>()
+    const refresh = vi.fn<() => void>()
     renderComponent(<ModaleCanonisation isOpen onClose={vi.fn<() => void>()} structure={antenne()} />, {
       canoniserStructureAction,
       pathname: '/structures-doublons/comparer?ids=7,3',
       previsualiserAdresseAction,
       rechercherUneEntrepriseAction,
-      router: routerStub(push),
+      router: routerStub({ refresh }),
     })
 
     // WHEN : l'image INSEE se charge puis on synchronise.
@@ -41,7 +41,7 @@ describe('modale de canonisation (comparaison structure / INSEE)', () => {
       path: '/structures-doublons/comparer?ids=7,3',
       structureId: 7,
     })
-    expect(push).toHaveBeenCalledWith('/structures-doublons')
+    expect(refresh).toHaveBeenCalledWith()
   })
 
   it('affiche une erreur quand l’INSEE ne renvoie aucun établissement', async () => {
@@ -58,17 +58,17 @@ describe('modale de canonisation (comparaison structure / INSEE)', () => {
     expect(erreur).toBeInTheDocument()
   })
 
-  it('affiche une erreur de synchronisation sans rediriger', async () => {
+  it('affiche une erreur de synchronisation sans rafraîchir', async () => {
     // GIVEN
     const rechercherUneEntrepriseAction = rechercherMock().mockResolvedValueOnce(insee)
     const canoniserStructureAction = canoniserMock().mockResolvedValueOnce([
       'Une structure canonique existe déjà pour ce SIRET : fusionnez-la plutôt',
     ])
-    const push = vi.fn<() => void>()
+    const refresh = vi.fn<() => void>()
     renderComponent(<ModaleCanonisation isOpen onClose={vi.fn<() => void>()} structure={antenne()} />, {
       canoniserStructureAction,
       rechercherUneEntrepriseAction,
-      router: routerStub(push),
+      router: routerStub({ refresh }),
     })
 
     // WHEN
@@ -77,7 +77,7 @@ describe('modale de canonisation (comparaison structure / INSEE)', () => {
     // THEN
     const notification = await screen.findByRole('alert')
     expect(notification.textContent).toContain('Erreur :')
-    expect(push).not.toHaveBeenCalled()
+    expect(refresh).not.toHaveBeenCalled()
   })
 
   it('ignore le clic « Synchroniser » tant que l’image INSEE n’est pas chargée', () => {
@@ -185,7 +185,7 @@ function antenne(overrides: Partial<StructureComparaisonViewModel> = {}): Struct
   }
 }
 
-function routerStub(push: () => void): Readonly<{
+function routerStub(spies: Readonly<{ push?(): void; refresh?(): void }> = {}): Readonly<{
   back(): void
   forward(): void
   prefetch(): void
@@ -197,8 +197,8 @@ function routerStub(push: () => void): Readonly<{
     back: vi.fn<() => void>(),
     forward: vi.fn<() => void>(),
     prefetch: vi.fn<() => void>(),
-    push,
-    refresh: vi.fn<() => void>(),
+    push: spies.push ?? vi.fn<() => void>(),
+    refresh: spies.refresh ?? vi.fn<() => void>(),
     replace: vi.fn<() => void>(),
   }
 }

--- a/src/components/StructuresDoublons/ModaleCanonisation.test.tsx
+++ b/src/components/StructuresDoublons/ModaleCanonisation.test.tsx
@@ -11,10 +11,14 @@ describe('modale de canonisation (comparaison structure / INSEE)', () => {
     // GIVEN
     const rechercherUneEntrepriseAction = rechercherMock().mockResolvedValueOnce(insee)
     const canoniserStructureAction = canoniserMock().mockResolvedValueOnce(['OK'])
+    const previsualiserAdresseAction = vi
+      .fn<(adresse: string) => Promise<null | Readonly<{ label: string; score: number }>>>()
+      .mockResolvedValueOnce({ label: '20 Avenue de Ségur, 75007 Paris', score: 0.97 })
     const push = vi.fn<() => void>()
     renderComponent(<ModaleCanonisation isOpen onClose={vi.fn<() => void>()} structure={antenne()} />, {
       canoniserStructureAction,
       pathname: '/structures-doublons/comparer?ids=7,3',
+      previsualiserAdresseAction,
       rechercherUneEntrepriseAction,
       router: routerStub(push),
     })
@@ -25,6 +29,10 @@ describe('modale de canonisation (comparaison structure / INSEE)', () => {
     expect(screen.getByText('AGENCE NATIONALE')).toBeInTheDocument()
     // APE : code + libellé côté INSEE (comparé au code de la structure, pas au libellé).
     expect(screen.getByText('84.12Z — Administration publique')).toBeInTheDocument()
+    // Adresse banifiée affichée côté INSEE (pas la chaîne brute INSEE en majuscules).
+    expect(previsualiserAdresseAction).toHaveBeenCalledWith('20 AVENUE DE SEGUR, 75007 PARIS')
+    expect(screen.getByText('20 Avenue de Ségur, 75007 Paris')).toBeInTheDocument()
+    expect(screen.queryByText('20 AVENUE DE SEGUR, 75007 PARIS')).not.toBeInTheDocument()
     fireEvent.click(bouton)
 
     // THEN

--- a/src/components/StructuresDoublons/ModaleCanonisation.test.tsx
+++ b/src/components/StructuresDoublons/ModaleCanonisation.test.tsx
@@ -1,0 +1,194 @@
+import { fireEvent, screen } from '@testing-library/react'
+import { describe, expect, it, Mock, vi } from 'vitest'
+
+import ModaleCanonisation from './ModaleCanonisation'
+import { EntrepriseViewModel } from '@/components/shared/Membre/EntrepriseType'
+import { renderComponent } from '@/components/testHelper'
+import { StructureComparaisonViewModel } from '@/presenters/comparaisonDoublonsPresenter'
+
+describe('modale de canonisation (comparaison structure / INSEE)', () => {
+  it('charge l’image INSEE, l’affiche et synchronise au clic', async () => {
+    // GIVEN
+    const rechercherUneEntrepriseAction = rechercherMock().mockResolvedValueOnce(insee)
+    const canoniserStructureAction = canoniserMock().mockResolvedValueOnce(['OK'])
+    const push = vi.fn<() => void>()
+    renderComponent(<ModaleCanonisation isOpen onClose={vi.fn<() => void>()} structure={antenne()} />, {
+      canoniserStructureAction,
+      pathname: '/structures-doublons/comparer?ids=7,3',
+      rechercherUneEntrepriseAction,
+      router: routerStub(push),
+    })
+
+    // WHEN : l'image INSEE se charge puis on synchronise.
+    const bouton = await screen.findByRole('button', { name: 'Synchroniser avec INSEE' })
+    expect(rechercherUneEntrepriseAction).toHaveBeenCalledWith({ siret: '13002603200016' })
+    expect(screen.getByText('AGENCE NATIONALE')).toBeInTheDocument()
+    fireEvent.click(bouton)
+
+    // THEN
+    await screen.findByRole('status')
+    expect(canoniserStructureAction).toHaveBeenCalledWith({
+      path: '/structures-doublons/comparer?ids=7,3',
+      structureId: 7,
+    })
+    expect(push).toHaveBeenCalledWith('/structures-doublons')
+  })
+
+  it('affiche une erreur quand l’INSEE ne renvoie aucun établissement', async () => {
+    // GIVEN
+    const rechercherUneEntrepriseAction = rechercherMock().mockResolvedValueOnce([
+      'Aucun établissement trouvé avec ce SIRET',
+    ])
+    renderComponent(<ModaleCanonisation isOpen onClose={vi.fn<() => void>()} structure={antenne()} />, {
+      rechercherUneEntrepriseAction,
+    })
+
+    // THEN
+    const erreur = await screen.findByText('Aucun établissement trouvé avec ce SIRET')
+    expect(erreur).toBeInTheDocument()
+  })
+
+  it('affiche une erreur de synchronisation sans rediriger', async () => {
+    // GIVEN
+    const rechercherUneEntrepriseAction = rechercherMock().mockResolvedValueOnce(insee)
+    const canoniserStructureAction = canoniserMock().mockResolvedValueOnce([
+      'Une structure canonique existe déjà pour ce SIRET : fusionnez-la plutôt',
+    ])
+    const push = vi.fn<() => void>()
+    renderComponent(<ModaleCanonisation isOpen onClose={vi.fn<() => void>()} structure={antenne()} />, {
+      canoniserStructureAction,
+      rechercherUneEntrepriseAction,
+      router: routerStub(push),
+    })
+
+    // WHEN
+    fireEvent.click(await screen.findByRole('button', { name: 'Synchroniser avec INSEE' }))
+
+    // THEN
+    const notification = await screen.findByRole('alert')
+    expect(notification.textContent).toContain('Erreur :')
+    expect(push).not.toHaveBeenCalled()
+  })
+
+  it('ignore le clic « Synchroniser » tant que l’image INSEE n’est pas chargée', () => {
+    // GIVEN une récupération INSEE qui ne se résout jamais (état « chargement »).
+    const rechercherUneEntrepriseAction = rechercherMock().mockReturnValueOnce(new Promise<never>(() => {}))
+    const canoniserStructureAction = canoniserMock().mockResolvedValueOnce(['OK'])
+    renderComponent(<ModaleCanonisation isOpen onClose={vi.fn<() => void>()} structure={antenne()} />, {
+      canoniserStructureAction,
+      rechercherUneEntrepriseAction,
+    })
+
+    // WHEN : le bouton est encore au libellé « Chargement… ».
+    fireEvent.click(screen.getByRole('button', { name: 'Chargement…' }))
+
+    // THEN
+    expect(canoniserStructureAction).not.toHaveBeenCalled()
+  })
+
+  it('affiche une erreur réseau si la récupération INSEE échoue', async () => {
+    // GIVEN
+    const rechercherUneEntrepriseAction = rechercherMock().mockRejectedValueOnce(new Error('réseau'))
+    renderComponent(<ModaleCanonisation isOpen onClose={vi.fn<() => void>()} structure={antenne()} />, {
+      rechercherUneEntrepriseAction,
+    })
+
+    // THEN
+    const erreur = await screen.findByText('Erreur lors de la récupération des données INSEE.')
+    expect(erreur).toBeInTheDocument()
+  })
+
+  it('n’interroge pas l’INSEE tant que la modale est fermée', () => {
+    // GIVEN
+    const rechercherUneEntrepriseAction = rechercherMock()
+
+    // WHEN
+    renderComponent(<ModaleCanonisation isOpen={false} onClose={vi.fn<() => void>()} structure={antenne()} />, {
+      rechercherUneEntrepriseAction,
+    })
+
+    // THEN
+    expect(rechercherUneEntrepriseAction).not.toHaveBeenCalled()
+  })
+
+  it('signale l’absence de SIRET sans interroger l’INSEE', async () => {
+    // GIVEN
+    const rechercherUneEntrepriseAction = rechercherMock()
+    renderComponent(<ModaleCanonisation isOpen onClose={vi.fn<() => void>()} structure={antenne({ siret: null })} />, {
+      rechercherUneEntrepriseAction,
+    })
+
+    // THEN
+    const message = await screen.findByText(/La structure n’a pas de SIRET/)
+    expect(message).toBeInTheDocument()
+    expect(rechercherUneEntrepriseAction).not.toHaveBeenCalled()
+  })
+})
+
+const insee: EntrepriseViewModel = {
+  activitePrincipale: '84.12Z',
+  activitePrincipaleLibelle: 'Administration publique',
+  adresse: '20 AVENUE DE SEGUR, 75007 PARIS',
+  categorieJuridiqueCode: '7389',
+  categorieJuridiqueLibelle: 'Établissement public national',
+  codeInsee: '75107',
+  codePostal: '75007',
+  commune: 'PARIS',
+  denomination: 'AGENCE NATIONALE',
+  identifiant: '13002603200016',
+  nomVoie: 'AVENUE DE SEGUR',
+  numeroVoie: '20',
+}
+
+function rechercherMock(): Mock<
+  (actionParam: Readonly<{ siret: string }>) => Promise<EntrepriseViewModel | ReadonlyArray<string>>
+> {
+  return vi.fn<(actionParam: Readonly<{ siret: string }>) => Promise<EntrepriseViewModel | ReadonlyArray<string>>>()
+}
+
+function canoniserMock(): Mock<
+  (actionParams: Readonly<{ path: string; structureId: number }>) => Promise<ReadonlyArray<string>>
+> {
+  return vi.fn<(actionParams: Readonly<{ path: string; structureId: number }>) => Promise<ReadonlyArray<string>>>()
+}
+
+function antenne(overrides: Partial<StructureComparaisonViewModel> = {}): StructureComparaisonViewModel {
+  return {
+    adresse: '1 rue de Test 28000 Chartres',
+    champs: [
+      { label: 'État administratif', valeur: 'A' },
+      { label: 'Code activité (APE)', valeur: '88.99B' },
+    ],
+    concepts: [],
+    denomination: 'Antenne Chartres',
+    denominationSirene: 'Antenne Chartres',
+    estAssocieLieuInclusion: false,
+    estCanonique: false,
+    estMembre: false,
+    id: 7,
+    latitude: 48.45,
+    longitude: 1.49,
+    rattachements: [],
+    rattachementsTotal: 0,
+    siret: '13002603200016',
+    ...overrides,
+  }
+}
+
+function routerStub(push: () => void): Readonly<{
+  back(): void
+  forward(): void
+  prefetch(): void
+  push(): void
+  refresh(): void
+  replace(): void
+}> {
+  return {
+    back: vi.fn<() => void>(),
+    forward: vi.fn<() => void>(),
+    prefetch: vi.fn<() => void>(),
+    push,
+    refresh: vi.fn<() => void>(),
+    replace: vi.fn<() => void>(),
+  }
+}

--- a/src/components/StructuresDoublons/ModaleCanonisation.test.tsx
+++ b/src/components/StructuresDoublons/ModaleCanonisation.test.tsx
@@ -23,6 +23,8 @@ describe('modale de canonisation (comparaison structure / INSEE)', () => {
     const bouton = await screen.findByRole('button', { name: 'Synchroniser avec INSEE' })
     expect(rechercherUneEntrepriseAction).toHaveBeenCalledWith({ siret: '13002603200016' })
     expect(screen.getByText('AGENCE NATIONALE')).toBeInTheDocument()
+    // APE : code + libellé côté INSEE (comparé au code de la structure, pas au libellé).
+    expect(screen.getByText('84.12Z — Administration publique')).toBeInTheDocument()
     fireEvent.click(bouton)
 
     // THEN

--- a/src/components/StructuresDoublons/ModaleCanonisation.tsx
+++ b/src/components/StructuresDoublons/ModaleCanonisation.tsx
@@ -144,17 +144,35 @@ function lignesComparaison(
     return structure.champs.find((candidat) => candidat.label === label)?.valeur ?? '—'
   }
 
+  // La structure ne stocke que le code APE ; on compare donc code à code et on affiche « code — libellé »
+  // côté INSEE pour que la ligne ne paraisse pas différente alors qu'il s'agit du même code.
+  const apeStructure = champ('Code activité (APE)')
+
   return [
     ligne('Dénomination', structure.denominationSirene || '—', entreprise.denomination),
     ligne('Adresse', structure.adresse, entreprise.adresse),
     ligne('État administratif', champ('État administratif'), 'Actif'),
-    ligne('Code activité (APE)', champ('Code activité (APE)'), entreprise.activitePrincipaleLibelle),
-    ligne('Catégorie juridique', '—', entreprise.categorieJuridiqueLibelle),
+    {
+      identique: apeStructure === entreprise.activitePrincipale,
+      insee: avecLibelle(entreprise.activitePrincipale, entreprise.activitePrincipaleLibelle),
+      label: 'Code activité (APE)',
+      structure: apeStructure,
+    },
+    ligne(
+      'Catégorie juridique',
+      '—',
+      avecLibelle(entreprise.categorieJuridiqueCode, entreprise.categorieJuridiqueLibelle)
+    ),
   ]
 }
 
 function ligne(label: string, valeurStructure: string, valeurInsee: string): LigneComparaison {
   return { identique: valeurStructure === valeurInsee, insee: valeurInsee, label, structure: valeurStructure }
+}
+
+// « code — libellé » si le libellé existe et diffère du code, sinon le code seul.
+function avecLibelle(code: string, libelle: string): string {
+  return libelle === '' || libelle === code ? code : `${code} — ${libelle}`
 }
 
 // État du chargement de l'image INSEE : en attente, chargée, ou en erreur (introuvable / réseau).

--- a/src/components/StructuresDoublons/ModaleCanonisation.tsx
+++ b/src/components/StructuresDoublons/ModaleCanonisation.tsx
@@ -47,7 +47,9 @@ export default function ModaleCanonisation({ isOpen, onClose, structure }: Props
     if (messages.includes('OK')) {
       onClose()
       Notification('success', { description: 'synchronisée avec l’INSEE', title: 'Structure ' })
-      router.push('/structures-doublons')
+      // La structure reste sur la page comparer mais devient canonique : on rafraîchit en place (le
+      // serveur a déjà revalidé le chemin) plutôt que de naviguer, pour que la carte se mette à jour.
+      router.refresh()
     } else {
       Notification('error', { description: messages.join(' · '), title: 'Erreur : ' })
     }

--- a/src/components/StructuresDoublons/ModaleCanonisation.tsx
+++ b/src/components/StructuresDoublons/ModaleCanonisation.tsx
@@ -7,6 +7,7 @@ import { Notification } from '../shared/Notification/Notification'
 import { clientContext } from '@/components/shared/ClientContext'
 import { EntrepriseViewModel } from '@/components/shared/Membre/EntrepriseType'
 import { StructureComparaisonViewModel } from '@/presenters/comparaisonDoublonsPresenter'
+import { ETAT_ADMINISTRATIF_CANONIQUE } from '@/shared/etatAdministratif'
 
 export default function ModaleCanonisation({ isOpen, onClose, structure }: Props): ReactElement {
   const { canoniserStructureAction, pathname, previsualiserAdresseAction, rechercherUneEntrepriseAction, router } =
@@ -164,7 +165,7 @@ function lignesComparaison(
       label: 'Adresse',
       structure: structure.adresse,
     },
-    ligne('État administratif', champ('État administratif'), 'Actif'),
+    ligne('État administratif', champ('État administratif'), ETAT_ADMINISTRATIF_CANONIQUE),
     {
       identique: apeStructure === entreprise.activitePrincipale,
       insee: avecLibelle(entreprise.activitePrincipale, entreprise.activitePrincipaleLibelle),

--- a/src/components/StructuresDoublons/ModaleCanonisation.tsx
+++ b/src/components/StructuresDoublons/ModaleCanonisation.tsx
@@ -1,0 +1,170 @@
+'use client'
+
+import { ReactElement, useContext, useEffect, useState } from 'react'
+
+import ConfirmationModal from '../shared/Modal/ConfirmationModal'
+import { Notification } from '../shared/Notification/Notification'
+import { clientContext } from '@/components/shared/ClientContext'
+import { EntrepriseViewModel } from '@/components/shared/Membre/EntrepriseType'
+import { StructureComparaisonViewModel } from '@/presenters/comparaisonDoublonsPresenter'
+
+export default function ModaleCanonisation({ isOpen, onClose, structure }: Props): ReactElement {
+  const { canoniserStructureAction, pathname, rechercherUneEntrepriseAction, router } = useContext(clientContext)
+  const [etat, setEtat] = useState<EtatInsee>({ statut: 'chargement' })
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  useEffect(() => {
+    if (!isOpen) {
+      return
+    }
+    if (structure.siret === null) {
+      setEtat({ message: 'La structure n’a pas de SIRET : comparaison INSEE impossible.', statut: 'erreur' })
+      return
+    }
+    setEtat({ statut: 'chargement' })
+    rechercherUneEntrepriseAction({ siret: structure.siret })
+      .then((resultat) => {
+        if ('denomination' in resultat) {
+          setEtat({ entreprise: resultat, statut: 'chargee' })
+        } else {
+          setEtat({ message: resultat.join(' · '), statut: 'erreur' })
+        }
+      })
+      .catch(() => {
+        setEtat({ message: 'Erreur lors de la récupération des données INSEE.', statut: 'erreur' })
+      })
+  }, [isOpen, structure.siret, rechercherUneEntrepriseAction])
+
+  async function synchroniser(): Promise<void> {
+    setIsSubmitting(true)
+    const messages = await canoniserStructureAction({ path: pathname, structureId: structure.id })
+    setIsSubmitting(false)
+    if (messages.includes('OK')) {
+      onClose()
+      Notification('success', { description: 'synchronisée avec l’INSEE', title: 'Structure ' })
+      router.push('/structures-doublons')
+    } else {
+      Notification('error', { description: messages.join(' · '), title: 'Erreur : ' })
+    }
+  }
+
+  const peutSynchroniser = etat.statut === 'chargee' && !isSubmitting
+
+  return (
+    <ConfirmationModal
+      cancelLabel="Fermer"
+      confirmLabel={confirmLabel(etat.statut, isSubmitting)}
+      id={`canoniser-${structure.id}`}
+      isOpen={isOpen}
+      onCancel={onClose}
+      onConfirm={() => {
+        if (peutSynchroniser) {
+          void synchroniser()
+        }
+      }}
+      title="Synchroniser avec l’INSEE"
+    >
+      <p className="fr-text--sm fr-text-mention--grey">
+        La synchronisation aligne la structure sur son image INSEE (dénomination, adresse, état, activité, catégorie
+        juridique) et la rend <span className="fr-text--bold">canonique</span> (suppression du libellé d’antenne).
+        Action tracée et réservée aux administrateurs autorisés.
+      </p>
+      <Comparaison etat={etat} structure={structure} />
+    </ConfirmationModal>
+  )
+}
+
+function confirmLabel(statut: EtatInsee['statut'], isSubmitting: boolean): string {
+  if (isSubmitting) {
+    return 'Synchronisation…'
+  }
+  if (statut === 'chargement') {
+    return 'Chargement…'
+  }
+
+  return 'Synchroniser avec INSEE'
+}
+
+function Comparaison({
+  etat,
+  structure,
+}: Readonly<{ etat: EtatInsee; structure: StructureComparaisonViewModel }>): ReactElement {
+  if (etat.statut === 'chargement') {
+    return <p className="fr-mt-2w">Récupération des données INSEE…</p>
+  }
+  if (etat.statut === 'erreur') {
+    return <p className="fr-mt-2w fr-error-text">{etat.message}</p>
+  }
+
+  const lignes = lignesComparaison(structure, etat.entreprise)
+
+  return (
+    <div className="fr-table fr-table--md fr-mt-2w">
+      <div className="fr-table__wrapper">
+        <div className="fr-table__container">
+          <div className="fr-table__content">
+            <table>
+              <caption className="fr-sr-only">Comparaison entre la structure et l’INSEE</caption>
+              <thead>
+                <tr>
+                  <th scope="col">Champ</th>
+                  <th scope="col">Structure (actuel)</th>
+                  <th scope="col">INSEE (après synchro)</th>
+                </tr>
+              </thead>
+              <tbody>
+                {lignes.map((ligne) => (
+                  <tr key={ligne.label}>
+                    <th scope="row">{ligne.label}</th>
+                    <td>{ligne.structure}</td>
+                    <td className={ligne.identique ? '' : 'fr-text--bold'}>{ligne.insee}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+type LigneComparaison = Readonly<{
+  identique: boolean
+  insee: string
+  label: string
+  structure: string
+}>
+
+function lignesComparaison(
+  structure: StructureComparaisonViewModel,
+  entreprise: EntrepriseViewModel
+): ReadonlyArray<LigneComparaison> {
+  function champ(label: string): string {
+    return structure.champs.find((candidat) => candidat.label === label)?.valeur ?? '—'
+  }
+
+  return [
+    ligne('Dénomination', structure.denominationSirene || '—', entreprise.denomination),
+    ligne('Adresse', structure.adresse, entreprise.adresse),
+    ligne('État administratif', champ('État administratif'), 'Actif'),
+    ligne('Code activité (APE)', champ('Code activité (APE)'), entreprise.activitePrincipaleLibelle),
+    ligne('Catégorie juridique', '—', entreprise.categorieJuridiqueLibelle),
+  ]
+}
+
+function ligne(label: string, valeurStructure: string, valeurInsee: string): LigneComparaison {
+  return { identique: valeurStructure === valeurInsee, insee: valeurInsee, label, structure: valeurStructure }
+}
+
+// État du chargement de l'image INSEE : en attente, chargée, ou en erreur (introuvable / réseau).
+type EtatInsee =
+  | Readonly<{ entreprise: EntrepriseViewModel; statut: 'chargee' }>
+  | Readonly<{ message: string; statut: 'erreur' }>
+  | Readonly<{ statut: 'chargement' }>
+
+type Props = Readonly<{
+  isOpen: boolean
+  onClose(): void
+  structure: StructureComparaisonViewModel
+}>

--- a/src/components/StructuresDoublons/ModaleCanonisation.tsx
+++ b/src/components/StructuresDoublons/ModaleCanonisation.tsx
@@ -54,7 +54,7 @@ export default function ModaleCanonisation({ isOpen, onClose, structure }: Props
     <ConfirmationModal
       cancelLabel="Fermer"
       confirmLabel={confirmLabel(etat.statut, isSubmitting)}
-      id={`canoniser-${structure.id}`}
+      id="canoniser-structure"
       isOpen={isOpen}
       onCancel={onClose}
       onConfirm={() => {

--- a/src/components/StructuresDoublons/ModaleCanonisation.tsx
+++ b/src/components/StructuresDoublons/ModaleCanonisation.tsx
@@ -9,7 +9,8 @@ import { EntrepriseViewModel } from '@/components/shared/Membre/EntrepriseType'
 import { StructureComparaisonViewModel } from '@/presenters/comparaisonDoublonsPresenter'
 
 export default function ModaleCanonisation({ isOpen, onClose, structure }: Props): ReactElement {
-  const { canoniserStructureAction, pathname, rechercherUneEntrepriseAction, router } = useContext(clientContext)
+  const { canoniserStructureAction, pathname, previsualiserAdresseAction, rechercherUneEntrepriseAction, router } =
+    useContext(clientContext)
   const [etat, setEtat] = useState<EtatInsee>({ statut: 'chargement' })
   const [isSubmitting, setIsSubmitting] = useState(false)
 
@@ -23,17 +24,20 @@ export default function ModaleCanonisation({ isOpen, onClose, structure }: Props
     }
     setEtat({ statut: 'chargement' })
     rechercherUneEntrepriseAction({ siret: structure.siret })
-      .then((resultat) => {
-        if ('denomination' in resultat) {
-          setEtat({ entreprise: resultat, statut: 'chargee' })
-        } else {
+      .then(async (resultat) => {
+        if (!('denomination' in resultat)) {
           setEtat({ message: resultat.join(' · '), statut: 'erreur' })
+          return
         }
+        // On banifie l'adresse INSEE pour afficher côté INSEE ce qui sera réellement écrit (la BAN
+        // renvoie une casse normalisée), plutôt que la chaîne brute INSEE en majuscules. Best-effort.
+        const apercu = await previsualiserAdresseAction(resultat.adresse)
+        setEtat({ adresseBanifiee: apercu?.label ?? null, entreprise: resultat, statut: 'chargee' })
       })
       .catch(() => {
         setEtat({ message: 'Erreur lors de la récupération des données INSEE.', statut: 'erreur' })
       })
-  }, [isOpen, structure.siret, rechercherUneEntrepriseAction])
+  }, [isOpen, structure.siret, previsualiserAdresseAction, rechercherUneEntrepriseAction])
 
   async function synchroniser(): Promise<void> {
     setIsSubmitting(true)
@@ -96,7 +100,7 @@ function Comparaison({
     return <p className="fr-mt-2w fr-error-text">{etat.message}</p>
   }
 
-  const lignes = lignesComparaison(structure, etat.entreprise)
+  const lignes = lignesComparaison(structure, etat.entreprise, etat.adresseBanifiee)
 
   return (
     <div className="fr-table fr-table--md fr-mt-2w">
@@ -138,7 +142,8 @@ type LigneComparaison = Readonly<{
 
 function lignesComparaison(
   structure: StructureComparaisonViewModel,
-  entreprise: EntrepriseViewModel
+  entreprise: EntrepriseViewModel,
+  adresseBanifiee: null | string
 ): ReadonlyArray<LigneComparaison> {
   function champ(label: string): string {
     return structure.champs.find((candidat) => candidat.label === label)?.valeur ?? '—'
@@ -147,10 +152,18 @@ function lignesComparaison(
   // La structure ne stocke que le code APE ; on compare donc code à code et on affiche « code — libellé »
   // côté INSEE pour que la ligne ne paraisse pas différente alors qu'il s'agit du même code.
   const apeStructure = champ('Code activité (APE)')
+  // Côté INSEE on montre l'adresse banifiée (ce qui sera réellement écrit), pas la chaîne brute INSEE
+  // en majuscules. Comparaison normalisée (casse/ponctuation) pour ne pas signaler une fausse différence.
+  const adresseInsee = adresseBanifiee ?? entreprise.adresse
 
   return [
     ligne('Dénomination', structure.denominationSirene || '—', entreprise.denomination),
-    ligne('Adresse', structure.adresse, entreprise.adresse),
+    {
+      identique: memeAdresse(structure.adresse, adresseInsee),
+      insee: adresseInsee,
+      label: 'Adresse',
+      structure: structure.adresse,
+    },
     ligne('État administratif', champ('État administratif'), 'Actif'),
     {
       identique: apeStructure === entreprise.activitePrincipale,
@@ -175,9 +188,22 @@ function avecLibelle(code: string, libelle: string): string {
   return libelle === '' || libelle === code ? code : `${code} — ${libelle}`
 }
 
+// Deux adresses sont « identiques » si elles ne diffèrent que par la casse, la ponctuation ou les
+// espaces (l'INSEE renvoie en majuscules, la BAN normalise la casse et ajoute des virgules).
+function memeAdresse(adresseA: string, adresseB: string): boolean {
+  function normaliser(valeur: string): string {
+    return valeur
+      .toLowerCase()
+      .replace(/[\s,]+/g, ' ')
+      .trim()
+  }
+
+  return normaliser(adresseA) === normaliser(adresseB)
+}
+
 // État du chargement de l'image INSEE : en attente, chargée, ou en erreur (introuvable / réseau).
 type EtatInsee =
-  | Readonly<{ entreprise: EntrepriseViewModel; statut: 'chargee' }>
+  | Readonly<{ adresseBanifiee: null | string; entreprise: EntrepriseViewModel; statut: 'chargee' }>
   | Readonly<{ message: string; statut: 'erreur' }>
   | Readonly<{ statut: 'chargement' }>
 

--- a/src/components/shared/ClientContext.tsx
+++ b/src/components/shared/ClientContext.tsx
@@ -13,6 +13,7 @@ import { ajouterUneNoteDeContexteAction } from '@/app/api/actions/ajouterUneNote
 import { ajouterUneNoteDeContextualisationAction } from '@/app/api/actions/ajouterUneNoteDeContextualisationAction'
 import { ajouterUneNotePriveeAction } from '@/app/api/actions/ajouterUneNotePriveeAction'
 import { ajouterUnMembreAction } from '@/app/api/actions/ajouterUnMembreAction'
+import { canoniserStructureAction } from '@/app/api/actions/canoniserStructureAction'
 import { changerMaStructureAction } from '@/app/api/actions/changerMaStructureAction'
 import { changerMonDepartementAction } from '@/app/api/actions/changerMonDepartementAction'
 import { changerMonRoleAction } from '@/app/api/actions/changerMonRoleAction'
@@ -71,6 +72,7 @@ export default function ClientContext({
       ajouterUneNoteDeContextualisationAction,
       ajouterUneNotePriveeAction,
       ajouterUnMembreAction,
+      canoniserStructureAction,
       changerMaStructureAction,
       changerMonDepartementAction,
       changerMonRoleAction,
@@ -131,6 +133,7 @@ export type ClientContextProviderValue = Readonly<{
   ajouterUneNoteDeContextualisationAction: typeof ajouterUneNoteDeContextualisationAction
   ajouterUneNotePriveeAction: typeof ajouterUneNotePriveeAction
   ajouterUnMembreAction: typeof ajouterUnMembreAction
+  canoniserStructureAction: typeof canoniserStructureAction
   changerMaStructureAction: typeof changerMaStructureAction
   changerMonDepartementAction: typeof changerMonDepartementAction
   changerMonRoleAction: typeof changerMonRoleAction

--- a/src/components/testHelper.tsx
+++ b/src/components/testHelper.tsx
@@ -31,6 +31,7 @@ export function renderComponent(
     ajouterUneNoteDeContextualisationAction: vi.fn(),
     ajouterUneNotePriveeAction: vi.fn(),
     ajouterUnMembreAction: vi.fn(),
+    canoniserStructureAction: vi.fn(),
     changerMaStructureAction: vi.fn(),
     changerMonDepartementAction: vi.fn(),
     changerMonRoleAction: vi.fn(),

--- a/src/gateways/PrismaStructureCanonisationRepository.test.ts
+++ b/src/gateways/PrismaStructureCanonisationRepository.test.ts
@@ -38,7 +38,7 @@ describe('canonisation de structure (repository Prisma)', () => {
     expect(structure?.denomination_antenne).toBeNull()
     expect(structure?.denomination_sirene).toBe('AGENCE NATIONALE DE LA COHESION DES TERRITOIRES')
     expect(structure?.code_activite_principale).toBe('84.12Z')
-    expect(structure?.etat_administratif).toBe('A')
+    expect(structure?.etat_administratif).toBe('Entreprise active / Etablissement actif')
     expect(structure?.edited_by).toBe('min')
     expect(structure?.last_sirene_enrich_at).not.toBeNull()
     await expect(clefInteropDeLAdresse(structure?.adresse_id)).resolves.toBe(CLEF_INTEROP)

--- a/src/gateways/PrismaStructureCanonisationRepository.test.ts
+++ b/src/gateways/PrismaStructureCanonisationRepository.test.ts
@@ -12,6 +12,7 @@ const ANTENNE = 990031
 const CANONIQUE = 990032
 const SIRET = '99003100000001'
 const CLEF_INTEROP = '99003_9999_00003'
+const CODE_BAN = '99003999-0000-4000-8000-000000000003'
 const CATEGORIE = '7389'
 
 describe('canonisation de structure (repository Prisma)', () => {
@@ -80,6 +81,25 @@ describe('canonisation de structure (repository Prisma)', () => {
     expect(result).toBe('OK')
     expect((await lire(ANTENNE))?.adresse_id).toBe(existante.id)
     await expect(prisma.adresse.count({ where: { clef_interop: CLEF_INTEROP } })).resolves.toBe(1)
+  })
+
+  it('réutilise une adresse existante via le code BAN unique, même si la clef_interop diffère', async () => {
+    // GIVEN une adresse déjà présente avec un code_ban (colonne unique) mais sans clef_interop.
+    await seedCategorie()
+    const existante = await prisma.adresse.create({
+      data: { code_ban: CODE_BAN, code_insee: '75107', code_postal: '75007', nom_commune: 'Paris' },
+    })
+    await creerUneStructure({ denomination_antenne: 'Antenne', id: ANTENNE, nom: 'Antenne', siret: SIRET })
+
+    // WHEN le géocodage renvoie ce code_ban avec une clef_interop différente.
+    const result = await new PrismaStructureCanonisationRepository().canoniser(
+      canonisation({ geocode: { ...geocodeInsee, banClefInterop: 'autre_clef_99003', banCodeBan: CODE_BAN } })
+    )
+
+    // THEN on réutilise la ligne existante (pas de doublon, pas de violation d'unicité).
+    expect(result).toBe('OK')
+    expect((await lire(ANTENNE))?.adresse_id).toBe(existante.id)
+    await expect(prisma.adresse.count({ where: { code_ban: CODE_BAN } })).resolves.toBe(1)
   })
 
   it('détecte la présence d’une canonique de même SIRET (hors structure courante)', async () => {
@@ -222,6 +242,6 @@ async function dernierAuditEchoue(): Promise<boolean> {
 async function nettoyer(): Promise<void> {
   await prisma.$executeRaw`DELETE FROM audit.structure_merge_log WHERE winner_id IN (${ANTENNE}, ${CANONIQUE})`
   await prisma.main_structure_administrative.deleteMany({ where: { id: { in: [ANTENNE, CANONIQUE] } } })
-  await prisma.adresse.deleteMany({ where: { clef_interop: CLEF_INTEROP } })
+  await prisma.adresse.deleteMany({ where: { OR: [{ clef_interop: CLEF_INTEROP }, { code_ban: CODE_BAN }] } })
   await prisma.categories_juridiques.deleteMany({ where: { code: CATEGORIE } })
 }

--- a/src/gateways/PrismaStructureCanonisationRepository.test.ts
+++ b/src/gateways/PrismaStructureCanonisationRepository.test.ts
@@ -1,0 +1,227 @@
+import { main_structure_administrative } from '@prisma/client'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { PrismaStructureCanonisationRepository } from './PrismaStructureCanonisationRepository'
+import { creerUneStructure } from './testHelper'
+import prisma from '../../prisma/prismaClient'
+import { AdresseGeocodeReadModel } from '@/gateways/apiBan/BanGeocodingGateway'
+import { Canonisation } from '@/use-cases/commands/CanoniserStructure'
+import { EntrepriseReadModel } from '@/use-cases/queries/RechercherUneEntreprise'
+
+const ANTENNE = 990031
+const CANONIQUE = 990032
+const SIRET = '99003100000001'
+const CLEF_INTEROP = '99003_9999_00003'
+const CATEGORIE = '7389'
+
+describe('canonisation de structure (repository Prisma)', () => {
+  afterEach(nettoyer)
+
+  it('aligne la structure sur l’image INSEE, la rend canonique, re-pointe l’adresse et journalise', async () => {
+    // GIVEN une antenne et le code catégorie juridique présent en référence.
+    await seedCategorie()
+    await creerUneStructure({
+      code_activite_principale: '99.99Z',
+      denomination_antenne: 'Antenne à canoniser',
+      id: ANTENNE,
+      nom: 'Ancienne dénomination',
+      siret: SIRET,
+    })
+
+    // WHEN
+    const result = await new PrismaStructureCanonisationRepository().canoniser(canonisation({}))
+
+    // THEN
+    expect(result).toBe('OK')
+    const structure = await lire(ANTENNE)
+    expect(structure?.denomination_antenne).toBeNull()
+    expect(structure?.denomination_sirene).toBe('AGENCE NATIONALE DE LA COHESION DES TERRITOIRES')
+    expect(structure?.code_activite_principale).toBe('84.12Z')
+    expect(structure?.etat_administratif).toBe('A')
+    expect(structure?.edited_by).toBe('min')
+    expect(structure?.last_sirene_enrich_at).not.toBeNull()
+    await expect(clefInteropDeLAdresse(structure?.adresse_id)).resolves.toBe(CLEF_INTEROP)
+    await expect(dernierAuditReussi()).resolves.toMatchObject({ moved_identifiers: { source: 'insee' } })
+  })
+
+  it('canonise sans re-pointer l’adresse quand le géocodage n’a rien rendu', async () => {
+    // GIVEN
+    await seedCategorie()
+    await creerUneStructure({
+      denomination_antenne: 'Antenne sans géocodage',
+      id: ANTENNE,
+      nom: 'Ancienne dénomination',
+      siret: SIRET,
+    })
+    const adresseAvant = (await lire(ANTENNE))?.adresse_id
+
+    // WHEN
+    const result = await new PrismaStructureCanonisationRepository().canoniser(canonisation({ geocode: null }))
+
+    // THEN
+    expect(result).toBe('OK')
+    const structure = await lire(ANTENNE)
+    expect(structure?.denomination_antenne).toBeNull()
+    expect(structure?.adresse_id).toBe(adresseAvant ?? null)
+  })
+
+  it('réutilise une adresse existante de même clef_interop BAN plutôt que d’en créer une', async () => {
+    // GIVEN une adresse déjà présente avec la clef_interop renvoyée par le géocodage.
+    await seedCategorie()
+    const existante = await prisma.adresse.create({
+      data: { clef_interop: CLEF_INTEROP, code_insee: '75107', code_postal: '75007', nom_commune: 'Paris' },
+    })
+    await creerUneStructure({ denomination_antenne: 'Antenne', id: ANTENNE, nom: 'Antenne', siret: SIRET })
+
+    // WHEN
+    const result = await new PrismaStructureCanonisationRepository().canoniser(canonisation({}))
+
+    // THEN
+    expect(result).toBe('OK')
+    expect((await lire(ANTENNE))?.adresse_id).toBe(existante.id)
+    await expect(prisma.adresse.count({ where: { clef_interop: CLEF_INTEROP } })).resolves.toBe(1)
+  })
+
+  it('détecte la présence d’une canonique de même SIRET (hors structure courante)', async () => {
+    // GIVEN une canonique (denomination_antenne null) et une antenne partageant le SIRET.
+    await creerUneStructure({ id: CANONIQUE, nom: 'Canonique', siret: SIRET })
+    await creerUneStructure({ denomination_antenne: 'Antenne', id: ANTENNE, nom: 'Antenne', siret: SIRET })
+    const repository = new PrismaStructureCanonisationRepository()
+
+    // THEN
+    await expect(repository.existeCanoniquePourSiret(SIRET, ANTENNE)).resolves.toBe(true)
+    await expect(repository.existeCanoniquePourSiret(SIRET, CANONIQUE)).resolves.toBe(false)
+    await expect(repository.existeCanoniquePourSiret('00000000000000', ANTENNE)).resolves.toBe(false)
+  })
+
+  it('remonte canonisationEchouee et journalise l’échec quand l’update viole une contrainte', async () => {
+    // GIVEN une catégorie juridique INSEE absente de la référence → violation de clé étrangère.
+    await creerUneStructure({
+      denomination_antenne: 'Antenne',
+      id: ANTENNE,
+      nom: 'Antenne',
+      siret: SIRET,
+    })
+
+    // WHEN
+    const result = await new PrismaStructureCanonisationRepository().canoniser(
+      canonisation({ entreprise: { ...entrepriseInsee, categorieJuridiqueCode: '0000' } })
+    )
+
+    // THEN
+    expect(result).toBe('canonisationEchouee')
+    await expect(dernierAuditEchoue()).resolves.toBe(true)
+    expect((await lire(ANTENNE))?.denomination_antenne).toBe('Antenne') // rollback : rien n'a changé
+  })
+
+  it('remonte canoniqueExistante en cas de collision sur la contrainte d’unicité (course)', async () => {
+    // GIVEN une canonique de même SIRET existe déjà : rendre l'antenne canonique heurte la contrainte
+    // UNIQUE (siret, denomination_antenne).
+    await seedCategorie()
+    await creerUneStructure({ id: CANONIQUE, nom: 'Canonique', siret: SIRET })
+    await creerUneStructure({ denomination_antenne: 'Antenne', id: ANTENNE, nom: 'Antenne', siret: SIRET })
+
+    // WHEN
+    const result = await new PrismaStructureCanonisationRepository().canoniser(canonisation({ geocode: null }))
+
+    // THEN
+    expect(result).toBe('canoniqueExistante')
+  })
+
+  it('lit la structure à canoniser, ou null si absente', async () => {
+    // GIVEN
+    await creerUneStructure({ denomination_antenne: 'Antenne', id: ANTENNE, nom: 'Antenne', siret: SIRET })
+    const repository = new PrismaStructureCanonisationRepository()
+
+    // THEN
+    await expect(repository.lireStructure(ANTENNE)).resolves.toStrictEqual({
+      deletedAt: null,
+      denominationAntenne: 'Antenne',
+      siret: SIRET,
+    })
+    await expect(repository.lireStructure(123456)).resolves.toBeNull()
+  })
+})
+
+const entrepriseInsee: EntrepriseReadModel = {
+  activitePrincipale: '84.12Z',
+  adresse: '20 AVENUE DE SEGUR, 75007 PARIS',
+  categorieJuridiqueCode: CATEGORIE,
+  codeInsee: '75107',
+  codePostal: '75007',
+  commune: 'PARIS',
+  denomination: 'AGENCE NATIONALE DE LA COHESION DES TERRITOIRES',
+  identifiant: SIRET,
+  nomVoie: 'AVENUE DE SEGUR',
+  numeroVoie: '20',
+}
+
+const geocodeInsee: AdresseGeocodeReadModel = {
+  banClefInterop: CLEF_INTEROP,
+  banCodeBan: null,
+  banCodeInsee: '75107',
+  banCodePostal: '75007',
+  banLatitude: 48.85,
+  banLongitude: 2.31,
+  banNomCommune: 'Paris',
+  banNomVoie: 'Avenue de Ségur',
+  banNumeroVoie: 20,
+  banRepetition: null,
+  score: 0.98,
+  type: 'housenumber',
+}
+
+function canonisation(override: Partial<Canonisation>): Canonisation {
+  return {
+    entreprise: entrepriseInsee,
+    geocode: geocodeInsee,
+    parUtilisateur: 'admin-test',
+    structureId: ANTENNE,
+    ...override,
+  }
+}
+
+async function seedCategorie(): Promise<void> {
+  await prisma.categories_juridiques.upsert({
+    create: { code: CATEGORIE, niveau: 3, nom: 'Catégorie de test' },
+    update: {},
+    where: { code: CATEGORIE },
+  })
+}
+
+async function lire(id: number): Promise<main_structure_administrative | null> {
+  return prisma.main_structure_administrative.findUnique({ where: { id } })
+}
+
+async function clefInteropDeLAdresse(adresseId: null | number | undefined): Promise<null | string> {
+  if (adresseId === null || adresseId === undefined) {
+    return null
+  }
+  const adresse = await prisma.adresse.findUnique({ where: { id: adresseId } })
+  return adresse?.clef_interop ?? null
+}
+
+async function dernierAuditReussi(): Promise<Record<string, unknown> | undefined> {
+  const lignes = await prisma.$queryRaw<Array<Record<string, unknown>>>`
+    SELECT moved_identifiers FROM audit.structure_merge_log
+    WHERE status = 'SUCCESS' AND dag_id = 'min-ui-canonisation' AND winner_id = ${ANTENNE}
+    ORDER BY id DESC LIMIT 1
+  `
+  return lignes.at(0)
+}
+
+async function dernierAuditEchoue(): Promise<boolean> {
+  const lignes = await prisma.$queryRaw<Array<{ id: number }>>`
+    SELECT id FROM audit.structure_merge_log
+    WHERE status = 'FAILURE' AND dag_id = 'min-ui-canonisation' AND winner_id = ${ANTENNE}
+    ORDER BY id DESC LIMIT 1
+  `
+  return lignes.length > 0
+}
+
+async function nettoyer(): Promise<void> {
+  await prisma.$executeRaw`DELETE FROM audit.structure_merge_log WHERE winner_id IN (${ANTENNE}, ${CANONIQUE})`
+  await prisma.main_structure_administrative.deleteMany({ where: { id: { in: [ANTENNE, CANONIQUE] } } })
+  await prisma.adresse.deleteMany({ where: { clef_interop: CLEF_INTEROP } })
+  await prisma.categories_juridiques.deleteMany({ where: { code: CATEGORIE } })
+}

--- a/src/gateways/PrismaStructureCanonisationRepository.ts
+++ b/src/gateways/PrismaStructureCanonisationRepository.ts
@@ -138,14 +138,20 @@ export class PrismaStructureCanonisationRepository implements CanoniserStructure
     return lignes.at(0)?.snapshot ?? null
   }
 
-  // Re-pointage d'adresse : réutilise l'adresse de même clef_interop BAN si elle existe, sinon crée
-  // une nouvelle ligne (avec géométrie PostGIS). On ne modifie jamais une ligne adresse existante.
-  // Mirroir de PrismaStructureRepository.trouverOuCreerAdresse, exécuté dans la transaction.
+  // Re-pointage d'adresse : on réutilise une adresse BAN existante — identifiée d'abord par son
+  // code_ban (colonne UNIQUE), à défaut par sa clef_interop — sinon on crée une nouvelle ligne (avec
+  // géométrie PostGIS). On ne modifie JAMAIS une ligne adresse existante. Matcher sur code_ban évite
+  // aussi de heurter la contrainte unique adresse_code_ban_ukey à l'INSERT.
   async #trouverOuCreerAdresse(
     tx: Prisma.TransactionClient,
     geocode: NonNullable<Canonisation['geocode']>
   ): Promise<number> {
-    const existante = await tx.adresse.findFirst({ where: { clef_interop: geocode.banClefInterop } })
+    const existante = await tx.adresse.findFirst({
+      where:
+        geocode.banCodeBan === null
+          ? { clef_interop: geocode.banClefInterop }
+          : { OR: [{ code_ban: geocode.banCodeBan }, { clef_interop: geocode.banClefInterop }] },
+    })
     if (existante) {
       return existante.id
     }

--- a/src/gateways/PrismaStructureCanonisationRepository.ts
+++ b/src/gateways/PrismaStructureCanonisationRepository.ts
@@ -1,0 +1,196 @@
+import { Prisma } from '@prisma/client'
+
+import prisma from '../../prisma/prismaClient'
+import { ResultAsync } from '@/use-cases/CommandHandler'
+import {
+  Canonisation,
+  CanoniserFailure,
+  CanoniserStructureRepository,
+  StructureACanoniser,
+} from '@/use-cases/commands/CanoniserStructure'
+
+// Canonisation = aligner la structure sur son image INSEE puis vider denomination_antenne. On écrase
+// les champs descriptifs (dénomination SIRENE, adresse, état administratif, APE, catégorie juridique),
+// on trace l'enrichissement (last_sirene_enrich_at, edited_by) et on journalise un snapshot avant/après
+// dans audit.structure_merge_log (dag_id dédié, loser_id = winner_id par convention).
+export class PrismaStructureCanonisationRepository implements CanoniserStructureRepository {
+  readonly #dataResource = prisma.main_structure_administrative
+
+  async canoniser(canonisation: Canonisation): ResultAsync<CanoniserFailure> {
+    try {
+      return await prisma.$transaction(async (tx) => this.#canoniserDansTransaction(tx, canonisation))
+    } catch (erreur) {
+      // Conflit sur la contrainte UNIQUE (siret, denomination_antenne) gagné par une course concurrente.
+      // L'UPDATE est en SQL brut : Prisma remonte P2010 portant le code PostgreSQL 23505 (unique_violation),
+      // et non le P2002 des mutations typées.
+      if (estViolationUnicite(erreur)) {
+        return 'canoniqueExistante'
+      }
+      await this.#journaliserEchec(canonisation, erreur)
+
+      return 'canonisationEchouee'
+    }
+  }
+
+  async existeCanoniquePourSiret(siret: string, exceptId: number): Promise<boolean> {
+    const nombre = await this.#dataResource.count({
+      where: {
+        deleted_at: null,
+        denomination_antenne: null,
+        id: { not: exceptId },
+        siret,
+      },
+    })
+
+    return nombre > 0
+  }
+
+  async lireStructure(structureId: number): Promise<null | StructureACanoniser> {
+    const structure = await this.#dataResource.findUnique({
+      select: { deleted_at: true, denomination_antenne: true, siret: true },
+      where: { id: structureId },
+    })
+    if (structure === null) {
+      return null
+    }
+
+    return {
+      deletedAt: structure.deleted_at,
+      denominationAntenne: structure.denomination_antenne,
+      siret: structure.siret,
+    }
+  }
+
+  async #canoniserDansTransaction(
+    tx: Prisma.TransactionClient,
+    canonisation: Canonisation
+  ): ResultAsync<CanoniserFailure> {
+    const { entreprise, geocode, structureId } = canonisation
+
+    const avant = await this.#snapshot(tx, structureId)
+    if (avant === null) {
+      return 'structureIntrouvable'
+    }
+
+    const adresseId = geocode === null ? null : await this.#trouverOuCreerAdresse(tx, geocode)
+
+    // Image INSEE : la canonique reflète la source faisant autorité. Timestamps posés en SQL
+    // (CURRENT_DATE / now()) — new Date() est interdit hors src/app. Adresse best-effort : conservée
+    // telle quelle (COALESCE) si le géocodage BAN n'a rien rendu. L'API INSEE ne renvoie que les
+    // établissements actifs, d'où etat_administratif = 'A'.
+    await tx.$executeRaw`
+      UPDATE main.structure_administrative SET
+        denomination_antenne = NULL,
+        denomination_sirene = ${entreprise.denomination},
+        etat_administratif = 'A',
+        code_activite_principale = ${entreprise.activitePrincipale},
+        categorie_juridique = ${entreprise.categorieJuridiqueCode},
+        adresse_id = COALESCE(${adresseId}::int, adresse_id),
+        last_sirene_enrich_at = CURRENT_DATE,
+        edited_by = 'min',
+        updated_at = now()
+      WHERE id = ${structureId}
+    `
+
+    const apres = await this.#snapshot(tx, structureId)
+    await this.#journaliserSucces(tx, canonisation, avant, apres)
+
+    return 'OK'
+  }
+
+  async #journaliserEchec(canonisation: Canonisation, erreur: unknown): Promise<void> {
+    const message = erreur instanceof Error ? erreur.message : String(erreur)
+    // Hors transaction (celle d'origine a rollback) : trace best-effort de l'échec.
+    await prisma.$executeRaw`
+      INSERT INTO audit.structure_merge_log
+        (status, dag_id, task_id, winner_id, loser_id, error_message)
+      VALUES ('FAILURE', 'min-ui-canonisation', ${canonisation.parUtilisateur},
+        ${canonisation.structureId}, ${canonisation.structureId}, ${message})
+    `
+  }
+
+  async #journaliserSucces(
+    tx: Prisma.TransactionClient,
+    canonisation: Canonisation,
+    avant: Prisma.JsonValue,
+    apres: Prisma.JsonValue
+  ): Promise<void> {
+    // Canonisation = pas de structure « perdante » : loser_id = winner_id par convention (le dag_id
+    // dédié permet de distinguer ces lignes des vraies fusions).
+    await tx.$executeRaw`
+      INSERT INTO audit.structure_merge_log
+        (status, dag_id, task_id, winner_id, loser_id, winner_before, winner_after, moved_identifiers)
+      VALUES (
+        'SUCCESS', 'min-ui-canonisation', ${canonisation.parUtilisateur},
+        ${canonisation.structureId}, ${canonisation.structureId},
+        ${JSON.stringify(avant)}::jsonb,
+        ${JSON.stringify(apres)}::jsonb,
+        ${JSON.stringify(imageInsee(canonisation))}::jsonb
+      )
+    `
+  }
+
+  async #snapshot(tx: Prisma.TransactionClient, structureId: number): Promise<null | Prisma.JsonValue> {
+    const lignes = await tx.$queryRaw<Array<{ snapshot: Prisma.JsonValue }>>`
+      SELECT to_jsonb(sa.*) AS snapshot FROM main.structure_administrative sa WHERE id = ${structureId}
+    `
+
+    return lignes.at(0)?.snapshot ?? null
+  }
+
+  // Re-pointage d'adresse : réutilise l'adresse de même clef_interop BAN si elle existe, sinon crée
+  // une nouvelle ligne (avec géométrie PostGIS). On ne modifie jamais une ligne adresse existante.
+  // Mirroir de PrismaStructureRepository.trouverOuCreerAdresse, exécuté dans la transaction.
+  async #trouverOuCreerAdresse(
+    tx: Prisma.TransactionClient,
+    geocode: NonNullable<Canonisation['geocode']>
+  ): Promise<number> {
+    const existante = await tx.adresse.findFirst({ where: { clef_interop: geocode.banClefInterop } })
+    if (existante) {
+      return existante.id
+    }
+
+    const resultat = await tx.$queryRaw<Array<{ id: number }>>`
+      INSERT INTO main.adresse (
+        clef_interop, code_ban, code_insee, code_postal,
+        nom_commune, nom_voie, numero_voie, repetition, geom
+      ) VALUES (
+        ${geocode.banClefInterop},
+        ${geocode.banCodeBan}::uuid,
+        ${geocode.banCodeInsee},
+        ${geocode.banCodePostal},
+        ${geocode.banNomCommune},
+        ${geocode.banNomVoie},
+        ${geocode.banNumeroVoie},
+        ${geocode.banRepetition},
+        public.ST_Point(${geocode.banLongitude}::double precision, ${geocode.banLatitude}::double precision, 4326)
+      )
+      RETURNING id
+    `
+
+    return resultat[0].id
+  }
+}
+
+// Violation d'une contrainte d'unicité : P2002 (mutation typée) ou P2010 portant le code PostgreSQL
+// 23505 (unique_violation) pour une requête SQL brute.
+function estViolationUnicite(erreur: unknown): boolean {
+  if (!(erreur instanceof Prisma.PrismaClientKnownRequestError)) {
+    return false
+  }
+  if (erreur.code === 'P2002') {
+    return true
+  }
+
+  return erreur.code === 'P2010' && (erreur.meta as { code?: string } | undefined)?.code === '23505'
+}
+
+// Résumé de l'image INSEE appliquée, tracé dans moved_identifiers du journal d'audit.
+function imageInsee(canonisation: Canonisation): Record<string, null | string> {
+  return {
+    adresse: canonisation.geocode === null ? null : canonisation.entreprise.adresse,
+    denominationSirene: canonisation.entreprise.denomination,
+    siret: canonisation.entreprise.identifiant,
+    source: 'insee',
+  }
+}

--- a/src/gateways/PrismaStructureCanonisationRepository.ts
+++ b/src/gateways/PrismaStructureCanonisationRepository.ts
@@ -1,6 +1,7 @@
 import { Prisma } from '@prisma/client'
 
 import prisma from '../../prisma/prismaClient'
+import { ETAT_ADMINISTRATIF_CANONIQUE } from '@/shared/etatAdministratif'
 import { ResultAsync } from '@/use-cases/CommandHandler'
 import {
   Canonisation,
@@ -77,12 +78,12 @@ export class PrismaStructureCanonisationRepository implements CanoniserStructure
     // Image INSEE : la canonique reflète la source faisant autorité. Timestamps posés en SQL
     // (CURRENT_DATE / now()) — new Date() est interdit hors src/app. Adresse best-effort : conservée
     // telle quelle (COALESCE) si le géocodage BAN n'a rien rendu. L'API INSEE ne renvoie que les
-    // établissements actifs, d'où etat_administratif = 'A'.
+    // établissements actifs, d'où le libellé d'état canonique (convention dataspace).
     await tx.$executeRaw`
       UPDATE main.structure_administrative SET
         denomination_antenne = NULL,
         denomination_sirene = ${entreprise.denomination},
-        etat_administratif = 'A',
+        etat_administratif = ${ETAT_ADMINISTRATIF_CANONIQUE},
         code_activite_principale = ${entreprise.activitePrincipale},
         categorie_juridique = ${entreprise.categorieJuridiqueCode},
         adresse_id = COALESCE(${adresseId}::int, adresse_id),

--- a/src/presenters/comparaisonDoublonsPresenter.test.ts
+++ b/src/presenters/comparaisonDoublonsPresenter.test.ts
@@ -190,6 +190,7 @@ function structureAvecCoords(
     longitude,
     rattachements: [],
     rattachementsTotal: 0,
+    siret: null,
   }
 }
 

--- a/src/presenters/comparaisonDoublonsPresenter.ts
+++ b/src/presenters/comparaisonDoublonsPresenter.ts
@@ -65,6 +65,8 @@ export type StructureComparaisonViewModel = Readonly<{
   longitude: null | number
   rattachements: ReadonlyArray<RattachementViewModel>
   rattachementsTotal: number
+  // SIRET brut, pour la requête INSEE de l'aperçu et le calcul de collision de canonisation côté client.
+  siret: null | string
 }>
 
 export type ChampViewModel = Readonly<{
@@ -189,6 +191,7 @@ function versStructureComparaison(structure: StructureDetailReadModel): Structur
       nombre: structure.rattachements[cle],
     })),
     rattachementsTotal: structure.rattachements.total,
+    siret: structure.siret,
   }
 }
 

--- a/src/shared/etatAdministratif.ts
+++ b/src/shared/etatAdministratif.ts
@@ -1,0 +1,5 @@
+// Libellé d'état administratif tel que stocké dans main.structure_administrative (convention dataspace,
+// combinant l'état de l'unité légale et celui de l'établissement). L'API INSEE ne renvoyant que des
+// établissements actifs (unité légale ET établissement actifs, cf. ApiSireneLoader.validerEtablissement),
+// une structure canonique synchronisée depuis l'INSEE porte toujours cette valeur.
+export const ETAT_ADMINISTRATIF_CANONIQUE = 'Entreprise active / Etablissement actif'

--- a/src/use-cases/commands/CanoniserStructure.test.ts
+++ b/src/use-cases/commands/CanoniserStructure.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  Canonisation,
+  CanoniserFailure,
+  CanoniserStructure,
+  CanoniserStructureRepository,
+  StructureACanoniser,
+} from './CanoniserStructure'
+import { ResultAsync } from '../CommandHandler'
+import { AdresseGeocodeReadModel, BanGeocodingGateway } from '@/gateways/apiBan/BanGeocodingGateway'
+import { epochTime } from '@/shared/testHelper'
+import { EntrepriseNonTrouvee, EntrepriseReadModel, SireneLoader } from '@/use-cases/queries/RechercherUneEntreprise'
+
+describe('canoniser une structure', () => {
+  beforeEach(() => {
+    spiedCanonisation = null
+    spiedSiret = null
+  })
+
+  it('refuse une structure introuvable, sans interroger l’INSEE', async () => {
+    // GIVEN
+    const canoniser = creerCanoniser({ structure: null })
+
+    // WHEN
+    const result = await canoniser.handle({ structureId: 1, uidUtilisateur: 'admin-1' })
+
+    // THEN
+    expect(result).toBe('structureIntrouvable')
+    expect(spiedSiret).toBeNull()
+    expect(spiedCanonisation).toBeNull()
+  })
+
+  it('refuse une structure déjà supprimée', async () => {
+    // GIVEN
+    const canoniser = creerCanoniser({ structure: structure({ deletedAt: epochTime }) })
+
+    // WHEN
+    const result = await canoniser.handle({ structureId: 1, uidUtilisateur: 'admin-1' })
+
+    // THEN
+    expect(result).toBe('structureIntrouvable')
+  })
+
+  it('refuse une structure déjà canonique', async () => {
+    // GIVEN
+    const canoniser = creerCanoniser({ structure: structure({ denominationAntenne: null }) })
+
+    // WHEN
+    const result = await canoniser.handle({ structureId: 1, uidUtilisateur: 'admin-1' })
+
+    // THEN
+    expect(result).toBe('structureDejaCanonique')
+  })
+
+  it('refuse une antenne sans SIRET', async () => {
+    // GIVEN
+    const canoniser = creerCanoniser({ structure: structure({ siret: null }) })
+
+    // WHEN
+    const result = await canoniser.handle({ structureId: 1, uidUtilisateur: 'admin-1' })
+
+    // THEN
+    expect(result).toBe('siretManquant')
+    expect(spiedSiret).toBeNull()
+  })
+
+  it('refuse de canoniser si une canonique de même SIRET existe déjà', async () => {
+    // GIVEN
+    const canoniser = creerCanoniser({ existeCanonique: true, structure: structure({}) })
+
+    // WHEN
+    const result = await canoniser.handle({ structureId: 1, uidUtilisateur: 'admin-1' })
+
+    // THEN
+    expect(result).toBe('canoniqueExistante')
+    expect(spiedSiret).toStrictEqual({ exceptId: 1, siret: '13002603200016' })
+    expect(spiedCanonisation).toBeNull()
+  })
+
+  it('refuse quand l’INSEE ne trouve aucun établissement actif', async () => {
+    // GIVEN
+    const canoniser = creerCanoniser({ entreprise: { estTrouvee: false }, structure: structure({}) })
+
+    // WHEN
+    const result = await canoniser.handle({ structureId: 1, uidUtilisateur: 'admin-1' })
+
+    // THEN
+    expect(result).toBe('entrepriseIntrouvable')
+    expect(spiedCanonisation).toBeNull()
+  })
+
+  it('canonise en alignant sur l’image INSEE et l’adresse géocodée', async () => {
+    // GIVEN
+    const canoniser = creerCanoniser({ structure: structure({}) })
+
+    // WHEN
+    const result = await canoniser.handle({ structureId: 1, uidUtilisateur: 'admin-1' })
+
+    // THEN
+    expect(result).toBe('OK')
+    expect(spiedSiret).toStrictEqual({ exceptId: 1, siret: '13002603200016' })
+    expect(spiedCanonisation).toStrictEqual({
+      entreprise: entrepriseInsee,
+      geocode: geocodeInsee,
+      parUtilisateur: 'admin-1',
+      structureId: 1,
+    })
+  })
+
+  it('canonise quand même si le géocodage BAN ne renvoie rien (adresse best-effort)', async () => {
+    // GIVEN
+    const canoniser = creerCanoniser({ geocode: null, structure: structure({}) })
+
+    // WHEN
+    const result = await canoniser.handle({ structureId: 1, uidUtilisateur: 'admin-1' })
+
+    // THEN
+    expect(result).toBe('OK')
+    expect(spiedCanonisation?.geocode).toBeNull()
+  })
+})
+
+let spiedCanonisation: Canonisation | null
+let spiedSiret: null | Readonly<{ exceptId: number; siret: string }>
+
+const entrepriseInsee: EntrepriseReadModel = {
+  activitePrincipale: '84.12Z',
+  adresse: '20 AVENUE DE SEGUR, 75007 PARIS',
+  categorieJuridiqueCode: '7389',
+  codeInsee: '75107',
+  codePostal: '75007',
+  commune: 'PARIS',
+  denomination: 'AGENCE NATIONALE DE LA COHESION DES TERRITOIRES',
+  identifiant: '13002603200016',
+  nomVoie: 'AVENUE DE SEGUR',
+  numeroVoie: '20',
+}
+
+const geocodeInsee: AdresseGeocodeReadModel = {
+  banClefInterop: '75107_8909_00020',
+  banCodeBan: null,
+  banCodeInsee: '75107',
+  banCodePostal: '75007',
+  banLatitude: 48.85,
+  banLongitude: 2.31,
+  banNomCommune: 'Paris',
+  banNomVoie: 'Avenue de Ségur',
+  banNumeroVoie: 20,
+  banRepetition: null,
+  score: 0.98,
+  type: 'housenumber',
+}
+
+function structure(overrides: Partial<StructureACanoniser>): StructureACanoniser {
+  return { deletedAt: null, denominationAntenne: 'Antenne Paris', siret: '13002603200016', ...overrides }
+}
+
+function creerCanoniser(
+  options: Readonly<{
+    entreprise?: EntrepriseNonTrouvee | EntrepriseReadModel
+    existeCanonique?: boolean
+    geocode?: AdresseGeocodeReadModel | null
+    structure: null | StructureACanoniser
+  }>
+): CanoniserStructure {
+  const sireneLoader: SireneLoader = {
+    async rechercherParIdentifiant(): Promise<EntrepriseNonTrouvee | EntrepriseReadModel> {
+      return Promise.resolve(options.entreprise ?? entrepriseInsee)
+    },
+  }
+  const banGeocodingGateway: BanGeocodingGateway = {
+    async geocoder(): Promise<AdresseGeocodeReadModel | null> {
+      return Promise.resolve(options.geocode === undefined ? geocodeInsee : options.geocode)
+    },
+  }
+
+  return new CanoniserStructure(sireneLoader, banGeocodingGateway, new RepositorySpy(options))
+}
+
+class RepositorySpy implements CanoniserStructureRepository {
+  readonly #options: Readonly<{ existeCanonique?: boolean; structure: null | StructureACanoniser }>
+
+  constructor(options: Readonly<{ existeCanonique?: boolean; structure: null | StructureACanoniser }>) {
+    this.#options = options
+  }
+
+  canoniser(canonisation: Canonisation): ResultAsync<CanoniserFailure> {
+    spiedCanonisation = canonisation
+    return Promise.resolve('OK')
+  }
+
+  existeCanoniquePourSiret(siret: string, exceptId: number): Promise<boolean> {
+    spiedSiret = { exceptId, siret }
+    return Promise.resolve(this.#options.existeCanonique ?? false)
+  }
+
+  lireStructure(): Promise<null | StructureACanoniser> {
+    return Promise.resolve(this.#options.structure)
+  }
+}

--- a/src/use-cases/commands/CanoniserStructure.ts
+++ b/src/use-cases/commands/CanoniserStructure.ts
@@ -1,0 +1,98 @@
+import { CommandHandler, ResultAsync } from '../CommandHandler'
+import { AdresseGeocodeReadModel, BanGeocodingGateway } from '@/gateways/apiBan/BanGeocodingGateway'
+import { EntrepriseReadModel, SireneLoader } from '@/use-cases/queries/RechercherUneEntreprise'
+
+// Canoniser une structure = transformer une « antenne » (denomination_antenne non nul) en forme
+// canonique (denomination_antenne = null) en l'alignant sur l'image INSEE faisant autorité. Une
+// canonique DOIT être une image de l'INSEE : on écrase donc tous les champs descriptifs (dénomination
+// SIRENE, adresse, état administratif, APE, catégorie juridique) avec les données INSEE.
+export class CanoniserStructure implements CommandHandler<Command, CanoniserFailure> {
+  readonly #banGeocodingGateway: BanGeocodingGateway
+  readonly #repository: CanoniserStructureRepository
+  readonly #sireneLoader: SireneLoader
+
+  constructor(
+    sireneLoader: SireneLoader,
+    banGeocodingGateway: BanGeocodingGateway,
+    repository: CanoniserStructureRepository
+  ) {
+    this.#banGeocodingGateway = banGeocodingGateway
+    this.#repository = repository
+    this.#sireneLoader = sireneLoader
+  }
+
+  async handle(command: Command): ResultAsync<CanoniserFailure> {
+    const structure = await this.#repository.lireStructure(command.structureId)
+    if (structure === null || structure.deletedAt !== null) {
+      return 'structureIntrouvable'
+    }
+    // Déjà canonique : rien à faire (et on ne re-synchronise pas via cette opération).
+    if (structure.denominationAntenne === null) {
+      return 'structureDejaCanonique'
+    }
+    // Sans SIRET, impossible d'interroger l'INSEE pour produire l'image canonique.
+    if (structure.siret === null) {
+      return 'siretManquant'
+    }
+
+    // Garde collision : la contrainte UNIQUE NULLS NOT DISTINCT (siret, denomination_antenne)
+    // interdit deux canoniques de même SIRET. On refuse plutôt que de heurter la base.
+    if (await this.#repository.existeCanoniquePourSiret(structure.siret, command.structureId)) {
+      return 'canoniqueExistante'
+    }
+
+    // L'API INSEE ne renvoie que les établissements actifs : un établissement fermé ou introuvable
+    // remonte EntrepriseNonTrouvee (cf. ApiSireneLoader.validerEtablissement).
+    const entreprise = await this.#sireneLoader.rechercherParIdentifiant(structure.siret)
+    if ('estTrouvee' in entreprise) {
+      return 'entrepriseIntrouvable'
+    }
+
+    // Adresse best-effort : on géocode l'adresse INSEE via la BAN pour obtenir le geom. Si la BAN ne
+    // trouve rien, on canonise quand même les autres champs sans re-pointer adresse_id.
+    const geocode = await this.#banGeocodingGateway.geocoder({
+      adresse: entreprise.adresse,
+      codeInsee: entreprise.codeInsee,
+    })
+
+    return this.#repository.canoniser({
+      entreprise,
+      geocode,
+      parUtilisateur: command.uidUtilisateur,
+      structureId: command.structureId,
+    })
+  }
+}
+
+export interface CanoniserStructureRepository {
+  canoniser(canonisation: Canonisation): ResultAsync<CanoniserFailure>
+  existeCanoniquePourSiret(siret: string, exceptId: number): Promise<boolean>
+  lireStructure(structureId: number): Promise<null | StructureACanoniser>
+}
+
+export type StructureACanoniser = Readonly<{
+  deletedAt: Date | null
+  denominationAntenne: null | string
+  siret: null | string
+}>
+
+export type Canonisation = Readonly<{
+  entreprise: EntrepriseReadModel
+  geocode: AdresseGeocodeReadModel | null
+  parUtilisateur: string
+  structureId: number
+}>
+
+export type CanoniserFailure =
+  | 'canoniqueExistante'
+  // Une canonique de même SIRET existe déjà : la canonisation violerait la contrainte d'unicité.
+  | 'canonisationEchouee'
+  | 'entrepriseIntrouvable'
+  | 'siretManquant'
+  | 'structureDejaCanonique'
+  | 'structureIntrouvable'
+
+type Command = Readonly<{
+  structureId: number
+  uidUtilisateur: string
+}>


### PR DESCRIPTION
## Contexte

Sur la page de comparaison des doublons (`structures-doublons/comparer?ids=…`), on peut déjà comparer/fusionner/transférer des structures. Cette PR ajoute une 3ᵉ opération : **canoniser** une structure *antenne* (`denomination_antenne` non nul) pour la transformer en structure *canonique* (`denomination_antenne = null`), en l'alignant sur la source faisant autorité, l'INSEE.

## Ce que fait la PR

- **CTA « Synchroniser avec INSEE »** au niveau du SIRET de chaque carte d'antenne.
- Au clic, une **modale compare côte à côte** les données portées par la structure et l'image INSEE (dénomination, **adresse**, état administratif, APE, catégorie juridique). Boutons **Fermer** / **Synchroniser avec INSEE**.
- La synchronisation **écrase tous les champs descriptifs** avec l'image INSEE (adresse géocodée via la BAN pour obtenir le `geom`) et vide `denomination_antenne` → la structure devient canonique. _Une canonique doit être une image de l'INSEE._
- **Garde anti-collision** : interdit (CTA désactivé **+** garde serveur) si une canonique de même SIRET existe déjà, pour respecter `UNIQUE (siret, denomination_antenne)`.
- **Permissions** : administrateur **+** bêta-testeur.
- **Traçabilité** : `last_sirene_enrich_at`, `edited_by='min'`, et journal `audit.structure_merge_log` (`dag_id='min-ui-canonisation'`).

## Implémentation

Reprend les patterns existants : use case `CanoniserStructure` + port repository, `PrismaStructureCanonisationRepository` (transaction, ré-utilisation/`creation` d'adresse PostGIS comme `PrismaStructureRepository`, journal d'audit comme la fusion), action `canoniserStructureAction`, réutilisation de `ApiSireneLoader`, `ApiBanGeocodingGateway` et `rechercherUneEntrepriseAction`.

Aucune migration Prisma ni Flyway.

## Tests

Use case (gardes + best-effort adresse), repository (intégration DB : alignement INSEE, ré-utilisation d'adresse, échec FK journalisé, collision unicité), action (auth + mapping d'erreurs), composants (CTA visible/désactivé, parcours modale, erreurs).

Closes #1643

🤖 Generated with [Claude Code](https://claude.com/claude-code)