### PR TITLE
feat(structures): ouvrir le menu Ma structure aux gestionnaires département

### DIFF
--- a/src/app/(connecte)/(avec-menu)/(default)/ma-structure-non-identifiee/page.tsx
+++ b/src/app/(connecte)/(avec-menu)/(default)/ma-structure-non-identifiee/page.tsx
@@ -1,0 +1,36 @@
+import { Metadata } from 'next'
+import { notFound, redirect } from 'next/navigation'
+import { ReactElement } from 'react'
+
+import MaStructureNonIdentifiee from '@/components/MaStructureNonIdentifiee/MaStructureNonIdentifiee'
+import FilAriane from '@/components/vitrine/FilAriane/FilAriane'
+import { getSession } from '@/gateways/NextAuthAuthentificationGateway'
+import { PrismaUtilisateurLoader } from '@/gateways/PrismaUtilisateurLoader'
+
+export const metadata: Metadata = {
+  title: 'Ma structure',
+}
+
+export default async function MaStructureNonIdentifieeController(): Promise<ReactElement> {
+  const session = await getSession()
+  if (!session) {
+    redirect('/connexion')
+  }
+
+  const utilisateur = await new PrismaUtilisateurLoader().findByUid(session.user.sub)
+
+  if (utilisateur.structureId !== null) {
+    redirect(`/structure/${utilisateur.structureId}`)
+  }
+
+  if (utilisateur.role.type !== 'gestionnaire_departement') {
+    notFound()
+  }
+
+  return (
+    <>
+      <FilAriane items={[{ href: '/tableau-de-bord', label: 'Tableau de bord' }, { label: 'Ma structure' }]} />
+      <MaStructureNonIdentifiee departement={utilisateur.role.organisation} />
+    </>
+  )
+}

--- a/src/app/api/actions/changerMonDepartementAction.ts
+++ b/src/app/api/actions/changerMonDepartementAction.ts
@@ -7,6 +7,7 @@ import { avecJournalisationMin } from './shared/journalisation'
 import prisma from '../../../../prisma/prismaClient'
 import departements from '../../../../ressources/departements.json'
 import { getSessionSub } from '@/gateways/NextAuthAuthentificationGateway'
+import { PrismaUtilisateurLoader } from '@/gateways/PrismaUtilisateurLoader'
 import { PrismaUtilisateurRepository } from '@/gateways/PrismaUtilisateurRepository'
 import { ResultAsync } from '@/use-cases/CommandHandler'
 import { ChangerMonDepartement } from '@/use-cases/commands/ChangerMonDepartement'
@@ -21,7 +22,10 @@ export async function changerMonDepartementAction(actionParams: ActionParams): R
 
     const uid = await getSessionSub()
 
