### PR TITLE
feat(structures): permettre la recherche d'une structure par son identifiant

### DIFF
--- a/src/components/MesUtilisateurs/OrganisationInput.tsx
+++ b/src/components/MesUtilisateurs/OrganisationInput.tsx
@@ -61,7 +61,8 @@ export default function OrganisationInput({
   )
 
   async function onSearch(search: string): Promise<Array<OrganisationOption>> {
-    if (search.length < 3) {
+    // Le seuil de 3 caracteres ne s'applique pas aux identifiants de structure, qui peuvent etre courts
+    if (search.length < 3 && !/^\d+$/.test(search)) {
       return []
     }
     return fetch(`/api/structures?${makeSearchParams(search, extraSearchParams).toString()}`)

--- a/src/components/transverse/EnTete/MenuUtilisateur/SelecteurStructure/SelecteurStructure.test.tsx
+++ b/src/components/transverse/EnTete/MenuUtilisateur/SelecteurStructure/SelecteurStructure.test.tsx
@@ -32,6 +32,23 @@ describe('sélecteur de structure (superadmin)', () => {
     })
   })
 
+  it('quand je tape un identifiant de structure de moins de 3 caractères alors la recherche est quand même lancée', async () => {
+    // GIVEN
+    vi.stubGlobal('fetch', vi.fn(structuresFetch))
+    const changerMaStructureAction = stubbedServerAction(['OK'])
+    afficherSelecteurStructure({ changerMaStructureAction })
+
+    // WHEN
+    const input = screen.getByLabelText('Structure')
+    fireEvent.change(input, { target: { value: '14' } })
+    await select(input, 'TETRIS — GRASSE')
+
+    // THEN
+    await waitFor(() => {
+      expect(changerMaStructureAction).toHaveBeenCalledWith({ idStructure: 14, path: '/' })
+    })
+  })
+
   it('quand la recherche aboutit, la liste affiche un badge FNE pour les structures FNE', async () => {
     // GIVEN
     vi.stubGlobal('fetch', vi.fn(structuresFetch))

--- a/src/components/transverse/EnTete/MenuUtilisateur/SelecteurStructure/SelecteurStructure.tsx
+++ b/src/components/transverse/EnTete/MenuUtilisateur/SelecteurStructure/SelecteurStructure.tsx
@@ -36,7 +36,8 @@ export default function SelecteurStructure({ ariaControlsId }: Props): ReactElem
 }
 
 async function chargerLesStructures(search: string): Promise<Array<StructureOption>> {
-  if (search.length < 3) {
+  // Le seuil de 3 caracteres ne s'applique pas aux identifiants de structure, qui peuvent etre courts
+  if (search.length < 3 && !/^\d+$/.test(search)) {
     return []
   }
   const response = await fetch(`/api/structures?search=${encodeURIComponent(search)}`)

--- a/src/gateways/PrismaStructureLoader.test.ts
+++ b/src/gateways/PrismaStructureLoader.test.ts
@@ -113,6 +113,97 @@ describe('structures loader', () => {
     })
   })
 
+  describe('recherche par identifiant', () => {
+    it('trouve une structure par son identifiant quand la recherche est entierement numerique', async () => {
+      // GIVEN
+      await createStructures()
+
+      // WHEN
+      const structureReadModel = await new PrismaStructureLoader().structures('416')
+
+      // THEN
+      expect(structureReadModel).toStrictEqual([
+        {
+          commune: 'NOISY-LE-GRAND',
+          isFne: false,
+          isMembre: false,
+          nom: 'GRAND PARIS GRAND EST',
+          uid: '416',
+        },
+      ])
+    })
+
+    it('ne trouve aucune structure quand aucun identifiant ne correspond', async () => {
+      // GIVEN
+      await createStructures()
+
+      // WHEN
+      const structureReadModel = await new PrismaStructureLoader().structures('99999')
+
+      // THEN
+      expect(structureReadModel).toStrictEqual([])
+    })
+
+    it("et un département, alors la structure n'est remontée que si elle appartient à ce département", async () => {
+      // GIVEN
+      await createStructures()
+
+      // WHEN
+      const dansLeDepartement = await new PrismaStructureLoader().structuresByDepartement('14', '06')
+      const horsDepartement = await new PrismaStructureLoader().structuresByDepartement('14', '93')
+
+      // THEN
+      expect(dansLeDepartement).toStrictEqual([
+        {
+          commune: 'GRASSE',
+          isFne: false,
+          isMembre: false,
+          nom: 'TETRIS',
+          uid: '14',
+        },
+      ])
+      expect(horsDepartement).toStrictEqual([])
+    })
+
+    it("et une région, alors la structure n'est remontée que si elle appartient à un département de cette région", async () => {
+      // GIVEN
+      await createStructures()
+
+      // WHEN
+      const structureReadModel = await new PrismaStructureLoader().structuresByRegion('14', '93')
+
+      // THEN
+      expect(structureReadModel).toStrictEqual([
+        {
+          commune: 'GRASSE',
+          isFne: false,
+          isMembre: false,
+          nom: 'TETRIS',
+          uid: '14',
+        },
+      ])
+    })
+
+    it('exclut les structures supprimées (soft-delete) de la recherche par identifiant', async () => {
+      // GIVEN
+      await creerUneRegion()
+      await creerUnDepartement({ code: '10', nom: 'Aube' })
+      await creerUneStructure({
+        commune: 'TROYES',
+        deleted_at: epochTime,
+        departementCode: '10',
+        id: 100,
+        nom: "Conseil départemental de l'Aube",
+      })
+
+      // WHEN
+      const structureReadModel = await new PrismaStructureLoader().structures('100')
+
+      // THEN
+      expect(structureReadModel).toStrictEqual([])
+    })
+  })
+
   describe('recherche flexible avec trigrams et unaccent', () => {
     it('trouve une structure avec des mots non contigus', async () => {
       // GIVEN

--- a/src/gateways/PrismaStructureLoader.ts
+++ b/src/gateways/PrismaStructureLoader.ts
@@ -30,10 +30,15 @@ export class PrismaStructureLoader implements StructureLoader {
     whereClause?: string,
     whereParams: ReadonlyArray<ReadonlyArray<string> | string> = []
   ): Promise<StructuresReadModel> {
-    const mots = match
-      .trim()
-      .split(/\s+/)
-      .filter((mot) => /\p{L}/u.test(mot))
+    const terme = match.trim()
+
+    // Un terme entierement numerique est interprete comme l'identifiant de la
+    // structure (celui visible dans l'URL /structure/<id>), cf. #1583.
+    if (/^\d+$/.test(terme)) {
+      return this.#rechercheParId(terme, whereClause, whereParams)
+    }
+
+    const mots = terme.split(/\s+/).filter((mot) => /\p{L}/u.test(mot))
 
     if (mots.length === 0) {
       return []
@@ -86,17 +91,43 @@ export class PrismaStructureLoader implements StructureLoader {
       LIMIT 10
     `
 
-    interface RawResult {
-      commune: null | string
-      id: number
-      is_fne: boolean
-      is_membre: boolean
-      nom: string
-    }
-
     const params = [...mots, ...whereParams]
     const results = await prisma.$queryRawUnsafe<Array<RawResult>>(query, ...params)
 
+    return this.#versReadModels(results)
+  }
+
+  async #rechercheParId(
+    id: string,
+    whereClause?: string,
+    whereParams: ReadonlyArray<ReadonlyArray<string> | string> = []
+  ): Promise<StructuresReadModel> {
+    const whereExtra = whereClause === undefined || whereClause === '' ? '' : `AND ${whereClause}`
+
+    const query = `
+      SELECT
+        sa.id,
+        COALESCE(sa.denomination_antenne, sa.denomination_sirene) AS nom,
+        a.nom_commune as commune,
+        EXISTS(SELECT 1 FROM min.membre m WHERE m.structure_id = sa.id) as is_membre,
+        EXISTS(
+          SELECT 1 FROM min.membre m
+          WHERE m.structure_id = sa.id AND m.statut = 'confirme'
+        ) as is_fne
+      FROM main.structure_administrative sa
+      LEFT JOIN main.adresse a ON sa.adresse_id = a.id
+      WHERE sa.id::text = $1
+        AND COALESCE(sa.denomination_antenne, sa.denomination_sirene) IS NOT NULL
+        AND sa.deleted_at IS NULL
+      ${whereExtra}
+    `
+
+    const results = await prisma.$queryRawUnsafe<Array<RawResult>>(query, id, ...whereParams)
+
+    return this.#versReadModels(results)
+  }
+
+  #versReadModels(results: ReadonlyArray<RawResult>): StructuresReadModel {
     return results.map((row) => ({
       commune: row.commune ?? '',
       isFne: row.is_fne,
@@ -106,3 +137,11 @@ export class PrismaStructureLoader implements StructureLoader {
     }))
   }
 }
+
+type RawResult = Readonly<{
+  commune: null | string
+  id: number
+  is_fne: boolean
+  is_membre: boolean
+  nom: string
+}>


### PR DESCRIPTION
## Contexte

Remontée utilisateur (#1583) : impossible de retrouver une structure dans le sélecteur alors que son URL est connue (`/structure/10096`). Suggestion retenue dans le ticket : pouvoir rechercher par id de structure.

## Problème

Le moteur de recherche (`/api/structures` → `PrismaStructureLoader`) ne cherche que sur la dénomination, par similarité trigram, et **filtre les mots ne contenant aucune lettre** : un terme purement numérique comme `10096` ne produisait aucun mot → résultat toujours vide.

## Solution

- **`PrismaStructureLoader`** : un terme entièrement numérique est interprété comme l'identifiant de la structure (`main.structure_administrative.id`, celui visible dans l'URL `/structure/<id>`) → recherche exacte par id, en conservant les filtres existants (département / région, soft-delete exclu). Un terme contenant des lettres garde le comportement trigram actuel.
- **`SelecteurStructure`** (en-tête superadmin) et **`OrganisationInput`** (Mes utilisateurs) : le seuil de 3 caractères minimum ne s'applique plus aux termes numériques, pour que les ids courts restent trouvables.

## Tests

- 5 nouveaux tests d'intégration dans `PrismaStructureLoader.test.ts` (id exact, id inexistant, filtres département et région, soft-delete)
- 1 nouveau test composant dans `SelecteurStructure.test.tsx` (recherche d'un id de 2 caractères)

Closes #1583

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N57pqVWAwgSENmfRpiTCYm