### PR TITLE
feat(structures): ouvrir la comparaison des doublons à tous les administrateurs

### DIFF
--- a/src/app/(connecte)/(avec-menu)/(default)/structures-doublons/comparer/page.tsx
+++ b/src/app/(connecte)/(avec-menu)/(default)/structures-doublons/comparer/page.tsx
@@ -24,7 +24,8 @@ export default async function ComparerStructuresController({ searchParams }: Pro
 
   const utilisateur = await new PrismaUtilisateurLoader().findByUid(session.user.sub)
   const contexte = await resoudreContexte(utilisateur, new PrismaMembreLoader())
-  if (!contexte.aCesRoles('administrateur_dispositif') || !contexte.isBetaTesteur) {
+  // Visibilité ouverte à tous les administrateurs (ANCT) ; la fusion reste réservée aux bêta-testeurs.
+  if (!contexte.aCesRoles('administrateur_dispositif')) {
     redirect('/tableau-de-bord')
   }
 
@@ -52,7 +53,7 @@ export default async function ComparerStructuresController({ searchParams }: Pro
           { label: 'Examiner' },
         ]}
       />
-      <ComparerStructures viewModel={viewModel} />
+      <ComparerStructures peutFusionner={contexte.isBetaTesteur} viewModel={viewModel} />
     </>
   )
 }