-    const message = await new ChangerMonDepartement(new PrismaUtilisateurRepository(prisma.utilisateurRecord)).handle({
+    const message = await new ChangerMonDepartement(
+      new PrismaUtilisateurRepository(prisma.utilisateurRecord),
+      new PrismaUtilisateurLoader()
+    ).handle({
       nouveauCodeDepartement: validationResult.data.nouveauCodeDepartement,
       uidUtilisateurCourant: uid,
     })

--- a/src/components/MaStructureNonIdentifiee/MaStructureNonIdentifiee.test.tsx
+++ b/src/components/MaStructureNonIdentifiee/MaStructureNonIdentifiee.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import MaStructureNonIdentifiee from './MaStructureNonIdentifiee'
+
+describe('ma structure non identifiée', () => {
+  it("étant un gestionnaire de département sans structure identifiée, quand j'affiche la page, alors le message d'explication s'affiche avec mon département et le contact du support", () => {
+    // WHEN
+    render(<MaStructureNonIdentifiee departement="Calvados (14)" />)
+
+    // THEN
+    const titre = screen.getByRole('heading', { level: 1, name: 'Ma structure' })
+    expect(titre).toBeInTheDocument()
+
+    const alerte = screen.getByRole('heading', { level: 3, name: 'Votre structure n’a pas encore été identifiée' })
+    expect(alerte).toBeInTheDocument()
+
+    const message = screen.getByText(/votre structure pour le département Calvados \(14\) n’a pas été identifiée/)
+    expect(message).toBeInTheDocument()
+    expect(screen.getByText(/cela va venir d’ici peu/)).toBeInTheDocument()
+    expect(screen.getByText(/pour connaître l’état d’avancement/)).toBeInTheDocument()
+
+    const lienSupport = screen.getByRole('link', { name: 'moninclusionnumerique@anct.gouv.fr' })
+    expect(lienSupport).toHaveAttribute('href', 'mailto:moninclusionnumerique@anct.gouv.fr')
+  })
+})

--- a/src/components/MaStructureNonIdentifiee/MaStructureNonIdentifiee.tsx
+++ b/src/components/MaStructureNonIdentifiee/MaStructureNonIdentifiee.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { ReactElement } from 'react'
+
+import PageTitle from '../shared/PageTitle/PageTitle'
+import TitleIcon from '../shared/TitleIcon/TitleIcon'
+
+export default function MaStructureNonIdentifiee({ departement }: Props): ReactElement {
+  return (
+    <div className="fr-grid-row fr-grid-row--center">
+      <div>
+        <PageTitle>
+          <TitleIcon icon="building-line" />
+          Ma structure
+        </PageTitle>
+        <div className="fr-alert fr-alert--info fr-mt-2w">
+          <h3 className="fr-alert__title">Votre structure n’a pas encore été identifiée</h3>
+          <p>
+            Pour l’instant, votre structure pour le département {departement} n’a pas été identifiée dans Mon Inclusion
+            Numérique, mais cela va venir d’ici peu. Vous pouvez contacter le support en écrivant à{' '}
+            <a className="fr-link" href="mailto:moninclusionnumerique@anct.gouv.fr">
+              moninclusionnumerique@anct.gouv.fr
+            </a>{' '}
+            pour connaître l’état d’avancement.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+type Props = Readonly<{
+  departement: string
+}>

--- a/src/components/transverse/EnTete/EnTete.test.tsx
+++ b/src/components/transverse/EnTete/EnTete.test.tsx
@@ -194,6 +194,54 @@ describe('en-tête : en tant qu’utilisateur authentifié', () => {
       expect(screen.queryByLabelText('Structure')).not.toBeInTheDocument()
     })
 
+    it('si le rôle est gestionnaire_departement et que je suis superadmin, alors les sélecteurs de département et de structure s’affichent', () => {
+      // GIVEN
+      renderComponent(<EnTete />, {
+        sessionUtilisateurViewModel: sessionUtilisateurViewModelFactory({
+          peutChangerDeRole: true,
+          role: {
+            doesItBelongToGroupeAdmin: false,
+            libelle: 'Rhône',
+            nom: 'Gestionnaire département',
+            pictogramme: 'maille',
+            rolesGerables: [],
+            type: 'gestionnaire_departement',
+          },
+        }),
+      })
+
+      // WHEN
+      jOuvreLeMenuUtilisateur()
+
+      // THEN
+      expect(screen.getByLabelText('Département')).toBeInTheDocument()
+      expect(screen.getByLabelText('Structure')).toBeInTheDocument()
+    })
+
+    it('si le rôle est gestionnaire_departement mais que je ne suis pas superadmin, alors le sélecteur de structure ne s’affiche pas', () => {
+      // GIVEN
+      renderComponent(<EnTete />, {
+        sessionUtilisateurViewModel: sessionUtilisateurViewModelFactory({
+          peutChangerDeRole: false,
+          role: {
+            doesItBelongToGroupeAdmin: false,
+            libelle: 'Rhône',
+            nom: 'Gestionnaire département',
+            pictogramme: 'maille',
+            rolesGerables: [],
+            type: 'gestionnaire_departement',
+          },
+        }),
+      })
+
+      // WHEN
+      jOuvreLeMenuUtilisateur()
+
+      // THEN
+      expect(screen.getByLabelText('Département')).toBeInTheDocument()
+      expect(screen.queryByLabelText('Structure')).not.toBeInTheDocument()
+    })
+
     it('si le rôle est gestionnaire_structure mais que je ne suis pas superadmin, alors le sélecteur de structure ne s’affiche pas', () => {
       // GIVEN
       renderComponent(<EnTete />, {

--- a/src/components/transverse/EnTete/MenuUtilisateur/MenuUtilisateur.tsx
+++ b/src/components/transverse/EnTete/MenuUtilisateur/MenuUtilisateur.tsx
@@ -72,7 +72,8 @@ export default function MenuUtilisateur({ ariaControlsId }: Props): ReactElement
             {sessionUtilisateurViewModel.role.type === 'gestionnaire_departement' ? (
               <SelecteurDepartement ariaControlsId={ariaControlsId} />
             ) : null}
-            {sessionUtilisateurViewModel.role.type === 'gestionnaire_structure' &&
+            {(sessionUtilisateurViewModel.role.type === 'gestionnaire_structure' ||
+              sessionUtilisateurViewModel.role.type === 'gestionnaire_departement') &&
             sessionUtilisateurViewModel.peutChangerDeRole ? (
               <SelecteurStructure ariaControlsId={ariaControlsId} />
             ) : null}

--- a/src/components/transverse/MenuLateral/MenuLateral.test.tsx
+++ b/src/components/transverse/MenuLateral/MenuLateral.test.tsx
@@ -210,7 +210,27 @@ describe('menu lateral', () => {
     expect(maStructure).not.toBeInTheDocument()
   })
 
-  it("étant un utilisateur non gestionnaire de structure, quand j'affiche le menu latéral, alors Ma structure n'est pas visible", () => {
+  it("étant un gestionnaire de département avec une structure, quand j'affiche le menu latéral, alors Ma structure pointe vers sa structure", () => {
+    // WHEN
+    render(
+      <menuActifContext.Provider value="/">
+        <MenuLateral
+          contexte={
+            new Contexte('gestionnaire_departement', [
+              { code: '93', type: 'departement' },
+              { code: '42', type: 'structure' },
+            ])
+          }
+        />
+      </menuActifContext.Provider>
+    )
+
+    // THEN
+    const maStructure = screen.getByRole('link', { name: 'Ma structure' })
+    expect(maStructure).toHaveAttribute('href', '/structure/42')
+  })
+
+  it("étant un gestionnaire de département sans structure identifiée, quand j'affiche le menu latéral, alors Ma structure pointe vers la page d'explication", () => {
     // WHEN
     render(
       <menuActifContext.Provider value="/">
@@ -219,8 +239,8 @@ describe('menu lateral', () => {
     )
 
     // THEN
-    const maStructure = screen.queryByRole('link', { name: 'Ma structure' })
-    expect(maStructure).not.toBeInTheDocument()
+    const maStructure = screen.getByRole('link', { name: 'Ma structure' })
+    expect(maStructure).toHaveAttribute('href', '/ma-structure-non-identifiee')
   })
 
   it.each([

--- a/src/components/transverse/MenuLateral/registreMenus.ts
+++ b/src/components/transverse/MenuLateral/registreMenus.ts
@@ -44,6 +44,12 @@ const menuMaStructure: MenuItem = {
   url: (contexte) => `/structure/${contexte.idStructure()}`,
 }
 
+const menuMaStructureNonIdentifiee: MenuItem = {
+  icon: 'building-line',
+  label: 'Ma structure',
+  url: () => '/ma-structure-non-identifiee',
+}
+
 function codeTerritoireOuPremierDepartement(contexte: Contexte): string {
   const code = contexte.codeTerritoire()
   return code === 'France' ? '01' : code
@@ -120,6 +126,8 @@ function sectionOrganisationParContexte(contexte: Contexte): Section {
   const menus: Array<MenuItem> = []
   if (contexte.idStructure() !== 0) {
     menus.push(menuMaStructure)
+  } else if (contexte.aCesRoles('gestionnaire_departement')) {
+    menus.push(menuMaStructureNonIdentifiee)
   }
   menus.push(menuMonEquipe)
   return { menus, titre: 'ORGANISATION' }

--- a/src/gateways/PrismaUtilisateurLoader.test.ts
+++ b/src/gateways/PrismaUtilisateurLoader.test.ts
@@ -1032,6 +1032,88 @@ describe('prisma utilisateur query', () => {
       expect(result.utilisateursCourants).toHaveLength(0)
     })
   })
+
+  describe('chercher la structure du premier gestionnaire d’un département', () => {
+    it('quand des gestionnaires du département sont rattachés à une structure alors je récupère la structure du premier, en ignorant l’utilisateur courant, les supprimés, les sans structure et les autres rôles', async () => {
+      // GIVEN
+      await creerUneRegion({ code: '32', nom: 'Hauts-de-France' })
+      await creerUnDepartement({ code: '02', nom: 'Aisne', regionCode: '32' })
+      await creerUneStructure({ id: 162, nom: 'PREFECTURE DE DEPARTEMENT AISNE' })
+      await creerUneStructure({ id: 163, nom: 'DEPARTEMENT DE L AISNE' })
+      await creerUnUtilisateur({
+        departementCode: '02',
+        role: 'gestionnaire_departement',
+        ssoEmail: 'courant@example.net',
+        ssoId: 'utilisateurCourantId',
+        structureId: 163,
+      })
+      await creerUnUtilisateur({
+        departementCode: '02',
+        isSupprime: true,
+        role: 'gestionnaire_departement',
+        ssoEmail: 'supprime@example.net',
+        ssoId: 'supprimeId',
+        structureId: 163,
+      })
+      await creerUnUtilisateur({
+        departementCode: '02',
+        role: 'gestionnaire_departement',
+        ssoEmail: 'sans.structure@example.net',
+        ssoId: 'sansStructureId',
+      })
+      await creerUnUtilisateur({
+        departementCode: '02',
+        role: 'gestionnaire_structure',
+        ssoEmail: 'autre.role@example.net',
+        ssoId: 'autreRoleId',
+        structureId: 163,
+      })
+      await creerUnUtilisateur({
+        departementCode: '02',
+        role: 'gestionnaire_departement',
+        ssoEmail: 'premier@example.net',
+        ssoId: 'premierId',
+        structureId: 162,
+      })
+      await creerUnUtilisateur({
+        departementCode: '02',
+        role: 'gestionnaire_departement',
+        ssoEmail: 'second@example.net',
+        ssoId: 'secondId',
+        structureId: 163,
+      })
+
+      // WHEN
+      const structureId = await new PrismaUtilisateurLoader().structureDuPremierGestionnaireDepartement(
+        '02',
+        'utilisateurCourantId'
+      )
+
+      // THEN
+      expect(structureId).toBe(162)
+    })
+
+    it('quand aucun gestionnaire du département n’est rattaché à une structure alors je récupère null', async () => {
+      // GIVEN
+      await creerUneRegion({ code: '32', nom: 'Hauts-de-France' })
+      await creerUnDepartement({ code: '02', nom: 'Aisne', regionCode: '32' })
+      await creerUnUtilisateur({
+        departementCode: '02',
+        role: 'gestionnaire_departement',
+        ssoEmail: 'sans.structure@example.net',
+        ssoId: 'sansStructureId',
+      })
+
+      // WHEN
+      const structureId = await new PrismaUtilisateurLoader().structureDuPremierGestionnaireDepartement(
+        '02',
+        'utilisateurCourantId'
+      )
+
+      // THEN
+      expect(structureId).toBeNull()
+    })
+  })
 })
 
 async function creationDesUtilisateurs(structureId: number): Promise<void> {

--- a/src/gateways/PrismaUtilisateurLoader.ts
+++ b/src/gateways/PrismaUtilisateurLoader.ts
@@ -3,13 +3,14 @@ import { Prisma } from '@prisma/client'
 import { organisation, toTypologieRole, UtilisateurEtSesRelationsRecord } from './shared/RoleMapper'
 import prisma from '../../prisma/prismaClient'
 import { Role } from '@/domain/Role'
+import { StructureDuDepartementLoader } from '@/use-cases/commands/ChangerMonDepartement'
 import {
   MesUtilisateursLoader,
   UtilisateursCourantsEtTotalReadModel,
 } from '@/use-cases/queries/RechercherMesUtilisateurs'
 import { RoleUtilisateur, UnUtilisateurReadModel } from '@/use-cases/queries/shared/UnUtilisateurReadModel'
 
-export class PrismaUtilisateurLoader implements MesUtilisateursLoader {
+export class PrismaUtilisateurLoader implements MesUtilisateursLoader, StructureDuDepartementLoader {
   readonly #dataResource = prisma.utilisateurRecord
 
   async findByUid(uid: string, email?: string): Promise<UnUtilisateurReadModel> {
@@ -164,6 +165,30 @@ export class PrismaUtilisateurLoader implements MesUtilisateursLoader {
       total,
       utilisateursCourants: utilisateursRecord.map(transform),
     }
+  }
+
+  async structureDuPremierGestionnaireDepartement(
+    codeDepartement: string,
+    uidUtilisateurExclu: string
+  ): Promise<null | number> {
+    const utilisateurRecord = await this.#dataResource.findFirst({
+      orderBy: {
+        id: 'asc',
+      },
+      where: {
+        departementCode: codeDepartement,
+        isSupprime: false,
+        role: 'gestionnaire_departement',
+        ssoId: {
+          not: uidUtilisateurExclu,
+        },
+        structureId: {
+          not: null,
+        },
+      },
+    })
+
+    return utilisateurRecord?.structureId ?? null
   }
 
   async #construireFiltreWhere(

--- a/src/use-cases/commands/ChangerMonDepartement.test.ts
+++ b/src/use-cases/commands/ChangerMonDepartement.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { ChangerMonDepartement, StructureDuDepartementLoader } from './ChangerMonDepartement'
+import {
+  GetUtilisateurRepository,
+  UpdateDepartementUtilisateurRepository,
+  UpdateStructureUtilisateurRepository,
+} from './shared/UtilisateurRepository'
+import { utilisateurFactory } from '@/domain/testHelper'
+import { Utilisateur, UtilisateurUidState } from '@/domain/Utilisateur'
+
+describe('changer mon département', () => {
+  beforeEach(() => {
+    spiedCodeDepartement = ''
+    spiedCodeDepartementDemande = ''
+    spiedIdStructure = 0
+    spiedUid = ''
+    spiedUidExclu = ''
+    structureDuDepartement = null
+  })
+
+  it('étant superadmin quand je change de département alors le département et la structure du premier gestionnaire de ce département sont mis à jour', async () => {
+    // GIVEN
+    structureDuDepartement = 162
+    const changerMonDepartement = new ChangerMonDepartement(utilisateurRepository, structureDuDepartementLoader)
+
+    // WHEN
+    const result = await changerMonDepartement.handle({
+      nouveauCodeDepartement: '02',
+      uidUtilisateurCourant: 'utilisateurSuperAdminUid',
+    })
+
+    // THEN
+    expect(result).toBe('OK')
+    expect(spiedUid).toBe('utilisateurSuperAdminUid')
+    expect(spiedCodeDepartement).toBe('02')
+    expect(spiedCodeDepartementDemande).toBe('02')
+    expect(spiedIdStructure).toBe(162)
+    expect(spiedUidExclu).toBe('utilisateurSuperAdminUid')
+  })
+
+  it('étant superadmin quand je change de département sans gestionnaire rattaché à une structure alors la structure est remise à null', async () => {
+    // GIVEN
+    structureDuDepartement = null
+    const changerMonDepartement = new ChangerMonDepartement(utilisateurRepository, structureDuDepartementLoader)
+
+    // WHEN
+    const result = await changerMonDepartement.handle({
+      nouveauCodeDepartement: '02',
+      uidUtilisateurCourant: 'utilisateurSuperAdminUid',
+    })
+
+    // THEN
+    expect(result).toBe('OK')
+    expect(spiedIdStructure).toBeNull()
+  })
+
+  it('n’étant pas superadmin quand je change de département alors rien n’est mis à jour', async () => {
+    // GIVEN
+    const changerMonDepartement = new ChangerMonDepartement(utilisateurRepository, structureDuDepartementLoader)
+
+    // WHEN
+    const result = await changerMonDepartement.handle({
+      nouveauCodeDepartement: '02',
+      uidUtilisateurCourant: 'utilisateurNonSuperAdminUid',
+    })
+
+    // THEN
+    expect(result).toBe('utilisateurNonAutoriseAChangerSonDepartement')
+    expect(spiedCodeDepartement).toBe('')
+    expect(spiedIdStructure).toBe(0)
+  })
+})
+
+let spiedCodeDepartement: string
+let spiedCodeDepartementDemande: string
+let spiedIdStructure: null | number
+let spiedUid: string
+let spiedUidExclu: string
+let structureDuDepartement: null | number
+
+const utilisateurByUid: Readonly<Record<string, Utilisateur>> = {
+  utilisateurNonSuperAdminUid: utilisateurFactory({
+    isSuperAdmin: false,
+    uid: { email: 'martin.tartempion@example.fr', value: 'utilisateurNonSuperAdminUid' },
+  }),
+  utilisateurSuperAdminUid: utilisateurFactory({
+    isSuperAdmin: true,
+    uid: { email: 'martin.tartempion@example.fr', value: 'utilisateurSuperAdminUid' },
+  }),
+}
+
+const utilisateurRepository = new (class
+  implements GetUtilisateurRepository, UpdateDepartementUtilisateurRepository, UpdateStructureUtilisateurRepository
+{
+  async get(uid: UtilisateurUidState['value']): Promise<Utilisateur> {
+    return Promise.resolve(utilisateurByUid[uid])
+  }
+
+  async updateDepartement(uid: UtilisateurUidState['value'], codeDepartement: string): Promise<void> {
+    spiedUid = uid
+    spiedCodeDepartement = codeDepartement
+    return Promise.resolve()
+  }
+
+  async updateStructure(uid: UtilisateurUidState['value'], idStructure: null | number): Promise<void> {
+    spiedUid = uid
+    spiedIdStructure = idStructure
+    return Promise.resolve()
+  }
+})()
+
+const structureDuDepartementLoader = new (class implements StructureDuDepartementLoader {
+  async structureDuPremierGestionnaireDepartement(
+    codeDepartement: string,
+    uidUtilisateurExclu: string
+  ): Promise<null | number> {
+    spiedCodeDepartementDemande = codeDepartement
+    spiedUidExclu = uidUtilisateurExclu
+    return Promise.resolve(structureDuDepartement)
+  }
+})()

--- a/src/use-cases/commands/ChangerMonDepartement.ts
+++ b/src/use-cases/commands/ChangerMonDepartement.ts
@@ -1,12 +1,28 @@
 import { CommandHandler, ResultAsync } from '../CommandHandler'
-import { GetUtilisateurRepository, UpdateDepartementUtilisateurRepository } from './shared/UtilisateurRepository'
+import {
+  GetUtilisateurRepository,
+  UpdateDepartementUtilisateurRepository,
+  UpdateStructureUtilisateurRepository,
+} from './shared/UtilisateurRepository'
 import { UtilisateurFailure } from '@/domain/Utilisateur'
 import { isOk } from '@/shared/lang'
 
+export interface StructureDuDepartementLoader {
+  structureDuPremierGestionnaireDepartement(
+    codeDepartement: string,
+    uidUtilisateurExclu: string
+  ): Promise<null | number>
+}
+
 export class ChangerMonDepartement implements CommandHandler<Command> {
+  readonly #structureDuDepartementLoader: StructureDuDepartementLoader
   readonly #utilisateurRepository: UtilisateurRepository
 
-  constructor(utilisateurRepository: UtilisateurRepository) {
+  constructor(
+    utilisateurRepository: UtilisateurRepository,
+    structureDuDepartementLoader: StructureDuDepartementLoader
+  ) {
+    this.#structureDuDepartementLoader = structureDuDepartementLoader
     this.#utilisateurRepository = utilisateurRepository
   }
 
@@ -15,6 +31,13 @@ export class ChangerMonDepartement implements CommandHandler<Command> {
     const result = utilisateurCourant.changerDepartement()
     if (isOk(result)) {
       await this.#utilisateurRepository.updateDepartement(command.uidUtilisateurCourant, command.nouveauCodeDepartement)
+      // La structure suit le département : celle du premier gestionnaire du nouveau département,
+      // ou null si aucune n'est identifiée (le menu retombe alors sur la page d'explication).
+      const idStructure = await this.#structureDuDepartementLoader.structureDuPremierGestionnaireDepartement(
+        command.nouveauCodeDepartement,
+        command.uidUtilisateurCourant
+      )
+      await this.#utilisateurRepository.updateStructure(command.uidUtilisateurCourant, idStructure)
     }
 
     return result
@@ -28,4 +51,5 @@ type Command = Readonly<{
   uidUtilisateurCourant: string
 }>
 
-interface UtilisateurRepository extends GetUtilisateurRepository, UpdateDepartementUtilisateurRepository {}
+interface UtilisateurRepository
+  extends GetUtilisateurRepository, UpdateDepartementUtilisateurRepository, UpdateStructureUtilisateurRepository {}

--- a/src/use-cases/queries/ResoudreContexte.test.ts
+++ b/src/use-cases/queries/ResoudreContexte.test.ts
@@ -104,7 +104,7 @@ describe('résoudre contexte - scopes', () => {
     ])
   })
 
-  it('un gestionnaire département avec une structure ne reçoit que le scope département', async () => {
+  it('un gestionnaire département avec une structure reçoit les scopes département et structure, sans les appartenances de la structure aux gouvernances', async () => {
     // GIVEN
     const utilisateur = utilisateurAvecRole('gestionnaire_departement', { departementCode: '75', structureId: 42 })
     const loader = loaderStub({
@@ -115,7 +115,24 @@ describe('résoudre contexte - scopes', () => {
     const contexte = await resoudreContexte(utilisateur, loader)
 
     // THEN
+    expect(contexte.scopes).toStrictEqual([
+      { code: '75', type: 'departement' },
+      { code: '42', type: 'structure' },
+    ])
+    expect(contexte.nbGouvernances()).toBe(1)
+    expect(contexte.idStructure()).toBe(42)
+  })
+
+  it('un gestionnaire département sans structure ne reçoit que le scope département', async () => {
+    // GIVEN
+    const utilisateur = utilisateurAvecRole('gestionnaire_departement', { departementCode: '75', structureId: null })
+
+    // WHEN
+    const contexte = await resoudreContexte(utilisateur, loaderStub())
+
+    // THEN
     expect(contexte.scopes).toStrictEqual([{ code: '75', type: 'departement' }])
+    expect(contexte.idStructure()).toBe(0)
   })
 
   it('un gestionnaire structure sans structure a un scope vide', async () => {

--- a/src/use-cases/queries/ResoudreContexte.ts
+++ b/src/use-cases/queries/ResoudreContexte.ts
@@ -173,6 +173,12 @@ async function construireScopes(
 
   if (utilisateur.role.type === 'gestionnaire_departement' && utilisateur.departementCode !== null) {
     scopes.push({ code: utilisateur.departementCode, type: 'departement' })
+    // Scope structure seul, sans les appartenances aux gouvernances : la structure de rattachement
+    // (souvent une préfecture, membre de sa gouvernance) ne doit pas ajouter de scope membre/coporteur
+    // qui ferait basculer nbGouvernances() et le menu Gouvernance.
+    if (utilisateur.structureId !== null) {
+      scopes.push({ code: String(utilisateur.structureId), type: 'structure' })
+    }
   }
 
   if (utilisateur.structureId !== null && utilisateur.role.type === 'gestionnaire_structure') {


### PR DESCRIPTION
## Contexte

Les gestionnaires département n'avaient pas accès à la page « Ma structure ». Leur compte (`min.utilisateur`) peut désormais être rattaché à une structure administrative (`structure_id`), sans création de membre de gouvernance associé — le rattachement des comptes existants est fait par un script de reprise de données séparé.

## Changements

- **Scope** (`ResoudreContexte`) : un gestionnaire département avec `structure_id` reçoit le scope `structure` en plus du scope `departement`. Volontairement **sans** les appartenances de la structure aux gouvernances : sa structure de rattachement (souvent une préfecture, membre de sa propre gouvernance) ajouterait sinon des scopes `membre`/`coporteur` qui feraient basculer `nbGouvernances()` et le menu Gouvernance.
- **Menu latéral** : « Ma structure » apparaît pour les gestionnaires département. Avec structure → `/structure/<id>` (page identique à celle des gestionnaires de structure, droits calculés par `peutGererStructure` comme aujourd'hui). Sans structure → toujours cliquable, vers la nouvelle page.
- **Nouvelle page `/ma-structure-non-identifiee`** : explique que la structure du gestionnaire (département affiché) n'a pas encore été identifiée dans l'outil, que cela arrive d'ici peu, avec le mail du support pour connaître l'état d'avancement. Redirige vers `/structure/<id>` si l'utilisateur a en fait une structure, 404 pour les autres rôles.

- **Menu utilisateur (superadmin)** : le sélecteur de structure s'affiche aussi en mode gestionnaire département (à côté du sélecteur de département), pour pouvoir tester le rattachement sans passer par la base. La commande `ChangerMaStructure` était déjà agnostique du rôle.

- **Changement de département (superadmin)** : la structure suit le département — au changement dans le sélecteur, `structure_id` est mis à jour avec la structure du premier gestionnaire actif du nouveau département (utilisateur courant exclu de la recherche), ou `null` si aucune n'est identifiée (retour à la page d'explication).

## Tests

- `ResoudreContexte` : le test gardien de l'ancien invariant (« un gestionnaire département avec une structure ne reçoit que le scope département ») est remplacé par deux tests codifiant le nouveau comportement (avec/sans structure, pas d'appartenances gouvernance).
- `MenuLateral` : deux cas gestionnaire département (avec structure → `/structure/42`, sans → page d'explication).
- Nouveau composant testé (message, département, lien support).
- Suite complète : 1130 tests, 190 fichiers, tous verts.

Closes #1425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GT4nQSNtSTBS33Df5LV9Da

