### PR TITLE
feat(monitoring): ajouter la route /api/health pour le suivi de disponibilité updown.io

### DIFF
--- a/src/app/api/health/route.test.ts
+++ b/src/app/api/health/route.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { GET } from './route'
+import prisma from '../../../../prisma/prismaClient'
+
+describe('route /api/health', () => {
+  it('retourne 200 et le statut ok quand la base de données répond', async () => {
+    // GIVEN
+    vi.spyOn(prisma, '$queryRaw').mockResolvedValueOnce([{ resultat: 1 }])
+
+    // WHEN
+    const result = await GET()
+
+    // THEN
+    expect(result.status).toBe(200)
+    expect(result.headers.get('cache-control')).toBe('no-store')
+    await expect(result.json()).resolves.toStrictEqual({ status: 'ok' })
+  })
+
+  it('retourne 503 et le statut error, sans détail interne, quand la base de données ne répond pas', async () => {
+    // GIVEN
+    vi.spyOn(prisma, '$queryRaw').mockRejectedValueOnce(new Error('connexion refusée'))
+
+    // WHEN
+    const result = await GET()
+
+    // THEN
+    expect(result.status).toBe(503)
+    expect(result.headers.get('cache-control')).toBe('no-store')
+    await expect(result.json()).resolves.toStrictEqual({ status: 'error' })
+  })
+})

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server'
+
+import prisma from '../../../../prisma/prismaClient'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(): Promise<NextResponse<Readonly<{ status: 'error' | 'ok' }>>> {
+  try {
+    await prisma.$queryRaw`SELECT 1`
+    return NextResponse.json({ status: 'ok' }, { headers: { 'cache-control': 'no-store' } })
+  } catch {
+    return NextResponse.json({ status: 'error' }, { headers: { 'cache-control': 'no-store' }, status: 503 })
+  }
+}


### PR DESCRIPTION
## Contexte

Nous voulons brancher https://mon.inclusion-numerique.anct.gouv.fr/ à updown.io pour monitorer la disponibilité de l'application.

## Changements

- Nouvelle route publique `GET /api/health` (sans authentification, updown.io ne sachant pas s'authentifier)
- Check profond : ping de la base de données via `SELECT 1` — une base injoignable rend l'application inutilisable, c'est le vrai signal de santé
- `200` + `{ "status": "ok" }` si la base répond, `503` + `{ "status": "error" }` sinon, sans détail interne (pas de stack trace ni d'info d'infra sur un endpoint public)
- Pas de cache : `force-dynamic` + `Cache-Control: no-store`
- Pas de journalisation `source.min__evenements` : lecture seule, et l'endpoint sera appelé toutes les 30 s à 1 min

## Configuration updown.io (hors code)

- URL : `https://mon.inclusion-numerique.anct.gouv.fr/api/health`
- Assertion sur la chaîne `ok` dans le corps de la réponse

Closes #1738

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVqAwB3L4U6DSnok1zYjkY