### PR TITLE
feat(structures): exclure les structures supprimées de la recherche

### DIFF
--- a/src/gateways/PrismaStructureLoader.test.ts
+++ b/src/gateways/PrismaStructureLoader.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { PrismaStructureLoader } from './PrismaStructureLoader'
 import { creerUnDepartement, creerUneGouvernance, creerUneRegion, creerUneStructure, creerUnMembre } from './testHelper'
 import prisma from '../../prisma/prismaClient'
+import { epochTime } from '../shared/testHelper'
 
 describe('structures loader', () => {
   beforeEach(async () => prisma.$queryRaw`START TRANSACTION`)
@@ -273,6 +274,25 @@ describe('structures loader', () => {
           uid: '100',
         },
       ])
+    })
+
+    it('exclut les structures supprimées (soft-delete) des résultats de recherche', async () => {
+      // GIVEN
+      await creerUneRegion()
+      await creerUnDepartement({ code: '10', nom: 'Aube' })
+      await creerUneStructure({
+        commune: 'TROYES',
+        deleted_at: epochTime,
+        departementCode: '10',
+        id: 100,
+        nom: "Conseil départemental de l'Aube",
+      })
+
+      // WHEN
+      const structureReadModel = await new PrismaStructureLoader().structures('conseil aube')
+
+      // THEN
+      expect(structureReadModel).toStrictEqual([])
     })
   })
 })

--- a/src/gateways/PrismaStructureLoader.ts
+++ b/src/gateways/PrismaStructureLoader.ts
@@ -79,6 +79,7 @@ export class PrismaStructureLoader implements StructureLoader {
       FROM main.structure_administrative sa
       LEFT JOIN main.adresse a ON sa.adresse_id = a.id
       WHERE COALESCE(sa.denomination_antenne, sa.denomination_sirene) IS NOT NULL
+        AND sa.deleted_at IS NULL
         AND (${conditionsMots})
       ${whereExtra}
       ORDER BY ${scoreMoyen} DESC, COALESCE(sa.denomination_antenne, sa.denomination_sirene) ASC


### PR DESCRIPTION
## Contexte

L'encart de recherche de structure (champ utilisé notamment par l'administrateur de dispositif à l'invitation d'un utilisateur, via `/api/structures`) remontait les structures supprimées (soft-delete `main.structure_administrative.deleted_at`).

## Changement

Ajout de `AND sa.deleted_at IS NULL` dans le `WHERE` de la requête de `PrismaStructureLoader.#rechercheFlexible`, méthode commune aux trois entrées de recherche (par nom, par département, par région). Les structures supprimées n'apparaissent donc plus dans aucun résultat de suggestion.

## Test

Test gardien ajouté : une structure avec `deleted_at` renseigné ne remonte pas dans les résultats.

## Vérifications
- `vitest` : 13/13 ✓ (dont le nouveau test)
- ESLint (max 0 warning) ✓
- `tsc --noEmit` ✓

Closes #1656

🤖 Generated with [Claude Code](https://claude.com/claude-code)