### PR TITLE
feat(structures): fusion étendue à la bascule coop et comparaison ouverte aux administrateurs

### DIFF
--- a/src/app/api/actions/fusionnerStructuresAction.ts
+++ b/src/app/api/actions/fusionnerStructuresAction.ts
@@ -13,7 +13,7 @@ import { FusionFailure, FusionnerStructures } from '@/use-cases/commands/Fusionn
 
 const MESSAGES_ECHEC: Readonly<Record<FusionFailure, string>> = {
   collisionIdentifiantSource:
-    'Conflit d’identifiant de source (Coop, Idposte ou Aidants Connect) avec la survivante : tranchez-le avant de fusionner',
+    'Conflit d’identifiant de source (Idposte ou Aidants Connect) avec la survivante : tranchez-le avant de fusionner',
   collisionMembreGouvernance: 'La survivante est déjà membre d’une gouvernance de la structure absorbée',
   fusionEchouee: 'La fusion a échoué, aucune modification effectuée',
   fusionImpossibleCanoniqueDansAntenne:

--- a/src/app/api/actions/transfererNotionsStructureAction.ts
+++ b/src/app/api/actions/transfererNotionsStructureAction.ts
@@ -18,7 +18,7 @@ import { resoudreContexte } from '@/use-cases/queries/ResoudreContexte'
 const MESSAGES_ECHEC: Readonly<Record<TransfertNotionsFailure, string>> = {
   aucuneNotionSelectionnee: 'Sélectionnez au moins une notion à transférer',
   collisionIdentifiantSource:
-    'Un identifiant source (Coop, Idposte ou Aidants Connect) entre en collision avec la structure cible',
+    'Un identifiant source (Idposte ou Aidants Connect) entre en collision avec la structure cible',
   collisionMembreGouvernance: 'La structure cible est déjà membre d’une gouvernance de la structure source',
   structureIntrouvable: 'Structure introuvable ou déjà supprimée',
   transfertEchoue: 'Le transfert a échoué, aucune modification effectuée',

--- a/src/gateways/PrismaStructureFusionRepository.test.ts
+++ b/src/gateways/PrismaStructureFusionRepository.test.ts
@@ -20,6 +20,8 @@ const DEPT = '993'
 const MEMBRE = 'fusion-test-membre'
 const COOP_ID = '44444444-4444-4444-4444-444444444444'
 const COOP_ID_SURVIVANTE = '55555555-5555-5555-5555-555555555555'
+const TP_ID_SURVIVANTE = 990031
+const TP_ID_ABSORBEE = 990032
 
 let personnesCreees: Array<number> = []
 
@@ -95,8 +97,9 @@ describe('fusion de structures (repository Prisma)', () => {
     await expect(estSupprimee(ABSORBEE)).resolves.toBe(true)
   })
 
-  it('refuse la fusion en cas de collision d’id de source et ne supprime pas l’absorbée', async () => {
-    // GIVEN survivante et absorbée portent chacune un structure_coop_id différent.
+  it('abandonne l’uuid coop de l’absorbée (sans échec) quand la survivante porte déjà le sien, et le trace', async () => {
+    // GIVEN survivante et absorbée portent chacune un structure_coop_id différent : depuis la bascule
+    // ADR-002 l'uuid n'est plus un vecteur de resync — plus de blocage, la survivante garde le sien.
     await seedBase()
     await creerUneStructure({
       id: SURVIVANTE,
@@ -116,9 +119,61 @@ describe('fusion de structures (repository Prisma)', () => {
     const result = await fusionner()
 
     // THEN
+    expect(result).toBe('OK')
+    await expect(coopIdDe(SURVIVANTE)).resolves.toBe(COOP_ID_SURVIVANTE)
+    await expect(coopIdDe(ABSORBEE)).resolves.toBeNull()
+    await expect(estSupprimee(ABSORBEE)).resolves.toBe(true)
+    await expect(dernierAuditReussi()).resolves.toMatchObject({ moved_identifiers: { structure_coop_id: COOP_ID } })
+  })
+
+  it('refuse la fusion en cas de collision d’id de source (idposte) et ne supprime pas l’absorbée', async () => {
+    // GIVEN survivante et absorbée portent chacune un structure_tp_id différent (id-poste resynchronise
+    // toujours par cet id : le blocage reste).
+    await seedBase()
+    await creerUneStructure({
+      id: SURVIVANTE,
+      nom: 'SURVIVANTE',
+      siret: '99002100000001',
+      structure_tp_id: TP_ID_SURVIVANTE,
+    })
+    await creerUneStructure({
+      denomination_antenne: 'Antenne absorbée',
+      id: ABSORBEE,
+      nom: 'ABSORBEE',
+      siret: '99002100000002',
+      structure_tp_id: TP_ID_ABSORBEE,
+    })
+
+    // WHEN
+    const result = await fusionner()
+
+    // THEN
     expect(result).toBe('collisionIdentifiantSource')
     await expect(estSupprimee(ABSORBEE)).resolves.toBe(false)
-    await expect(coopIdDe(SURVIVANTE)).resolves.toBe(COOP_ID_SURVIVANTE)
+  })
+
+  it('repointe les références coop (activites, employes_structures) vers la survivante quand les colonnes de la bascule existent', async () => {
+    // GIVEN le schéma coop post-bascule ADR-002 (colonnes int dual-write) avec des lignes pointant l'absorbée.
+    await seedBase()
+    await creerUneStructure({ id: SURVIVANTE, nom: 'SURVIVANTE', siret: '99002100000001' })
+    await creerUneStructure({
+      denomination_antenne: 'Antenne absorbée',
+      id: ABSORBEE,
+      nom: 'ABSORBEE',
+      siret: '99002100000002',
+    })
+    await creerSchemaCoopPostBascule()
+
+    // WHEN
+    const result = await fusionner()
+
+    // THEN
+    expect(result).toBe('OK')
+    await expect(referencesCoopVers(SURVIVANTE)).resolves.toStrictEqual({ activites: 2, employesStructures: 1 })
+    await expect(referencesCoopVers(ABSORBEE)).resolves.toStrictEqual({ activites: 0, employesStructures: 0 })
+    await expect(dernierAuditReussi()).resolves.toMatchObject({
+      moved_identifiers: { coop_activites_repointees: 2, coop_employes_structures_repointes: 1 },
+    })
   })
 
   it('retourne structureIntrouvable quand la survivante n’existe pas', async () => {
@@ -187,6 +242,27 @@ async function estSupprimee(id: number): Promise<boolean> {
   return structure?.deleted_at != null
 }
 
+// Simule le schéma coop post-bascule ADR-002 (colonnes int dual-write) : tables minimales sans FK
+// (les vraies vivent côté coop) — seules les colonnes détectées par le repointage comptent.
+async function creerSchemaCoopPostBascule(): Promise<void> {
+  await prisma.$executeRaw`CREATE SCHEMA IF NOT EXISTS coop`
+  await prisma.$executeRaw`CREATE TABLE coop.activites (id serial PRIMARY KEY, structure_employeuse_main_id integer)`
+  await prisma.$executeRaw`CREATE TABLE coop.employes_structures (id serial PRIMARY KEY, structure_main_id integer)`
+  await prisma.$executeRaw`INSERT INTO coop.activites (structure_employeuse_main_id) VALUES (${ABSORBEE}), (${ABSORBEE})`
+  await prisma.$executeRaw`INSERT INTO coop.employes_structures (structure_main_id) VALUES (${ABSORBEE})`
+}
+
+async function referencesCoopVers(structureId: number): Promise<Record<string, number>> {
+  const lignes = await prisma.$queryRaw<Array<{ activites: bigint; employes: bigint }>>`
+    SELECT
+      (SELECT count(*) FROM coop.activites WHERE structure_employeuse_main_id = ${structureId}) AS activites,
+      (SELECT count(*) FROM coop.employes_structures WHERE structure_main_id = ${structureId}) AS employes
+  `
+  const ligne = lignes[0]
+
+  return { activites: Number(ligne.activites), employesStructures: Number(ligne.employes) }
+}
+
 async function dernierAuditReussi(): Promise<Record<string, unknown> | undefined> {
   const lignes = await prisma.$queryRaw<Array<Record<string, unknown>>>`
     SELECT moved_identifiers FROM audit.structure_merge_log
@@ -197,6 +273,8 @@ async function dernierAuditReussi(): Promise<Record<string, unknown> | undefined
 }
 
 async function nettoyer(): Promise<void> {
+  // Le schéma coop n'existe pas dans la base de test MIN hors du test de repointage qui le crée.
+  await prisma.$executeRaw`DROP SCHEMA IF EXISTS coop CASCADE`
   await prisma.$executeRaw`
     DELETE FROM audit.structure_merge_log
     WHERE winner_id IN (${SURVIVANTE}, ${ABSORBEE}) OR loser_id IN (${SURVIVANTE}, ${ABSORBEE})

--- a/src/gateways/PrismaStructureFusionRepository.ts
+++ b/src/gateways/PrismaStructureFusionRepository.ts
@@ -7,9 +7,11 @@ import { ResultAsync } from '@/use-cases/CommandHandler'
 import { Fusion, FusionFailure, StructureFusionRepository } from '@/use-cases/commands/FusionnerStructures'
 
 // Fusion = déplacer les 6 notions de l'absorbée vers la survivante (via le moteur partagé, qui
-// transfère aussi les ids de source coop/tp/ac — c'est le correctif du bug d'abandon), balayer les
-// FK résiduelles non rattachées à une notion (affectations source='min'…), puis soft-delete
-// l'absorbée. La survivante conserve TOUS ses champs descriptifs (aucun import depuis l'absorbée).
+// transfère aussi les ids de source tp/ac — correctif du bug d'abandon — et l'uuid coop quand la
+// survivante n'en porte pas, sinon il est abandonné et tracé), balayer les FK résiduelles non
+// rattachées à une notion (affectations source='min'…), repointer les références coop (bascule
+// ADR-002 : la coop pointe la SA par id int), puis soft-delete l'absorbée. La survivante conserve
+// TOUS ses champs descriptifs (aucun import depuis l'absorbée).
 export class PrismaStructureFusionRepository implements StructureFusionRepository {
   async fusionner(fusion: Fusion): ResultAsync<FusionFailure> {
     try {
@@ -24,7 +26,7 @@ export class PrismaStructureFusionRepository implements StructureFusionRepositor
     const { idAbsorbee, idSurvivante, parUtilisateur } = fusion
 
     const lignes = await tx.$queryRaw<Array<LigneStructure>>`
-      SELECT id, deleted_at, denomination_antenne, siret, ridet, rna, to_jsonb(sa.*) AS snapshot
+      SELECT id, deleted_at, denomination_antenne, siret, ridet, rna, structure_coop_id, to_jsonb(sa.*) AS snapshot
       FROM main.structure_administrative sa
       WHERE id IN (${idSurvivante}, ${idAbsorbee})
     `
@@ -55,8 +57,9 @@ export class PrismaStructureFusionRepository implements StructureFusionRepositor
 
     // Balayage des FK résiduelles que les notions ne couvrent pas (affectations source='min'…).
     await this.#repointerAffectationsResiduelles(tx, idSurvivante, idAbsorbee)
+    const referencesCoop = await this.#repointerReferencesCoop(tx, idSurvivante, idAbsorbee)
     await soumettreSoftDelete(tx, idAbsorbee, parUtilisateur)
-    await this.#journaliserSucces(tx, fusion, survivante, absorbee)
+    await this.#journaliserSucces(tx, fusion, survivante, absorbee, referencesCoop)
 
     return 'OK'
   }
@@ -75,7 +78,8 @@ export class PrismaStructureFusionRepository implements StructureFusionRepositor
     tx: Prisma.TransactionClient,
     fusion: Fusion,
     survivante: LigneStructure,
-    absorbee: LigneStructure
+    absorbee: LigneStructure,
+    referencesCoop: Readonly<Record<string, number>>
   ): Promise<void> {
     const apres = (
       await tx.$queryRaw<Array<{ snapshot: Prisma.JsonValue }>>`
@@ -92,7 +96,7 @@ export class PrismaStructureFusionRepository implements StructureFusionRepositor
         ${JSON.stringify(survivante.snapshot)}::jsonb,
         ${JSON.stringify(absorbee.snapshot)}::jsonb,
         ${JSON.stringify(apres?.snapshot ?? null)}::jsonb,
-        ${JSON.stringify(identifiantsAbandonnes(absorbee))}::jsonb
+        ${JSON.stringify({ ...identifiantsAbandonnes(absorbee, survivante), ...referencesCoop })}::jsonb
       )
     `
   }
@@ -137,6 +141,45 @@ export class PrismaStructureFusionRepository implements StructureFusionRepositor
         tx.$executeRaw`DELETE FROM main.personne_affectations_emploi WHERE structure_administrative_id = ${idAbsorbee}`
     )
   }
+
+  // Depuis la bascule ADR-002, les tables coop référencent la SA par son id int (colonnes dual-write
+  // `structure_employeuse_main_id` / `structure_main_id`, renommage possible à l'échange final —
+  // repasse prévue sur les scripts coop définitifs). Sans repointage, la coop continuerait de
+  // pointer une structure soft-deleted. Détection des colonnes à chaud : no-op tant que la coop n'a
+  // pas déployé, et dans les bases (test) sans schéma coop — l'ordre de déploiement min/coop reste
+  // libre. Tables possédées par la coop (volumes jusqu'à plusieurs milliers d'activités par
+  // structure) : hors journal min__evenements, tracées en compteurs dans structure_merge_log.
+  async #repointerReferencesCoop(
+    tx: Prisma.TransactionClient,
+    idSurvivante: number,
+    idAbsorbee: number
+  ): Promise<Record<string, number>> {
+    const colonnes = await tx.$queryRaw<Array<{ nom: string }>>`
+      SELECT table_name || '.' || column_name AS nom
+      FROM information_schema.columns
+      WHERE table_schema = 'coop'
+        AND (table_name, column_name) IN (
+          ('activites', 'structure_employeuse_main_id'),
+          ('employes_structures', 'structure_main_id')
+        )
+    `
+    const presentes = new Set(colonnes.map(({ nom }) => nom))
+    const compteurs: Record<string, number> = {}
+    if (presentes.has('activites.structure_employeuse_main_id')) {
+      compteurs.coop_activites_repointees = await tx.$executeRaw`
+        UPDATE coop.activites SET structure_employeuse_main_id = ${idSurvivante}
+        WHERE structure_employeuse_main_id = ${idAbsorbee}
+      `
+    }
+    if (presentes.has('employes_structures.structure_main_id')) {
+      compteurs.coop_employes_structures_repointes = await tx.$executeRaw`
+        UPDATE coop.employes_structures SET structure_main_id = ${idSurvivante}
+        WHERE structure_main_id = ${idAbsorbee}
+      `
+    }
+
+    return compteurs
+  }
 }
 
 interface LigneStructure {
@@ -147,14 +190,19 @@ interface LigneStructure {
   rna: null | string
   siret: null | string
   snapshot: Prisma.JsonValue
+  structure_coop_id: null | string
 }
 
-// Identifiants d'IDENTITÉ de l'absorbée, perdus par la fusion (la survivante garde les siens) →
-// tracés dans le journal. Les ids de SOURCE (coop/tp/ac) n'y figurent plus : ils sont transférés.
-function identifiantsAbandonnes(absorbee: LigneStructure): Record<string, null | string> {
+// Identifiants de l'absorbée perdus par la fusion → tracés dans le journal. Identité (siret/ridet/
+// rna) : la survivante garde les siens. Uuid coop : abandonné seulement quand la survivante porte
+// déjà le sien (sinon transféré, donc absent d'ici). Les ids de source tp/ac restent transférés.
+function identifiantsAbandonnes(absorbee: LigneStructure, survivante: LigneStructure): Record<string, null | string> {
+  const coopAbandonne = absorbee.structure_coop_id !== null && survivante.structure_coop_id !== null
+
   return {
     ridet: absorbee.ridet,
     rna: absorbee.rna,
     siret: absorbee.siret,
+    structure_coop_id: coopAbandonne ? absorbee.structure_coop_id : null,
   }
 }

--- a/src/gateways/PrismaStructureTransfertRepository.test.ts
+++ b/src/gateways/PrismaStructureTransfertRepository.test.ts
@@ -25,6 +25,7 @@ const COOP_ID_SOURCE = '11111111-1111-1111-1111-111111111111'
 const AC_ID_SOURCE = '22222222-2222-2222-2222-222222222222'
 const COOP_ID_CIBLE = '33333333-3333-3333-3333-333333333333'
 const TP_ID_SOURCE = 880011
+const TP_ID_CIBLE = 880012
 
 let personnesCreees: Array<number> = []
 
@@ -86,19 +87,38 @@ describe('transfert des notions d’une structure (repository Prisma)', () => {
     await expect(estSupprimee(SOURCE)).resolves.toBe(false)
   })
 
-  it('refuse en cas de collision d’id scalaire et ne modifie rien', async () => {
-    // GIVEN source et cible portent chacune un structure_coop_id différent.
+  it('refuse en cas de collision d’id scalaire (idposte) et ne modifie rien', async () => {
+    // GIVEN source et cible portent chacune un structure_tp_id différent (id-poste resynchronise
+    // toujours par cet id : le blocage reste, contrairement à l'uuid coop).
+    await seedBase()
+    await creerUneStructure({ id: SOURCE, siret: '99001100000001', structure_tp_id: TP_ID_SOURCE })
+    await creerUneStructure({ id: CIBLE, siret: '99001100000002', structure_tp_id: TP_ID_CIBLE })
+
+    // WHEN
+    const result = await transferer(['idposte'])
+
+    // THEN
+    expect(result).toBe('collisionIdentifiantSource')
+    await expect(idsScalaires(SOURCE)).resolves.toMatchObject({ tp: TP_ID_SOURCE })
+    await expect(nombreAudits()).resolves.toBe(0)
+  })
+
+  it('abandonne l’uuid coop de la source (sans échec) quand la cible porte déjà le sien', async () => {
+    // GIVEN source et cible portent chacune un structure_coop_id différent : depuis la bascule
+    // ADR-002 l'uuid n'est plus un vecteur de resync — la cible garde le sien.
     await seedBase()
     await creerUneStructure({ id: SOURCE, siret: '99001100000001', structure_coop_id: COOP_ID_SOURCE })
     await creerUneStructure({ id: CIBLE, siret: '99001100000002', structure_coop_id: COOP_ID_CIBLE })
+    await affecter(SOURCE, 'coop')
 
     // WHEN
     const result = await transferer(['coop'])
 
-    // THEN
-    expect(result).toBe('collisionIdentifiantSource')
-    await expect(idsScalaires(SOURCE)).resolves.toMatchObject({ coop: COOP_ID_SOURCE })
-    await expect(nombreAudits()).resolves.toBe(0)
+    // THEN l'affectation est déplacée, l'uuid de la source est abandonné, la cible garde le sien.
+    expect(result).toBe('OK')
+    await expect(idsScalaires(SOURCE)).resolves.toMatchObject({ coop: null })
+    await expect(idsScalaires(CIBLE)).resolves.toMatchObject({ coop: COOP_ID_CIBLE })
+    await expect(nombreAudits()).resolves.toBe(1)
   })
 
   it('refuse en cas de collision de membre sur la même gouvernance', async () => {

--- a/src/gateways/shared/deplacerNotions.ts
+++ b/src/gateways/shared/deplacerNotions.ts
@@ -43,7 +43,7 @@ export async function deplacerNotionsDansTransaction(
     await transfererContacts(tx, idSource, idCible)
   }
   if (choisi('coop')) {
-    await transfererCoop(tx, idSource, idCible, source)
+    await transfererCoop(tx, idSource, idCible, source, cible)
   }
   if (choisi('idposte')) {
     await transfererIdposte(tx, idSource, idCible, source)
@@ -127,6 +127,9 @@ interface LigneStructure {
 }
 
 // Une notion source sélectionnée porte un id scalaire alors que la cible en porte déjà un autre.
+// L'uuid coop ne bloque plus : depuis la bascule coop → ids int natifs (ADR-002), il n'est plus un
+// vecteur de resync — en cas de doublon il est abandonné, cf. transfererCoop. idposte et Aidants
+// Connect restent bloquants (leurs ETL resynchronisent toujours par ces ids).
 function collisionIdentifiantSource(
   choisi: (notion: NotionCle) => boolean,
   source: LigneStructure,
@@ -137,7 +140,6 @@ function collisionIdentifiantSource(
   }
 
   return (
-    (choisi('coop') && conflit(source.structure_coop_id, cible.structure_coop_id)) ||
     (choisi('idposte') && conflit(source.structure_tp_id, cible.structure_tp_id)) ||
     (choisi('aidantsConnect') && conflit(source.structure_ac_id, cible.structure_ac_id))
   )
@@ -263,11 +265,17 @@ async function transfererContacts(tx: Prisma.TransactionClient, idSource: number
   )
 }
 
+// L'uuid coop de la source est transféré si la cible n'en porte pas (le resync pré-bascule suit la
+// cible), sinon ABANDONNÉ (mis à NULL, sans échec) : la cible garde le sien, l'uuid perdu est tracé
+// par la fusion dans moved_identifiers. ⚠️ À ne déployer qu'avec le décommissionnement de la
+// branche SA du coop-dag : tant qu'il tourne, un uuid abandonné ferait recréer la structure au run
+// suivant (lookup par structure_coop_id → insert).
 async function transfererCoop(
   tx: Prisma.TransactionClient,
   idSource: number,
   idCible: number,
-  source: LigneStructure
+  source: LigneStructure,
+  cible: LigneStructure
 ): Promise<void> {
   await deplacerAffectations(tx, idSource, idCible, 'coop')
   if (source.structure_coop_id === null) {
@@ -280,6 +288,9 @@ async function transfererCoop(
     UPDATE main.structure_administrative SET structure_coop_id = NULL WHERE id = ${idSource}
   `
   )
+  if (cible.structure_coop_id !== null) {
+    return
+  }
   await miseAJourStructure(
     tx,
     idCible,

--- a/src/use-cases/commands/FusionnerStructures.ts
+++ b/src/use-cases/commands/FusionnerStructures.ts
@@ -27,8 +27,11 @@ export interface StructureFusionRepository {
 // La fusion = déplacer la TOTALITÉ des notions de l'absorbée vers la survivante puis soft-delete
 // l'absorbée. On ne récupère JAMAIS les champs descriptifs de l'absorbée (dénomination, adresse, APE,
 // catégorie juridique…) : la survivante garde les siens — importer ceux d'un doublon casserait la
-// cohérence INSEE. Les identifiants d'identité (siret/ridet/rna) de l'absorbée sont abandonnés (loggés) ;
-// les ids de source (coop/tp/ac) sont, eux, transférés (sinon le doublon ressuscite au resync).
+// cohérence INSEE. Les identifiants d'identité (siret/ridet/rna) de l'absorbée sont abandonnés (loggés).
+// Les ids de source tp/ac sont transférés (sinon le doublon ressuscite au resync) et bloquent en cas
+// de conflit ; l'uuid coop est transféré si la survivante n'en porte pas, sinon abandonné et loggé
+// (bascule ADR-002 : la coop référence la SA par id int, repointé par la fusion — l'uuid n'est plus
+// un vecteur de resync).
 export type Fusion = Readonly<{
   idAbsorbee: number
   idSurvivante: number


### PR DESCRIPTION
## Contexte

Suite du plan de bascule coop → main (#1707, ADR-002) et évolution de l'outil de doublons de structures.

## Contenu

**Fusion étendue à la bascule coop → ids main** (b1c5a0ee)
- La fusion de structures bascule désormais les références coop vers les ids main.

**Comparaison des doublons ouverte à tous les administrateurs** (964fa2c4)
- Les pages `/structures-doublons` et `/structures-doublons/comparer` ne requièrent plus le flag bêta-testeur, seulement le rôle `administrateur_dispositif` (accès par URL directe, pas d'entrée de menu ajoutée).
- La fusion, le transfert et la canonisation restent réservés aux bêta-testeurs : garde `isBetaTesteur` ajoutée côté serveur sur `fusionnerStructuresAction` (elle ne vérifiait que le rôle admin), et mode lecture seule de la page de comparaison (prop `peutFusionner`) sans cible, coches, « Appliquer » ni « Synchroniser avec l'INSEE ».
- Tests gardiens : refus serveur de la fusion pour un admin non bêta-testeur, mode lecture seule du composant.

Refs #1707

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFN89BGMrSDMSTSmELh6Mo