### PR TITLE
fix(tableau-de-bord): rendre le tableau de bord structure aux membres simples

### DIFF
--- a/src/app/(connecte)/(avec-menu)/(default)/tableau-de-bord/page.tsx
+++ b/src/app/(connecte)/(avec-menu)/(default)/tableau-de-bord/page.tsx
@@ -46,7 +46,7 @@ export default async function TableauDeBordController(): Promise<ReactElement> {
     scope = contexte.scopes.find((scope) => scope.type === 'france')
   } else if (contexte.aCesRoles('gestionnaire_departement')) {
     scope = contexte.scopes.find((scope) => scope.type === 'departement')
-  } else if (contexte.estGestionnaireStructureHorsGouvernance()) {
+  } else if (contexte.estGestionnaireStructureSansCoportage()) {
     scope = contexte.scopes.find((scope) => scope.type === 'structure')
   } else if (options.length === 1 && options[0].value !== 'France') {
     scope = { code: options[0].value, type: 'departement' }

--- a/src/app/(connecte)/(avec-menu)/(default)/tableau-de-bord/registreBlocs.test.ts
+++ b/src/app/(connecte)/(avec-menu)/(default)/tableau-de-bord/registreBlocs.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+
+import { blocsParContexte } from './registreBlocs'
+import { Contexte, Scope } from '@/use-cases/queries/ResoudreContexte'
+
+describe('blocs par contexte', () => {
+  it('un gestionnaire de structure membre simple (non coporteur) voit le tableau de bord de sa structure', () => {
+    // GIVEN
+    const contexte = new Contexte('gestionnaire_structure', [
+      { code: '42', type: 'structure' },
+      { code: '93', type: 'membre' },
+    ])
+
+    // WHEN
+    const blocs = blocsParContexte(contexte)
+
+    // THEN
+    expect(blocs).toContain('donneesStructure')
+    expect(blocs).toContain('financements')
+    expect(blocs).not.toContain('etatDesLieux')
+    expect(blocs).not.toContain('gouvernance')
+    expect(blocs).not.toContain('rejoindreGouvernance')
+  })
+
+  it('un gestionnaire de structure coporteur voit la vue départementale de la gouvernance', () => {
+    // GIVEN
+    const contexte = new Contexte('gestionnaire_structure', [
+      { code: '42', type: 'structure' },
+      { code: '93', type: 'coporteur' },
+    ])
+
+    // WHEN
+    const blocs = blocsParContexte(contexte)
+
+    // THEN
+    expect(blocs).toContain('etatDesLieux')
+    expect(blocs).toContain('gouvernance')
+    expect(blocs).toContain('financements')
+    expect(blocs).not.toContain('donneesStructure')
+  })
+
+  it('un gestionnaire de structure hors gouvernance voit sa structure et l’invitation à rejoindre une gouvernance', () => {
+    // GIVEN
+    const contexte = new Contexte('gestionnaire_structure', [{ code: '42', type: 'structure' }])
+
+    // WHEN
+    const blocs = blocsParContexte(contexte)
+
+    // THEN
+    expect(blocs).toContain('donneesStructure')
+    expect(blocs).toContain('rejoindreGouvernance')
+    expect(blocs).toContain('cartographie')
+    expect(blocs).not.toContain('etatDesLieux')
+    expect(blocs).not.toContain('gouvernance')
+  })
+
+  it.each([
+    {
+      intention: 'administrateur dispositif',
+      role: 'administrateur_dispositif' as const,
+      scopes: [{ type: 'france' } as Scope],
+    },
+    {
+      intention: 'gestionnaire département',
+      role: 'gestionnaire_departement' as const,
+      scopes: [{ code: '93', type: 'departement' } as Scope],
+    },
+  ])('un $intention voit la vue départementale, les financements et les bénéficiaires', ({ role, scopes }) => {
+    // GIVEN
+    const contexte = new Contexte(role, scopes)
+
+    // WHEN
+    const blocs = blocsParContexte(contexte)
+
+    // THEN
+    expect(blocs).toContain('etatDesLieux')
+    expect(blocs).toContain('gouvernance')
+    expect(blocs).toContain('financements')
+    expect(blocs).toContain('beneficiaires')
+    expect(blocs).not.toContain('donneesStructure')
+  })
+})

--- a/src/app/(connecte)/(avec-menu)/(default)/tableau-de-bord/registreBlocs.ts
+++ b/src/app/(connecte)/(avec-menu)/(default)/tableau-de-bord/registreBlocs.ts
@@ -14,13 +14,13 @@ export type IdentifiantBloc =
 export function blocsParContexte(contexte: Contexte): ReadonlyArray<IdentifiantBloc> {
   const blocs: Array<IdentifiantBloc> = ['accueil']
 
-  if (contexte.estGestionnaireStructureHorsGouvernance()) {
+  if (contexte.estGestionnaireStructureSansCoportage()) {
     blocs.push('donneesStructure')
   }
 
   if (
     contexte.aCesRoles('administrateur_dispositif', 'gestionnaire_departement', 'gestionnaire_region') ||
-    contexte.estDansGouvernance()
+    contexte.estCoporteur()
   ) {
     blocs.push('etatDesLieux', 'gouvernance')
   }


### PR DESCRIPTION
## Contexte

Un membre **simple** (non coporteur) d'une gouvernance doit retrouver le **tableau de bord de sa structure** (comme une structure hors gouvernance). Seul un membre **coporteur** doit voir la vue départementale (état des lieux + gouvernance).

Cette règle avait été implémentée et validée en prod le 1er juin (`66e6303e`), puis **annulée par une régression** le 19 juin (`c11fcf43`, message orienté « accompagnements Coop », sans ticket). La régression était de plus **partielle** : `scopeFiltre()`, `BlocAccueil` et le menu latéral étaient restés sur la règle du 1er juin → état incohérent pour un membre simple.

## Changements

- `registreBlocs.ts` : `estGestionnaireStructureSansCoportage()` pour le bloc `donneesStructure`, `estCoporteur()` pour `etatDesLieux`/`gouvernance`.
- `page.tsx` : scope `structure` pour le membre simple.
- **Nouveau test** `registreBlocs.test.ts` verrouillant la règle (aucun test ne couvrait `blocsParContexte`, ce qui avait laissé passer la régression).
- L'amélioration `structureId` de `c11fcf43` (chargement des accompagnements Coop) est conservée.

## Validation

Validé contre la base dev (état d'un admin dépersonnifié en `gestionnaire_structure`) :

| | Membre simple (struct 18) | Coporteur (struct 23) |
|---|---|---|
| `scopeFiltre` | `{id:18, structure}` | `departemental` |
| blocs | `accueil, donneesStructure, financements` | `accueil, etatDesLieux, gouvernance, financements` |
| sous-titre | « espace structure » | « outil de pilotage » |

Tous les blocs/facettes sont désormais cohérents pour le membre simple.

Closes #1652