### PR TITLE
feat(structures-doublons): autoriser la fusion d'une canonique dans une autre canonique

### DIFF
--- a/src/app/api/actions/fusionnerStructuresAction.ts
+++ b/src/app/api/actions/fusionnerStructuresAction.ts
@@ -15,7 +15,8 @@ const MESSAGES_ECHEC: Readonly<Record<FusionFailure, string>> = {
     'Conflit d’identifiant de source (Coop, Idposte ou Aidants Connect) avec la survivante : tranchez-le avant de fusionner',
   collisionMembreGouvernance: 'La survivante est déjà membre d’une gouvernance de la structure absorbée',
   fusionEchouee: 'La fusion a échoué, aucune modification effectuée',
-  fusionImpossibleCanoniqueAbsorbee: 'Une structure canonique (INSEE) ne peut pas être absorbée',
+  fusionImpossibleCanoniqueDansAntenne:
+    'Une structure canonique (INSEE) ne peut être absorbée que par une autre canonique, pas par une antenne',
   fusionImpossibleMemeStructure: 'Impossible de fusionner une structure avec elle-même',
   structureIntrouvable: 'Structure introuvable ou déjà supprimée',
 }

--- a/src/components/StructuresDoublons/ComparerStructures.test.tsx
+++ b/src/components/StructuresDoublons/ComparerStructures.test.tsx
@@ -76,7 +76,7 @@ describe('consolider un doublon (cible + transfert/fusion par notion)', () => {
     })
   })
 