--- a/src/app/(connecte)/(avec-menu)/(default)/structures-doublons/page.tsx
+++ b/src/app/(connecte)/(avec-menu)/(default)/structures-doublons/page.tsx
@@ -29,7 +29,8 @@ export default async function StructuresDoublonsController({ searchParams }: Pro
 
   const utilisateur = await new PrismaUtilisateurLoader().findByUid(session.user.sub)
   const contexte = await resoudreContexte(utilisateur, new PrismaMembreLoader())
-  if (!contexte.aCesRoles('administrateur_dispositif') || !contexte.isBetaTesteur) {
+  // Visibilité ouverte à tous les administrateurs (ANCT) ; la fusion reste réservée aux bêta-testeurs.
+  if (!contexte.aCesRoles('administrateur_dispositif')) {
     redirect('/tableau-de-bord')
   }
 

--- a/src/app/api/actions/fusionnerStructuresAction.test.ts
+++ b/src/app/api/actions/fusionnerStructuresAction.test.ts
@@ -1,0 +1,68 @@
+import * as nextCache from 'next/cache'
+import { describe, expect, it } from 'vitest'
+
+import { fusionnerStructuresAction } from './fusionnerStructuresAction'
+import * as ssoGateway from '@/gateways/NextAuthAuthentificationGateway'
+import { PrismaUtilisateurLoader } from '@/gateways/PrismaUtilisateurLoader'
+import { FusionnerStructures } from '@/use-cases/commands/FusionnerStructures'
+import { utilisateurReadModelFactory } from '@/use-cases/testHelper'
+
+describe('fusionner des structures action', () => {
+  it('fusionne et purge le cache quand un bêta-testeur confirme', async () => {
+    // GIVEN
+    vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce('userFooId')
+    vi.spyOn(PrismaUtilisateurLoader.prototype, 'findByUid').mockResolvedValueOnce(
+      utilisateurReadModelFactory({ isBetaTesteur: true })
+    )
+    vi.spyOn(FusionnerStructures.prototype, 'handle').mockResolvedValueOnce('OK')
+    vi.spyOn(nextCache, 'revalidatePath').mockImplementationOnce(() => undefined)
+
+    // WHEN
+    const messages = await fusionnerStructuresAction({
+      idsAbsorbees: [7],
+      idSurvivante: 3,
+      path: '/structures-doublons/comparer?ids=3,7',
+    })
+
+    // THEN
+    expect(FusionnerStructures.prototype.handle).toHaveBeenCalledWith({
+      idAbsorbee: 7,
+      idSurvivante: 3,
+      uidUtilisateur: 'userFooId',
+    })
+    expect(nextCache.revalidatePath).toHaveBeenCalledWith('/structures-doublons/comparer?ids=3,7')
+    expect(messages).toStrictEqual(['OK'])
+  })
+
+  it('refuse la fusion à un administrateur non bêta-testeur, même si la comparaison lui est visible', async () => {
+    // GIVEN
+    vi.spyOn(ssoGateway, 'getSessionSub').mockResolvedValueOnce('userFooId')
+    vi.spyOn(PrismaUtilisateurLoader.prototype, 'findByUid').mockResolvedValueOnce(
+      utilisateurReadModelFactory({ isBetaTesteur: false })
+    )
+    const handle = vi.spyOn(FusionnerStructures.prototype, 'handle')
+
+    // WHEN
+    const messages = await fusionnerStructuresAction({
+      idsAbsorbees: [7],
+      idSurvivante: 3,
+      path: '/structures-doublons/comparer?ids=3,7',
+    })
+
+    // THEN
+    expect(messages).toStrictEqual(['Action réservée aux administrateurs autorisés'])
+    expect(handle).not.toHaveBeenCalled()
+  })
+
+  it('renvoie une erreur de validation quand aucune structure à absorber n’est fournie', async () => {
+    // WHEN
+    const messages = await fusionnerStructuresAction({
+      idsAbsorbees: [],
+      idSurvivante: 3,
+      path: '/structures-doublons/comparer?ids=3,7',
+    })
+
+    // THEN
+    expect(messages).toStrictEqual(['Sélectionnez au moins une structure à fusionner'])
+  })
+})

--- a/src/app/api/actions/fusionnerStructuresAction.ts
+++ b/src/app/api/actions/fusionnerStructuresAction.ts
@@ -4,12 +4,12 @@ import { revalidatePath } from 'next/cache'
 import { z } from 'zod'
 
 import { avecJournalisationMin } from './shared/journalisation'
-import prisma from '../../../../prisma/prismaClient'
-import { Administrateur } from '@/domain/Administrateur'
 import { getSessionSub } from '@/gateways/NextAuthAuthentificationGateway'
+import { PrismaMembreLoader } from '@/gateways/PrismaMembreLoader'
 import { PrismaStructureFusionRepository } from '@/gateways/PrismaStructureFusionRepository'
-import { PrismaUtilisateurRepository } from '@/gateways/PrismaUtilisateurRepository'
+import { PrismaUtilisateurLoader } from '@/gateways/PrismaUtilisateurLoader'
 import { FusionFailure, FusionnerStructures } from '@/use-cases/commands/FusionnerStructures'
+import { resoudreContexte } from '@/use-cases/queries/ResoudreContexte'
 
 const MESSAGES_ECHEC: Readonly<Record<FusionFailure, string>> = {
   collisionIdentifiantSource:
@@ -29,11 +29,12 @@ export async function fusionnerStructuresAction(actionParams: ActionParams): Pro
       return validationResult.error.issues.map(({ message }) => message)
     }
 
-    // Garde : seul un administrateur_dispositif peut fusionner des structures.
+    // Garde : la comparaison est visible par tout administrateur, mais seul un bêta-testeur peut fusionner.
     const sub = await getSessionSub()
-    const utilisateur = await new PrismaUtilisateurRepository(prisma.utilisateurRecord).get(sub)
-    if (!(utilisateur instanceof Administrateur)) {
-      return ['Action réservée aux administrateurs']
+    const utilisateur = await new PrismaUtilisateurLoader().findByUid(sub)
+    const contexte = await resoudreContexte(utilisateur, new PrismaMembreLoader())
+    if (!contexte.aCesRoles('administrateur_dispositif') || !contexte.isBetaTesteur) {
+      return ['Action réservée aux administrateurs autorisés']
     }
 
     // Fusion séquentielle : chaque absorbée est fusionnée dans la (même) survivante, une transaction

--- a/src/components/StructuresDoublons/ComparerStructures.test.tsx
+++ b/src/components/StructuresDoublons/ComparerStructures.test.tsx
@@ -12,7 +12,7 @@ import {
 describe('consolider un doublon (cible + transfert/fusion par notion)', () => {
   it('affiche les cartes, prend la canonique comme cible par défaut et désactive Appliquer', () => {
     // WHEN
-    renderComponent(<ComparerStructures viewModel={deuxStructures()} />)
+    renderComponent(<ComparerStructures peutFusionner={true} viewModel={deuxStructures()} />)
 
     // THEN : la canonique (structure 3) est cible → carte source = structure 7.
     expect(screen.getByRole('heading', { level: 1, name: 'Examiner un doublon' })).toBeInTheDocument()
@@ -23,7 +23,7 @@ describe('consolider un doublon (cible + transfert/fusion par notion)', () => {
 
   it('affiche sur chaque carte le titre « id - dénomination » dont la dénomination est un lien vers la fiche et un lien vers l’historique', () => {
     // WHEN
-    renderComponent(<ComparerStructures viewModel={deuxStructures()} />)
+    renderComponent(<ComparerStructures peutFusionner={true} viewModel={deuxStructures()} />)
 
     // THEN
     expect(screen.getByRole('heading', { level: 2, name: '3 - Cible' })).toBeInTheDocument()
@@ -40,7 +40,7 @@ describe('consolider un doublon (cible + transfert/fusion par notion)', () => {
     // GIVEN
     const transfererNotionsStructureAction = stubbedServerAction(['OK'])
     const push = vi.fn<() => void>()
-    renderComponent(<ComparerStructures viewModel={deuxStructures()} />, {
+    renderComponent(<ComparerStructures peutFusionner={true} viewModel={deuxStructures()} />, {
       pathname: '/structures-doublons/comparer',
       router: {
         back: vi.fn<() => void>(),
@@ -72,7 +72,7 @@ describe('consolider un doublon (cible + transfert/fusion par notion)', () => {
   it('la surcoche « Fusionner » coche toutes les notions et déclenche la fusion', async () => {
     // GIVEN
     const fusionnerStructuresAction = stubbedServerAction(['OK'])
-    renderComponent(<ComparerStructures viewModel={deuxStructures()} />, {
+    renderComponent(<ComparerStructures peutFusionner={true} viewModel={deuxStructures()} />, {
       fusionnerStructuresAction,
       pathname: '/structures-doublons/comparer',
     })
@@ -93,7 +93,7 @@ describe('consolider un doublon (cible + transfert/fusion par notion)', () => {
 
   it('une carte canonique non-cible ne propose aucune coche quand la cible est une antenne', () => {
     // GIVEN
-    renderComponent(<ComparerStructures viewModel={deuxStructures()} />)
+    renderComponent(<ComparerStructures peutFusionner={true} viewModel={deuxStructures()} />)
 
     // WHEN : on désigne la structure 7 (antenne) comme cible → la canonique (3) devient une carte non-cible.
     fireEvent.click(screen.getAllByRole('radio', { name: 'Cible (destination)' })[1])
@@ -115,7 +115,7 @@ describe('consolider un doublon (cible + transfert/fusion par notion)', () => {
         siret: '99999999900099',
       }),
     ]
-    renderComponent(<ComparerStructures viewModel={viewModel} />, {
+    renderComponent(<ComparerStructures peutFusionner={true} viewModel={viewModel} />, {
       fusionnerStructuresAction,
       pathname: '/structures-doublons/comparer',
     })
@@ -140,7 +140,7 @@ describe('consolider un doublon (cible + transfert/fusion par notion)', () => {
     const source = carte({ concepts: [conceptAc('ac-source')], denomination: 'Source', id: 7 })
 
     // WHEN
-    renderComponent(<ComparerStructures viewModel={[cible, source]} />)
+    renderComponent(<ComparerStructures peutFusionner={true} viewModel={[cible, source]} />)
 
     // THEN
     expect(screen.getByLabelText(/Aidants Connect/)).toBeDisabled()
@@ -152,7 +152,7 @@ describe('consolider un doublon (cible + transfert/fusion par notion)', () => {
     const cible = carte({ denomination: 'Cible', estCanonique: true, id: 3 })
     const sourceA = carte({ concepts: [conceptCoop('coop-a')], denomination: 'Source A', id: 7 })
     const sourceB = carte({ concepts: [conceptCoop('coop-b')], denomination: 'Source B', id: 11 })
-    renderComponent(<ComparerStructures viewModel={[cible, sourceA, sourceB]} />)
+    renderComponent(<ComparerStructures peutFusionner={true} viewModel={[cible, sourceA, sourceB]} />)
 
     // WHEN : on coche Coop sur la source A.
     fireEvent.click(screen.getAllByLabelText(/Coop/)[0])
@@ -165,7 +165,7 @@ describe('consolider un doublon (cible + transfert/fusion par notion)', () => {
     // GIVEN la fusion réussit, le transfert échoue.
     const fusionnerStructuresAction = stubbedServerAction(['OK'])
     const transfererNotionsStructureAction = stubbedServerAction(['Conflit'])
-    renderComponent(<ComparerStructures viewModel={troisStructures()} />, {
+    renderComponent(<ComparerStructures peutFusionner={true} viewModel={troisStructures()} />, {
       fusionnerStructuresAction,
       pathname: '/structures-doublons/comparer',
       transfererNotionsStructureAction,
@@ -195,7 +195,7 @@ describe('consolider un doublon (cible + transfert/fusion par notion)', () => {
 
   it('bascule sur la vue Distances et affiche la matrice', () => {
     // GIVEN
-    renderComponent(<ComparerStructures viewModel={deuxStructures()} />)
+    renderComponent(<ComparerStructures peutFusionner={true} viewModel={deuxStructures()} />)
 
     // WHEN
     fireEvent.click(screen.getByRole('button', { name: 'Distances' }))
@@ -207,7 +207,7 @@ describe('consolider un doublon (cible + transfert/fusion par notion)', () => {
 
   it('désactive le CTA « Synchroniser avec INSEE » quand une canonique de même SIRET est présente', () => {
     // WHEN : l'antenne 7 partage son SIRET avec la canonique 3.
-    renderComponent(<ComparerStructures viewModel={deuxStructures()} />)
+    renderComponent(<ComparerStructures peutFusionner={true} viewModel={deuxStructures()} />)
 
     // THEN
     expect(screen.getByRole('button', { name: 'Synchroniser avec l’INSEE' })).toBeDisabled()
@@ -222,10 +222,37 @@ describe('consolider un doublon (cible + transfert/fusion par notion)', () => {
     ]
 
     // WHEN
-    renderComponent(<ComparerStructures viewModel={viewModel} />)
+    renderComponent(<ComparerStructures peutFusionner={true} viewModel={viewModel} />)
 
     // THEN
     expect(screen.getByRole('button', { name: 'Synchroniser avec l’INSEE' })).toBeEnabled()
+  })
+
+  it('affiche la comparaison en lecture seule sans aucune commande pour un administrateur non bêta-testeur', () => {
+    // WHEN
+    renderComponent(<ComparerStructures peutFusionner={false} viewModel={deuxStructures()} />)
+
+    // THEN : les cartes et concepts restent visibles…
+    expect(screen.getByRole('heading', { level: 2, name: '3 - Cible' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 2, name: '7 - Antenne' })).toBeInTheDocument()
+    expect(screen.getAllByText('Concepts portés')).toHaveLength(2)
+    expect(screen.getByText(/réservées aux bêta-testeurs/)).toBeInTheDocument()
+    // … mais aucune commande de mutation n'est proposée.
+    expect(screen.queryByRole('button', { name: 'Appliquer' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Synchroniser avec l’INSEE' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('radio', { name: 'Cible (destination)' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+  })
+
+  it('laisse la vue Distances accessible en lecture seule', () => {
+    // GIVEN
+    renderComponent(<ComparerStructures peutFusionner={false} viewModel={deuxStructures()} />)
+
+    // WHEN
+    fireEvent.click(screen.getByRole('button', { name: 'Distances' }))
+
+    // THEN
+    expect(screen.getByRole('columnheader', { name: 'Cible' })).toBeInTheDocument()
   })
 
   it('ouvre la modale de canonisation au clic et déclenche la récupération INSEE', async () => {
@@ -237,7 +264,9 @@ describe('consolider un doublon (cible + transfert/fusion par notion)', () => {
       carte({ denomination: 'Cible', estCanonique: true, id: 3 }),
       carte({ denomination: 'Antenne', id: 7, siret: '99999999900099' }),
     ]
-    renderComponent(<ComparerStructures viewModel={viewModel} />, { rechercherUneEntrepriseAction })
+    renderComponent(<ComparerStructures peutFusionner={true} viewModel={viewModel} />, {
+      rechercherUneEntrepriseAction,
+    })
 
     // WHEN
     fireEvent.click(screen.getByRole('button', { name: 'Synchroniser avec l’INSEE' }))

--- a/src/components/StructuresDoublons/ComparerStructures.tsx
+++ b/src/components/StructuresDoublons/ComparerStructures.tsx
@@ -31,7 +31,7 @@ type EtatCarte = Readonly<{
 
 const ETAT_VIDE: EtatCarte = { fusionner: false, notions: [] }
 
-export default function ComparerStructures({ viewModel }: Props): ReactElement {
+export default function ComparerStructures({ peutFusionner, viewModel }: Props): ReactElement {
   const { fusionnerStructuresAction, pathname, router, transfererNotionsStructureAction } = useContext(clientContext)
 
   // Cible par défaut : la canonique (INSEE) si elle existe — c'est la destination naturelle.
@@ -166,11 +166,18 @@ export default function ComparerStructures({ viewModel }: Props): ReactElement {
   return (
     <section>
       <h1>Examiner un doublon</h1>
-      <p className="fr-text--sm fr-text-mention--grey">
-        Choisissez la structure <span className="fr-text--bold">cible (destination)</span>, puis sur chaque autre carte
-        cochez les notions à transférer — ou « Fusionner » pour tout déplacer et supprimer la structure. Une canonique
-        (INSEE) ne peut être absorbée que par une autre canonique.
-      </p>
+      {peutFusionner ? (
+        <p className="fr-text--sm fr-text-mention--grey">
+          Choisissez la structure <span className="fr-text--bold">cible (destination)</span>, puis sur chaque autre
+          carte cochez les notions à transférer — ou « Fusionner » pour tout déplacer et supprimer la structure. Une
+          canonique (INSEE) ne peut être absorbée que par une autre canonique.
+        </p>
+      ) : (
+        <p className="fr-text--sm fr-text-mention--grey">
+          Comparez les champs, concepts et rattachements des structures candidates au doublon. Les opérations de fusion
+          et de transfert sont réservées aux bêta-testeurs.
+        </p>
+      )}
 
       <div className="fr-btns-group fr-btns-group--inline fr-btns-group--sm fr-mb-2w">
         <button
@@ -215,6 +222,7 @@ export default function ComparerStructures({ viewModel }: Props): ReactElement {
                 onToggleNotion={(cle) => {
                   basculerNotion(structure, cle)
                 }}
+                peutFusionner={peutFusionner}
                 structure={structure}
               />
             </div>
@@ -224,54 +232,60 @@ export default function ComparerStructures({ viewModel }: Props): ReactElement {
         <MatriceDistances matrice={matriceDistances(viewModel)} />
       )}
 
-      <div className="fr-mt-4w">
-        <button
-          className="fr-btn"
-          disabled={!operationPossible}
-          onClick={() => {
-            setIsModalOpen(true)
-          }}
-          type="button"
-        >
-          Appliquer
-        </button>
-        {operationPossible ? null : (
-          <p className="fr-text--sm fr-text-mention--grey fr-mt-1w">
-            Choisissez une cible et, sur au moins une autre carte, une notion à transférer ou « Fusionner ».
-          </p>
-        )}
-      </div>
+      {peutFusionner ? (
+        <div className="fr-mt-4w">
+          <button
+            className="fr-btn"
+            disabled={!operationPossible}
+            onClick={() => {
+              setIsModalOpen(true)
+            }}
+            type="button"
+          >
+            Appliquer
+          </button>
+          {operationPossible ? null : (
+            <p className="fr-text--sm fr-text-mention--grey fr-mt-1w">
+              Choisissez une cible et, sur au moins une autre carte, une notion à transférer ou « Fusionner ».
+            </p>
+          )}
+        </div>
+      ) : null}
 
-      <ConfirmationModal
-        confirmLabel={isSubmitting ? 'Application…' : 'Confirmer'}
-        confirmVariant="error"
-        id="confirmer-consolidation"
-        isOpen={isModalOpen}
-        onCancel={() => {
-          setIsModalOpen(false)
-        }}
-        onConfirm={() => {
-          void appliquer()
-        }}
-        title="Confirmer les opérations"
-      >
-        {cible === undefined ? null : (
-          <RecapitulatifOperations
-            cartesFusion={cartesFusion}
-            cartesTransfert={cartesTransfert}
-            cible={cible}
-            etatDe={etatDe}
+      {peutFusionner ? (
+        <>
+          <ConfirmationModal
+            confirmLabel={isSubmitting ? 'Application…' : 'Confirmer'}
+            confirmVariant="error"
+            id="confirmer-consolidation"
+            isOpen={isModalOpen}
+            onCancel={() => {
+              setIsModalOpen(false)
+            }}
+            onConfirm={() => {
+              void appliquer()
+            }}
+            title="Confirmer les opérations"
+          >
+            {cible === undefined ? null : (
+              <RecapitulatifOperations
+                cartesFusion={cartesFusion}
+                cartesTransfert={cartesTransfert}
+                cible={cible}
+                etatDe={etatDe}
+              />
+            )}
+          </ConfirmationModal>
+
+          <ModaleCanonisation
+            isOpen={idCanonisation !== null}
+            onClose={() => {
+              setIdCanonisation(null)
+            }}
+            structure={structureCanonisation ?? viewModel[0]}
           />
-        )}
-      </ConfirmationModal>
-
-      <ModaleCanonisation
-        isOpen={idCanonisation !== null}
-        onClose={() => {
-          setIdCanonisation(null)
-        }}
-        structure={structureCanonisation ?? viewModel[0]}
-      />
+        </>
+      ) : null}
     </section>
   )
 }
@@ -338,6 +352,7 @@ function CarteStructure({
   onCible,
   onToggleFusion,
   onToggleNotion,
+  peutFusionner,
   structure,
 }: Readonly<{
   cibleEstCanonique: boolean
@@ -349,12 +364,16 @@ function CarteStructure({
   onCible(): void
   onToggleFusion(): void
   onToggleNotion(cle: NotionCle): void
+  peutFusionner: boolean
   structure: StructureComparaisonViewModel
 }>): ReactElement {
   const rattachementsDetail = structure.rattachements.filter((rattachement) => rattachement.nombre > 0)
   const conceptsPortes = structure.concepts.filter((concept) => concept.present)
 
   function roleDe(): RoleCarte {
+    if (!peutFusionner) {
+      return 'rien'
+    }
     if (estCible) {
       return 'cible'
     }
@@ -366,6 +385,9 @@ function CarteStructure({
   }
 
   function controles(): ReactElement {
+    if (!peutFusionner) {
+      return <ConceptsPortes conceptsPortes={conceptsPortes} legende="Concepts portés" />
+    }
     if (estCible) {
       return <ConceptsPortes conceptsPortes={conceptsPortes} legende="Concepts portés (destination)" />
     }
@@ -474,7 +496,7 @@ function CarteStructure({
         ))}
       </dl>
 
-      {structure.estCanonique ? null : (
+      {structure.estCanonique || !peutFusionner ? null : (
         <div className="fr-mb-2w">
           <button
             className="fr-btn fr-btn--secondary fr-btn--sm fr-icon-refresh-line fr-btn--icon-left"
@@ -512,22 +534,24 @@ function CarteStructure({
         </ul>
       )}
 
-      <fieldset className="fr-fieldset fr-mt-2w">
-        <div className="fr-fieldset__content">
-          <div className="fr-radio-group">
-            <input
-              checked={estCible}
-              id={`cible-${structure.id}`}
-              name="cible-doublon"
-              onChange={onCible}
-              type="radio"
-            />
-            <label className="fr-label" htmlFor={`cible-${structure.id}`}>
-              Cible (destination)
-            </label>
+      {peutFusionner ? (
+        <fieldset className="fr-fieldset fr-mt-2w">
+          <div className="fr-fieldset__content">
+            <div className="fr-radio-group">
+              <input
+                checked={estCible}
+                id={`cible-${structure.id}`}
+                name="cible-doublon"
+                onChange={onCible}
+                type="radio"
+              />
+              <label className="fr-label" htmlFor={`cible-${structure.id}`}>
+                Cible (destination)
+              </label>
+            </div>
           </div>
-        </div>
-      </fieldset>
+        </fieldset>
+      ) : null}
 
       {controles()}
     </div>
@@ -658,5 +682,6 @@ function styleCellule(niveau: NiveauDistance): CSSProperties {
 }
 
 type Props = Readonly<{
+  peutFusionner: boolean
   viewModel: ComparaisonViewModel
 }>


### PR DESCRIPTION
## Contexte

L'outil de doublons de structures est aujourd'hui réservé aux administrateurs dispositif bêta-testeurs, fusion comprise. Les membres de l'ANCT doivent pouvoir consulter la comparaison, sans pouvoir fusionner.

## Contenu

- Les pages `/structures-doublons` et `/structures-doublons/comparer` ne requièrent plus le flag bêta-testeur, seulement le rôle `administrateur_dispositif` (accès par URL directe, pas d'entrée de menu ajoutée).
- La page de comparaison passe en lecture seule pour les non bêta-testeurs (prop `peutFusionner`) : pas de cible, de coches de notions, d'« Appliquer » ni de « Synchroniser avec l'INSEE ».
- La fusion reste réservée aux bêta-testeurs **côté serveur** : garde `isBetaTesteur` ajoutée sur `fusionnerStructuresAction`, qui ne vérifiait que le rôle admin (transfert, canonisation et renommage la vérifiaient déjà).
- Tests gardiens : refus serveur de la fusion pour un admin non bêta-testeur (nouveau `fusionnerStructuresAction.test.ts`), mode lecture seule du composant.

Closes #1732