### PR TITLE
fix(tableau-de-bord): ne compter que les lieux actifs dans les données structure

### DIFF
--- a/src/gateways/tableauDeBord/PrismaDonneesStructureLoader.test.ts
+++ b/src/gateways/tableauDeBord/PrismaDonneesStructureLoader.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+
+import { PrismaDonneesStructureLoader } from './PrismaDonneesStructureLoader'
+import prisma from '../../../prisma/prismaClient'
+import { creerUnePersonne, creerUnePersonneAffectation, creerUneStructure } from '../testHelper'
+import { epochTime } from '@/shared/testHelper'
+
+describe('données structure loader', () => {
+  // Le schéma coop (répliqué depuis dataspace en prod) n'est pas couvert par les
+  // migrations Prisma : on matérialise le minimum requis par le loader.
+  beforeAll(async () => {
+    await prisma.$executeRaw`CREATE SCHEMA IF NOT EXISTS coop`
+    await prisma.$executeRaw`CREATE TABLE IF NOT EXISTS coop.activites (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      date date,
+      suppression timestamp,
+      accompagnements_count integer,
+      structure_employeuse_id uuid
+    )`
+  })
+
+  beforeEach(async () => prisma.$queryRaw`START TRANSACTION`)
+
+  afterEach(async () => prisma.$queryRaw`ROLLBACK TRANSACTION`)
+
+  it('quand les lieux de la structure ont des affectations actives, alors ils sont tous comptés', async () => {
+    // GIVEN
+    await creerUneStructure({ id: 4901 })
+    const personneId = await creerUnePersonne()
+    await creerUnePersonneAffectation({ personne_id: personneId, structure_id: 4901, type: 'structure_emploi' })
+    // lieu associé à la structure avec une affectation active (matérialisé par le helper, id = 4901)
+    await creerUnePersonneAffectation({ personne_id: personneId, structure_id: 4901, type: 'lieu_activite' })
+    // lieu relié uniquement par l'affectation active d'une personne employée, sans association directe
+    await prisma.main_lieu_inclusion.create({ data: { id: 648, nom: 'Communauté de communes' } })
+    await prisma.main_personne_affectations_lieu.create({
+      data: { est_active: true, lieu_id: 648, personne_id: personneId, source: 'coop' },
+    })
+
+    // WHEN
+    const donneesStructure = await new PrismaDonneesStructureLoader().get(4901, epochTime)
+
+    // THEN
+    expect(donneesStructure).toMatchObject({ nombreLieux: 2 })
+  })
+
+  it('quand un lieu est rattaché à la structure par la seule association et n’a plus aucune affectation active, alors il n’est pas compté', async () => {
+    // GIVEN
+    await creerUneStructure({ id: 4901 })
+    const personneId = await creerUnePersonne()
+    await creerUnePersonneAffectation({ personne_id: personneId, structure_id: 4901, type: 'structure_emploi' })
+    await creerUnePersonneAffectation({ personne_id: personneId, structure_id: 4901, type: 'lieu_activite' })
+    // lieu fantôme : associé à la structure (ex. pont siret) mais dont l'unique affectation est inactive
+    await prisma.main_lieu_inclusion.create({ data: { id: 7114, nom: 'Espace France Services' } })
+    await prisma.main_lieu_inclusion_structure_administrative.create({
+      data: { lieu_id: 7114, structure_administrative_id: 4901 },
+    })
+    await prisma.main_personne_affectations_lieu.create({
+      data: { est_active: false, lieu_id: 7114, personne_id: personneId, source: 'coop' },
+    })
+
+    // WHEN
+    const donneesStructure = await new PrismaDonneesStructureLoader().get(4901, epochTime)
+
+    // THEN
+    expect(donneesStructure).toMatchObject({ nombreLieux: 1 })
+  })
+})

--- a/src/gateways/tableauDeBord/PrismaDonneesStructureLoader.ts
+++ b/src/gateways/tableauDeBord/PrismaDonneesStructureLoader.ts
@@ -34,11 +34,14 @@ export class PrismaDonneesStructureLoader implements DonneesStructureLoader {
     }
   }
 
+  // Même règle « lieu actif » que le listing (PrismaListeLieuxInclusionLoader) :
+  // un lieu rattaché à la SA par la seule asso (carto, pont siret) mais sans plus
+  // aucune affectation active est archivé et ne doit pas être compté (#1560).
   async #compterLieux(structureId: number): Promise<number> {
     const result = await prisma.$queryRaw<ReadonlyArray<{ total: bigint }>>`
       SELECT COUNT(DISTINCT l.id)::bigint AS total
       FROM main.lieu_inclusion l
-      WHERE EXISTS (
+      WHERE (EXISTS (
           SELECT 1 FROM main.lieu_inclusion_structure_administrative asso
           WHERE asso.lieu_id = l.id AND asso.structure_administrative_id = ${structureId}
         )
@@ -52,6 +55,10 @@ export class PrismaDonneesStructureLoader implements DonneesStructureLoader {
               SELECT pe.id FROM min.personne_enrichie pe
               WHERE pe.structure_employeuse_id = ${structureId}
             )
+        ))
+        AND EXISTS (
+          SELECT 1 FROM main.personne_affectations_lieu pal_active
+          WHERE pal_active.lieu_id = l.id AND pal_active.est_active = true
         )
     `
     return Number(result[0]?.total ?? 0)


### PR DESCRIPTION
## Contexte

Suite de l'investigation du #1560 (lieu fantôme « Chalet Marie-Léa », SA 4901 : 5 lieux affichés vs 4 côté Coop).

Depuis l'investigation, la cause racine amont a été corrigée par la synchro coop (l'affectation périmée est bien passée `est_active = false` le 2026-06-10). L'écart résiduel venait d'ailleurs : une ligne d'association lieu ↔ SA héritée du pont SIRET one-shot (`V093_siret_bridge`) rattache toujours le lieu 7114 à la SA 4901, et le compteur du dashboard comptait tout lieu associé **sans vérifier qu'il est encore actif** — contrairement au listing « Suivi des lieux » qui affiche, lui, le bon chiffre.

## Changement

- `PrismaDonneesStructureLoader.#compterLieux` : application de la même règle « lieu actif = au moins une affectation active » que `PrismaListeLieuxInclusionLoader` (statut actif). Le dashboard et le suivi des lieux affichent désormais le même nombre.
- Ajout du test DB du loader (cas nominal + cas du lieu fantôme, vérifié rouge→vert). Le setup matérialise `coop.activites`, absent des migrations Prisma (schéma répliqué depuis dataspace en prod), ce qui empêchait jusqu'ici de tester ce loader.

## Validation

- Requête corrigée exécutée sur `dataspace_dev` : SA 4901 → **4** lieux (au lieu de 5), conforme à la Coop et au listing.
- `vitest` (2 tests), `eslint`, `prettier`, `tsc` : OK.

## Note d'architecture

La directive du ticket (porter la règle dans la vue de synthèse Conum) est devenue sans objet pour les lieux : depuis la correction de la synchro coop, `personne_affectations_lieu.est_active` est le signal canonique par-lieu. La question de fond sur la sémantique et le cycle de vie de l'association lieu ↔ SA est désormais portée par #1711.

Closes #1560

🤖 Generated with [Claude Code](https://claude.com/claude-code)