-  it('une carte canonique non-cible ne propose aucune coche (cible uniquement)', () => {
+  it('une carte canonique non-cible ne propose aucune coche quand la cible est une antenne', () => {
     // GIVEN
     renderComponent(<ComparerStructures viewModel={deuxStructures()} />)
 
@@ -84,7 +84,39 @@ describe('consolider un doublon (cible + transfert/fusion par notion)', () => {
     fireEvent.click(screen.getAllByRole('radio', { name: 'Cible (destination)' })[1])
 
     // THEN
-    expect(screen.getByText(/jamais transférée ni absorbée/)).toBeInTheDocument()
+    expect(screen.getByText(/Structure canonique \(INSEE\) : elle ne peut être absorbée/)).toBeInTheDocument()
+  })
+
+  it('autorise la fusion d’une canonique dans une autre canonique', async () => {
+    // GIVEN deux canoniques (doublon inter-SIRET) : la 3 est cible par défaut, la 7 est source canonique.
+    const fusionnerStructuresAction = stubbedServerAction(['OK'])
+    const viewModel: ComparaisonViewModel = [
+      carte({ denomination: 'Cible canonique', estCanonique: true, id: 3 }),
+      carte({
+        concepts: [conceptIdposte()],
+        denomination: 'Doublon canonique',
+        estCanonique: true,
+        id: 7,
+        siret: '99999999900099',
+      }),
+    ]
+    renderComponent(<ComparerStructures viewModel={viewModel} />, {
+      fusionnerStructuresAction,
+      pathname: '/structures-doublons/comparer',
+    })
+
+    // WHEN
+    fireEvent.click(screen.getByLabelText(/Fusionner/))
+    fireEvent.click(screen.getByRole('button', { name: 'Appliquer' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Confirmer' }))
+
+    // THEN
+    await screen.findByRole('status')
+    expect(fusionnerStructuresAction).toHaveBeenCalledWith({
+      idsAbsorbees: [7],
+      idSurvivante: 3,
+      path: '/structures-doublons/comparer',
+    })
   })
 
   it('désactive une notion dont l’id scalaire entre en collision avec la cible', () => {

--- a/src/components/StructuresDoublons/ComparerStructures.tsx
+++ b/src/components/StructuresDoublons/ComparerStructures.tsx
@@ -179,7 +179,7 @@ export default function ComparerStructures({ viewModel }: Props): ReactElement {
       <p className="fr-text--sm fr-text-mention--grey">
         Choisissez la structure <span className="fr-text--bold">cible (destination)</span>, puis sur chaque autre carte
         cochez les notions à transférer — ou « Fusionner » pour tout déplacer et supprimer la structure. Une canonique
-        (INSEE) ne peut être que cible.
+        (INSEE) ne peut être absorbée que par une autre canonique.
       </p>
 
       <div className="fr-btns-group fr-btns-group--inline fr-btns-group--sm fr-mb-2w">
@@ -208,6 +208,7 @@ export default function ComparerStructures({ viewModel }: Props): ReactElement {
           {viewModel.map((structure) => (
             <div className="fr-col-12 fr-col-md-6" key={structure.id}>
               <CarteStructure
+                cibleEstCanonique={cible?.estCanonique ?? false}
                 collisionCanonique={collisionCanonique(structure)}
                 estCible={structure.id === idCible}
                 etat={etatDe(structure.id)}
@@ -338,6 +339,7 @@ function MatriceDistances({ matrice }: Readonly<{ matrice: MatriceDistancesViewM
 }
 
 function CarteStructure({
+  cibleEstCanonique,
   collisionCanonique,
   estCible,
   etat,
@@ -348,6 +350,7 @@ function CarteStructure({
   onToggleNotion,
   structure,
 }: Readonly<{
+  cibleEstCanonique: boolean
   collisionCanonique: boolean
   estCible: boolean
   etat: EtatCarte
@@ -376,10 +379,10 @@ function CarteStructure({
     if (estCible) {
       return <ConceptsPortes conceptsPortes={conceptsPortes} legende="Concepts portés (destination)" />
     }
-    if (structure.estCanonique) {
+    if (structure.estCanonique && !cibleEstCanonique) {
       return (
         <p className="fr-text--xs fr-text-mention--grey fr-mt-2w">
-          Structure canonique (INSEE) : elle ne peut être que cible, jamais transférée ni absorbée.
+          Structure canonique (INSEE) : elle ne peut être absorbée que par une autre canonique, pas par une antenne.
         </p>
       )
     }

--- a/src/gateways/PrismaStructureFusionRepository.test.ts
+++ b/src/gateways/PrismaStructureFusionRepository.test.ts
@@ -62,8 +62,27 @@ describe('fusion de structures (repository Prisma)', () => {
     await expect(dernierAuditReussi()).resolves.toMatchObject({ moved_identifiers: { siret: '99002100000002' } })
   })
 
-  it('refuse de fusionner quand l’absorbée est une canonique (INSEE)', async () => {
-    // GIVEN absorbée canonique (pas de denomination_antenne).
+  it('refuse de fusionner une canonique (INSEE) dans une antenne', async () => {
+    // GIVEN survivante antenne, absorbée canonique (pas de denomination_antenne).
+    await seedBase()
+    await creerUneStructure({
+      denomination_antenne: 'Antenne survivante',
+      id: SURVIVANTE,
+      nom: 'SURVIVANTE',
+      siret: '99002100000001',
+    })
+    await creerUneStructure({ id: ABSORBEE, nom: 'ABSORBEE-CANONIQUE', siret: '99002100000002' })
+
+    // WHEN
+    const result = await fusionner()
+
+    // THEN
+    expect(result).toBe('fusionImpossibleCanoniqueDansAntenne')
+    await expect(estSupprimee(ABSORBEE)).resolves.toBe(false)
+  })
+
+  it('autorise la fusion d’une canonique (INSEE) dans une autre canonique', async () => {
+    // GIVEN survivante ET absorbée canoniques (deux SIRET distincts, doublon inter-SIRET).
     await seedBase()
     await creerUneStructure({ id: SURVIVANTE, nom: 'SURVIVANTE', siret: '99002100000001' })
     await creerUneStructure({ id: ABSORBEE, nom: 'ABSORBEE-CANONIQUE', siret: '99002100000002' })
@@ -72,8 +91,8 @@ describe('fusion de structures (repository Prisma)', () => {
     const result = await fusionner()
 
     // THEN
-    expect(result).toBe('fusionImpossibleCanoniqueAbsorbee')
-    await expect(estSupprimee(ABSORBEE)).resolves.toBe(false)
+    expect(result).toBe('OK')
+    await expect(estSupprimee(ABSORBEE)).resolves.toBe(true)
   })
 
   it('refuse la fusion en cas de collision d’id de source et ne supprime pas l’absorbée', async () => {

--- a/src/gateways/PrismaStructureFusionRepository.ts
+++ b/src/gateways/PrismaStructureFusionRepository.ts
@@ -35,10 +35,11 @@ export class PrismaStructureFusionRepository implements StructureFusionRepositor
     if (survivante.deleted_at !== null || absorbee.deleted_at !== null) {
       return 'structureIntrouvable'
     }
-    // Une canonique (forme INSEE, sans denomination_antenne) ne peut pas être l'absorbée : on ne
-    // supprime jamais une entité INSEE.
-    if (absorbee.denomination_antenne === null) {
-      return 'fusionImpossibleCanoniqueAbsorbee'
+    // Une canonique (forme INSEE, sans denomination_antenne) ne peut être absorbée que par une autre
+    // canonique : fusionner deux canoniques (doublons inter-SIRET) est permis, mais jamais absorber une
+    // canonique dans une antenne — on ne fait pas disparaître une entité INSEE au profit d'une variante.
+    if (absorbee.denomination_antenne === null && survivante.denomination_antenne !== null) {
+      return 'fusionImpossibleCanoniqueDansAntenne'
     }
 
     // Déplacement des 6 notions (ids de source inclus) + gardes C1/C2 du moteur partagé.

--- a/src/use-cases/commands/FusionnerStructures.ts
+++ b/src/use-cases/commands/FusionnerStructures.ts
@@ -39,8 +39,9 @@ export type FusionFailure =
   | 'collisionIdentifiantSource'
   | 'collisionMembreGouvernance'
   | 'fusionEchouee'
-  // Une canonique vient de l'INSEE : on ne la supprime jamais, donc elle ne peut pas être absorbée.
-  | 'fusionImpossibleCanoniqueAbsorbee'
+  // Une canonique (INSEE) peut être absorbée par une autre canonique (doublons inter-SIRET), mais
+  // jamais par une antenne : on ne fait pas disparaître une entité INSEE au profit d'une variante.
+  | 'fusionImpossibleCanoniqueDansAntenne'
   | 'fusionImpossibleMemeStructure'
   | 'structureIntrouvable'
 


### PR DESCRIPTION
## Contexte

La fusion de structures (`structures-doublons`) interdisait d'absorber toute structure **canonique** (forme INSEE, `denomination_antenne IS NULL`). Règle trop restrictive.

## Changement

Vraie règle métier :
- ❌ canonique → **antenne** : interdit (on ne fait pas disparaître une entité INSEE au profit d'une variante) ;
- ✅ canonique → **canonique** : autorisé (doublons inter-SIRET ; le SIRET de l'absorbée est journalisé puis abandonné).

### Détail
- **Garde-fou serveur** (`PrismaStructureFusionRepository`) : blocage uniquement si la survivante est une antenne. Failure renommé `fusionImpossibleCanoniqueAbsorbee` → `fusionImpossibleCanoniqueDansAntenne` + message utilisateur.
- **UI** (`ComparerStructures`) : une carte canonique source propose ses contrôles quand la cible est canonique ; texte d'aide mis à jour.
- **Tests gardiens** repository + UI pour les deux branches de la règle.

> Les paires canonique/canonique inter-SIRET ne remontent pas toujours dans la détection et sont traitées manuellement (URL `/comparer` forgée avec les ids) — d'où l'enforcement **côté serveur**.

## Vérifications
- `tsc --noEmit` ✅ · `eslint --max-warnings 0` ✅
- tests repository 5/5 ✅ · tests UI 14/14 ✅

Closes #1662

🤖 Generated with [Claude Code](https://claude.com/claude-code)