### PR TITLE
fix(structures-doublons): ne plus supprimer dans main.poste lors de la fusion

### DIFF
--- a/src/gateways/shared/deplacerNotions.ts
+++ b/src/gateways/shared/deplacerNotions.ts
@@ -230,6 +230,14 @@ async function transfererIdposte(
   source: LigneStructure
 ): Promise<void> {
   // poste : UNIQUE(poste_conum_id, structure_id, personne_id).
+  // On repointe uniquement les postes qui n'entrent pas en collision avec un poste déjà
+  // présent sur la cible. On ne SUPPRIME PAS les doublons exacts restants : main.poste est
+  // alimentée par l'ETL id-poste (dataspace), MIN ne doit pas y faire de DELETE (il
+  // détruirait une ligne ETL, recréée/désynchronisée au run suivant ; min_scalingo n'a
+  // d'ailleurs qu'UPDATE sur poste). Les doublons non repointables (cas rare : même
+  // poste_conum_id + personne des deux côtés) restent sur la source — la fusion la
+  // soft-delete quand même ; un transfert la conserve (sourceEstVide = false) et l'ETL
+  // réconcilie au prochain run.
   await tx.$executeRaw`
     UPDATE main.poste p SET structure_id = ${idCible}
     WHERE p.structure_id = ${idSource}
@@ -240,7 +248,6 @@ async function transfererIdposte(
           AND q.personne_id IS NOT DISTINCT FROM p.personne_id
       )
   `
-  await tx.$executeRaw`DELETE FROM main.poste WHERE structure_id = ${idSource}`
   // contrat : pas de contrainte d'unicité sur structure_id → UPDATE direct.
   await tx.$executeRaw`UPDATE main.contrat SET structure_id = ${idCible} WHERE structure_id = ${idSource}`
   await deplacerAffectations(tx, idSource, idCible, 'idposte')


### PR DESCRIPTION
## Contexte

La fusion de structures-doublons (`deplacerNotionsDansTransaction` → `transfererIdposte`) faisait un `DELETE FROM main.poste` pour nettoyer les doublons exacts non repointables. En prod, `min_scalingo` n'a pas le droit de supprimer dans `main.poste` → `ERROR 42501 permission denied for table poste`.

## Décision

`main.poste` est une table **alimentée par l'ETL id-poste** (dataspace). MIN ne doit pas y faire de `DELETE` : il détruirait une ligne ETL, qui serait recréée/désynchronisée au prochain run. On accorde donc à `min_scalingo` **uniquement `UPDATE`** sur `poste` (et non `DELETE`).

## Changement

`transfererIdposte` ne fait plus que l'`UPDATE` collision-aware (repointage de `structure_id`). Le `DELETE FROM main.poste` est supprimé.

- Cas rare de collision (même `poste_conum_id` + personne des deux côtés) : les postes non repointables restent sur la structure source.
  - **Fusion** : la source est soft-deletée quand même (comportement inchangé).
  - **Transfert** : `sourceEstVide` renvoie `false` → la source est conservée (plus correct : on ne supprime pas une source qui porte encore des lignes).
- L'ETL réconcilie au prochain run id-poste.
- Aucun test existant ne peuple `main.poste` (les tests utilisent des affectations) → pas de régression.

## Couplage déploiement

⚠️ À déployer **avec** la migration dataspace **MR !885** (V113) qui accorde `UPDATE` sur `main.poste`/`main.contrat` et `DELETE` sur `main.lieu_inclusion_structure_administrative`. Les deux ensemble débloquent la fusion en prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)