### PR TITLE
feat(structures-doublons): coupler coop et lieuInclusion dans le transfert partiel

### DIFF
--- a/src/components/StructuresDoublons/ComparerStructures.test.tsx
+++ b/src/components/StructuresDoublons/ComparerStructures.test.tsx
@@ -114,6 +114,52 @@ describe('consolider un doublon (cible + transfert/fusion par notion)', () => {
     expect(screen.getAllByLabelText(/Coop/)[1]).toBeDisabled()
   })
 
+  it('couple Coop et Lieu d’inclusion : cocher l’un coche l’autre et les transfère ensemble', async () => {
+    // GIVEN une source portant Coop ET Lieu d’inclusion.
+    const transfererNotionsStructureAction = stubbedServerAction(['OK'])
+    const viewModel: ComparaisonViewModel = [
+      carte({ denomination: 'Cible', estCanonique: true, id: 3 }),
+      carte({ concepts: [conceptCoop('coop-x'), conceptLieu()], denomination: 'Source', id: 7 }),
+    ]
+    renderComponent(<ComparerStructures viewModel={viewModel} />, {
+      pathname: '/structures-doublons/comparer',
+      transfererNotionsStructureAction,
+    })
+
+    // WHEN : on coche uniquement Coop.
+    fireEvent.click(screen.getByLabelText(/Coop/))
+
+    // THEN : Lieu d’inclusion est coché automatiquement…
+    expect(screen.getByLabelText(/Lieu/)).toBeChecked()
+
+    // …et le transfert porte les deux notions.
+    fireEvent.click(screen.getByRole('button', { name: 'Appliquer' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Confirmer' }))
+    await screen.findByRole('status')
+    expect(transfererNotionsStructureAction).toHaveBeenCalledWith({
+      idCible: 3,
+      idSource: 7,
+      notions: ['coop', 'lieuInclusion'],
+      path: '/structures-doublons/comparer',
+    })
+  })
+
+  it('couple l’indisponibilité : un id Coop en collision désactive aussi Lieu d’inclusion', () => {
+    // GIVEN la cible porte déjà un id Coop différent → collision sur la source.
+    const viewModel: ComparaisonViewModel = [
+      carte({ concepts: [conceptCoop('coop-cible')], denomination: 'Cible', estCanonique: true, id: 3 }),
+      carte({ concepts: [conceptCoop('coop-source'), conceptLieu()], denomination: 'Source', id: 7 }),
+    ]
+
+    // WHEN
+    renderComponent(<ComparerStructures viewModel={viewModel} />)
+
+    // THEN : Coop est verrouillé, et Lieu d’inclusion l’est aussi par couplage.
+    // (matcher ancré : le message d’indisponibilité du lieu contient lui aussi le mot « Coop ».)
+    expect(screen.getByLabelText(/^Coop/)).toBeDisabled()
+    expect(screen.getByLabelText(/^Lieu/)).toBeDisabled()
+  })
+
   it('agrège fusion et transfert et notifie en cas d’échec partiel', async () => {
     // GIVEN la fusion réussit, le transfert échoue.
     const fusionnerStructuresAction = stubbedServerAction(['OK'])
@@ -233,6 +279,10 @@ function conceptAc(idExterne: string): ConceptViewModel {
 
 function conceptCoop(idExterne: string): ConceptViewModel {
   return { cle: 'coop', idExterne, label: 'Coop', present: true, resume: '1 affectation' }
+}
+
+function conceptLieu(): ConceptViewModel {
+  return { cle: 'lieuInclusion', idExterne: null, label: 'Lieu d’inclusion', present: true, resume: '1 lieu rattaché' }
 }
 
 function carte(

--- a/src/components/StructuresDoublons/ComparerStructures.tsx
+++ b/src/components/StructuresDoublons/ComparerStructures.tsx
@@ -30,6 +30,11 @@ type EtatCarte = Readonly<{
 
 const ETAT_VIDE: EtatCarte = { fusionner: false, notions: [] }
 
+// coop et lieuInclusion sont indissociables en transfert partiel : le lien lieu↔structure est une
+// projection de l'identifiant Coop (structure_coop_id), re-dérivé par le DAG coop. Déplacer l'un
+// sans l'autre laisse une association orpheline sur la source et un doublon re-créé sur la cible.
+const NOTIONS_COUPLEES: ReadonlyArray<NotionCle> = ['coop', 'lieuInclusion']
+
 export default function ComparerStructures({ viewModel }: Props): ReactElement {
   const { fusionnerStructuresAction, pathname, router, transfererNotionsStructureAction } = useContext(clientContext)
 
@@ -108,12 +113,22 @@ export default function ComparerStructures({ viewModel }: Props): ReactElement {
     })
   }
 
+  // Disponibilité couplée : une notion couplée n'est déplaçable que si TOUTES les notions de son
+  // groupe le sont (un id Coop en collision verrouille donc aussi lieuInclusion).
+  function notionDisponible(structure: StructureComparaisonViewModel, concept: ConceptViewModel): boolean {
+    return groupeCouple(structure, concept.cle).every((cle) => {
+      const membre = structure.concepts.find((autre) => autre.cle === cle)
+      return membre === undefined || idScalaireDisponible(membre, structure.id)
+    })
+  }
+
   function basculerNotion(structure: StructureComparaisonViewModel, cle: NotionCle): void {
     setEtats((precedent) => {
       const actuel = precedent[structure.id] ?? ETAT_VIDE
-      const notions = actuel.notions.includes(cle)
-        ? actuel.notions.filter((autre) => autre !== cle)
-        : [...actuel.notions, cle]
+      const groupe = groupeCouple(structure, cle)
+      const activer = !actuel.notions.includes(cle)
+      const base = actuel.notions.filter((autre) => !groupe.includes(autre))
+      const notions = activer ? [...base, ...groupe] : base
       if (notions.length === 0) {
         return sansClef(precedent, structure.id)
       }
@@ -196,7 +211,7 @@ export default function ComparerStructures({ viewModel }: Props): ReactElement {
                 collisionCanonique={collisionCanonique(structure)}
                 estCible={structure.id === idCible}
                 etat={etatDe(structure.id)}
-                idScalaireDisponible={(concept) => idScalaireDisponible(concept, structure.id)}
+                notionDisponible={(concept) => notionDisponible(structure, concept)}
                 onCanoniser={() => {
                   setIdCanonisation(structure.id)
                 }}
@@ -326,7 +341,7 @@ function CarteStructure({
   collisionCanonique,
   estCible,
   etat,
-  idScalaireDisponible,
+  notionDisponible,
   onCanoniser,
   onCible,
   onToggleFusion,
@@ -336,7 +351,7 @@ function CarteStructure({
   collisionCanonique: boolean
   estCible: boolean
   etat: EtatCarte
-  idScalaireDisponible(concept: ConceptViewModel): boolean
+  notionDisponible(concept: ConceptViewModel): boolean
   onCanoniser(): void
   onCible(): void
   onToggleFusion(): void
@@ -372,6 +387,8 @@ function CarteStructure({
       return <p className="fr-text--sm fr-text-mention--grey fr-mt-2w">Aucune notion à transférer.</p>
     }
 
+    const coopEtLieuCouples = NOTIONS_COUPLEES.every((cle) => conceptsPortes.some((concept) => concept.cle === cle))
+
     return (
       <fieldset className="fr-fieldset fr-mt-2w">
         <legend className="fr-fieldset__legend fr-text--bold">Notions à déplacer vers la cible</legend>
@@ -382,8 +399,17 @@ function CarteStructure({
               Fusionner (tout transférer puis supprimer la structure)
             </label>
           </div>
+          {coopEtLieuCouples ? (
+            <p className="fr-text--xs fr-text-mention--grey fr-mb-1w">
+              Coop et Lieu d’inclusion sont déplacés ensemble : le lien lieu↔structure dépend de l’identifiant Coop.
+            </p>
+          ) : null}
           {conceptsPortes.map((concept) => {
-            const disponible = idScalaireDisponible(concept)
+            const disponible = notionDisponible(concept)
+            const messageIndisponible =
+              concept.idExterne === null
+                ? 'Déplacé conjointement avec Coop, dont l’identifiant n’est pas disponible (voir ci-dessus).'
+                : 'Identifiant déjà porté par la cible ou réclamé par une autre structure. Avant d’abandonner cet id, vérifiez qu’il n’existe plus côté source externe, sinon le doublon réapparaîtra au resync.'
             return (
               <div className="fr-checkbox-group" key={concept.cle}>
                 <input
@@ -398,12 +424,7 @@ function CarteStructure({
                 <label className="fr-label" htmlFor={`notion-${concept.cle}-${structure.id}`}>
                   {concept.label} — {concept.resume}
                   {concept.idExterne === null ? null : ` · id ${concept.idExterne}`}
-                  {disponible ? null : (
-                    <span className="fr-error-text">
-                      Identifiant déjà porté par la cible ou réclamé par une autre structure. Avant d’abandonner cet id,
-                      vérifiez qu’il n’existe plus côté source externe, sinon le doublon réapparaîtra au resync.
-                    </span>
-                  )}
+                  {disponible ? null : <span className="fr-error-text">{messageIndisponible}</span>}
                 </label>
               </div>
             )
@@ -584,6 +605,19 @@ function RecapitulatifOperations({
       </p>
     </>
   )
+}
+
+// Groupe de notions à basculer ensemble pour une clé : coop et lieuInclusion sont indissociables
+// dès que la structure porte les deux (cf. NOTIONS_COUPLEES). Sinon, la clé seule.
+function groupeCouple(structure: StructureComparaisonViewModel, cle: NotionCle): ReadonlyArray<NotionCle> {
+  if (!NOTIONS_COUPLEES.includes(cle)) {
+    return [cle]
+  }
+  const presentes = NOTIONS_COUPLEES.filter((couplee) =>
+    structure.concepts.some((concept) => concept.cle === couplee && concept.present)
+  )
+
+  return presentes.length > 1 ? presentes : [cle]
 }
 
 // Retire l'entrée d'une structure de l'état (devenue cible, ou plus aucune notion cochée).


### PR DESCRIPTION
## Contexte

Suite de #1639 (transfert/fusion des 6 notions). Analyse du pipeline dataspace : le lien
lieu↔structure (`main.lieu_inclusion_structure_administrative`) est, en régime permanent, une
**projection de l'identifiant Coop** (`structure_coop_id`), re-créé à chaque run par coop-dag
(jointure `sa.structure_coop_id = li.structure_coop_id`, `ON CONFLICT DO NOTHING`, **sans DELETE**).

## Problème (transfert partiel uniquement)

Déplacer `coop` **sans** `lieuInclusion` (ou l'inverse) dans la carte de comparaison :
- laisse une **association orpheline** sur la source (soft-deleted), que coop-dag ne nettoie jamais ;
- fait **re-créer** l'asso sur la cible au prochain run → **doublon de lien** + fenêtre d'incohérence.

La **fusion** (6 notions) était déjà correcte (la notion `lieuInclusion` repointe toutes les asso).
Seul le transfert partiel exposait le trou.

## Changement (UI-only)

Couplage dur dans `ComparerStructures` :
- `NOTIONS_COUPLEES = ['coop', 'lieuInclusion']` : cocher/décocher l'un bascule l'autre dès que la
  structure porte les deux notions ;
- disponibilité couplée : un id Coop en collision verrouille aussi `lieuInclusion` ;
- note explicative + message d'indisponibilité adapté.

Aucun impact backend/presenter. La fusion reste inchangée.

## Tests

13/13 (11 existants + 2 nouveaux : couplage de bascule, couplage d'indisponibilité). typecheck + lint OK.

## Hors périmètre (dette dataspace identifiée)

Finir la phase 4b (asso carto-pur par SIRET), edge 0b (ligne coop orpheline après réconciliation
carto↔coop), absence de dedup de lieux par similarité.

🤖 Generated with [Claude Code](https://claude.com/claude-code)